### PR TITLE
refactor: remove backward-compat iac-to-service shims

### DIFF
--- a/src/augint_tools/config/ai_shell.py
+++ b/src/augint_tools/config/ai_shell.py
@@ -70,10 +70,7 @@ def load_ai_shell_config(path: Path | None = None) -> AiShellConfig | None:
 
         project = data.get("project", {})
 
-        # Map old "iac" to "service" for backward compatibility
         repo_type = project.get("repo_type", "library")
-        if repo_type == "iac":
-            repo_type = "service"
 
         # Parse [ai_tools] sections
         ai_tools = data.get("ai_tools", {})

--- a/src/augint_tools/config/workspace.py
+++ b/src/augint_tools/config/workspace.py
@@ -56,17 +56,12 @@ def load_workspace_config(path: Path | None = None) -> WorkspaceConfig | None:
 
         repos = []
         for repo_data in repos_data:
-            # Map old "iac" to "service" for backward compatibility
-            repo_type = repo_data.get("repo_type", "library")
-            if repo_type == "iac":
-                repo_type = "service"
-
             repos.append(
                 RepoConfig(
                     name=repo_data["name"],
                     path=repo_data["path"],
                     url=repo_data["url"],
-                    repo_type=repo_type,
+                    repo_type=repo_data.get("repo_type", "library"),
                     base_branch=repo_data.get("base_branch", "main"),
                     pr_target_branch=repo_data.get("pr_target_branch", "main"),
                     install=repo_data.get("install", ""),


### PR DESCRIPTION
## Summary
- Removed dead backward-compatibility shims that silently mapped `"iac"` to `"service"` in `ai_shell.py` and `workspace.py`
- No configs use `"iac"` anymore; enforcing correct `repo_type` values going forward

Closes #3

## Test plan
- [x] All 94 tests pass
- [x] ruff, mypy checks pass
- [x] No remaining references to `iac` in source