### PR TITLE
docs: remove iac references and ai-shell config bloat

### DIFF
--- a/.ai-shell.toml
+++ b/.ai-shell.toml
@@ -1,0 +1,21 @@
+[project]
+repo_type = "library"
+branch_strategy = "main"
+
+# See ai-shell docs for full .ai-shell.toml reference:
+# https://github.com/svange/augint-shell
+
+# =============================================================================
+# [ai_tools] - augint-tools configuration (sections below are read by ai-tools)
+# =============================================================================
+
+# [ai_tools.repo]
+# update_work_branch_strategy = "rebase"
+# default_submit_preset = "default"
+
+# [ai_tools.commands]
+# quality = "uv run pre-commit run --all-files"
+# tests = "uv run pytest --cov=src --cov-fail-under=80 -v"
+# security = "uv run pip-audit"
+# licenses = "uv run pip-licenses --from=mixed --summary"
+# build = "uv build"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,7 +143,7 @@ Exit codes: 0=success, 1=failure, 2=action-required, 3=blocked, 4=partial
 
 Three repo types with different branching strategies:
 - **library** - PyPI/npm packages, feature branches -> main directly
-- **service** - Services/IaC, feature branches -> dev -> main
+- **service** - Deployable services, feature branches -> dev -> main
 - **workspace** - Coordination repo that orchestrates multiple child repos
 
 Classification stored in `ai-shell.toml`:

--- a/README.md
+++ b/README.md
@@ -173,16 +173,6 @@ uv run pre-commit run --all-files  # All hooks
 4. **Repo-type aware** - Different defaults for libraries, services, and workspaces
 5. **Skills call tools** - AI skills orchestrate this CLI, not replace it with shell scripts
 
-## Architecture
-
-See [augint-tools.md](./augint-tools.md) for the complete design specification and implementation guide.
-
 ## License
 
-MIT License - See LICENSE file for details.
-
-## Status
-
-**Current version: 2.0.0**
-
-This is a complete rewrite and repurposing of the `augint-tools` package. All commands are currently scaffolded stubs that emit JSON with `implemented: false`. See [augint-tools.md](./augint-tools.md) for the implementation roadmap.
+MIT

--- a/src/augint_tools/config/ai_shell.py
+++ b/src/augint_tools/config/ai_shell.py
@@ -70,10 +70,7 @@ def load_ai_shell_config(path: Path | None = None) -> AiShellConfig | None:
 
         project = data.get("project", {})
 
-        # Map old "iac" to "service" for backward compatibility
         repo_type = project.get("repo_type", "library")
-        if repo_type == "iac":
-            repo_type = "service"
 
         # Parse [ai_tools] sections
         ai_tools = data.get("ai_tools", {})

--- a/src/augint_tools/config/workspace.py
+++ b/src/augint_tools/config/workspace.py
@@ -56,17 +56,12 @@ def load_workspace_config(path: Path | None = None) -> WorkspaceConfig | None:
 
         repos = []
         for repo_data in repos_data:
-            # Map old "iac" to "service" for backward compatibility
-            repo_type = repo_data.get("repo_type", "library")
-            if repo_type == "iac":
-                repo_type = "service"
-
             repos.append(
                 RepoConfig(
                     name=repo_data["name"],
                     path=repo_data["path"],
                     url=repo_data["url"],
-                    repo_type=repo_type,
+                    repo_type=repo_data.get("repo_type", "library"),
                     base_branch=repo_data.get("base_branch", "main"),
                     pr_target_branch=repo_data.get("pr_target_branch", "main"),
                     install=repo_data.get("install", ""),


### PR DESCRIPTION
## Summary
- Stripped `.ai-shell.toml` from 158 lines to 21 -- removed ai-shell-owned section docs (`[aws]`, `[claude]`, `[opencode]`, `[codex]`, `[container]`, `[llm]`, `[aider]`), kept only `[project]` and `[ai_tools]`
- Removed iac-to-service backward-compat shims from `workspace.py` and `ai_shell.py`
- Fixed stale `Services/IaC` reference in CLAUDE.md
- Removed outdated "Status: v2.0.0 / all stubs" section and broken `augint-tools.md` link from README.md

Closes #3

## Test plan
- [x] All 94 tests pass
- [x] ruff, mypy, pre-commit all pass
- [x] No remaining `iac` references in source or docs