### PR TITLE
feat!: remove stub commands, unused params, and update docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,29 +79,23 @@ Global output flags: `--json`, `--actionable`, `--summary`
 - `repo inspect` -- one-call repo snapshot (kind, branch, toolchain, command plan)
 - `repo status` -- git state + upstream + open PR + CI + next action
 - `repo issues pick` -- issue recommendation/search
-- `repo issues view` -- issue detail (stub)
 - `repo branch prepare` -- create work branch from correct base
 - `repo check plan` -- resolve validation plan without running
 - `repo check run` -- execute validation plan
 - `repo submit` -- stage, check, push, create PR, automerge
 - `repo ci watch` -- monitor CI run
 - `repo ci triage` -- classify CI failures
-- `repo promote` -- dev->main promotion (stub)
-- `repo rollback plan/apply` -- rollback workflow (stub)
-- `repo health` -- hygiene audit (stub)
 
 **Workspace commands** (`src/augint_tools/cli/commands/workspace.py`):
 - `workspace inspect` -- workspace snapshot
 - `workspace sync` -- clone/pull child repos
 - `workspace status` -- workspace health (--actionable, --blocked-only, --dirty-only)
 - `workspace issues` -- aggregate issues across repos
-- `workspace graph` -- dependency order (stub)
 - `workspace branch` -- coordinated branch prep (--issue, --description, --name)
 - `workspace check` -- grouped validation across repos (--phase, --repos, --preset)
 - `workspace test` -- alias for check --phase tests
 - `workspace lint` -- alias for check --phase quality
 - `workspace submit` -- open PRs for changed repos
-- `workspace update` -- downstream propagation (stub)
 - `workspace foreach` -- arbitrary command across repos
 
 ### Workspace Environment Variables
@@ -171,9 +165,7 @@ build = "uv build"
 
 2. **AI-first design**: Commands are called by ai-shell skills, not just humans. Error messages must be specific and parseable.
 
-3. **Stub pattern**: Unimplemented commands call `emit_stub()` which outputs a structured error with `implemented: false`. This preserves the command surface while development is in progress.
-
-4. **Detection once**: Commands call `detect()` once at the top and pass the `RepoContext` down. No scattered detection logic.
+3. **Detection once**: Commands call `detect()` once at the top and pass the `RepoContext` down. No scattered detection logic.
 
 ## Key Files
 

--- a/README.md
+++ b/README.md
@@ -39,15 +39,15 @@ ai-tools init --library
 # Check repository status
 ai-tools repo status --json
 
-# List issues
-ai-tools repo issues "bug"
+# Search/pick issues
+ai-tools repo issues pick "bug"
 
 # Create feature branch
-ai-tools repo branch feat/issue-42-example
+ai-tools repo branch prepare --issue 42 --description "fix the thing"
 
-# Run tests and linting
-ai-tools repo test
-ai-tools repo lint --fix
+# Run checks
+ai-tools repo check run
+ai-tools repo check run --preset full --fix
 
 # Submit work (push + create PR)
 ai-tools repo submit
@@ -66,10 +66,11 @@ ai-tools workspace sync --json
 ai-tools workspace status
 
 # Create coordinated branches
-ai-tools workspace branch feat/multi-repo-change
+ai-tools workspace branch --name feat/multi-repo-change
 
-# Run tests across all repos
+# Run tests and lint across all repos
 ai-tools workspace test
+ai-tools workspace lint
 
 # Run command in all repos
 ai-tools workspace foreach -- git status
@@ -86,24 +87,28 @@ ai-tools workspace submit
 
 ### Repository Commands (`ai-tools repo`)
 
+- `inspect` - One-call repo snapshot (kind, branch, toolchain, command plan)
 - `status` - Show repository status (branch, dirty state, PRs, CI)
-- `issues [query]` - List and filter issues
-- `branch <name>` - Create or switch branches using repo defaults
-- `test` - Run configured test commands
-- `lint [--fix]` - Run quality checks
-- `submit` - Push branch and create PR
+- `issues pick [query]` - Issue recommendation and search
+- `branch prepare` - Create work branch from correct base
+- `check plan` - Resolve validation plan without running
+- `check run` - Execute validation plan
+- `submit` - Push branch and create PR with automerge
+- `ci watch` - Monitor CI run
+- `ci triage` - Classify CI failures
 
 ### Workspace Commands (`ai-tools workspace`)
 
+- `inspect` - Workspace snapshot
 - `status` - Status across all child repositories
 - `sync` - Clone missing repos and update existing
 - `issues [query]` - Aggregate issues from all repos
-- `branch <name>` - Create coordinated branches
-- `test` - Run tests in dependency order
-- `lint [--fix]` - Quality checks across repos
+- `branch` - Create coordinated branches
+- `check` - Grouped validation across repos
+- `test` - Alias for check --phase tests
+- `lint` - Alias for check --phase quality
 - `foreach <command>` - Execute command in all repos
 - `submit` - Push and create PRs for modified repos
-- `update` - Propagate upstream changes downstream
 
 ## Configuration
 

--- a/src/augint_tools/cli/commands/repo.py
+++ b/src/augint_tools/cli/commands/repo.py
@@ -23,7 +23,7 @@ from augint_tools.github import (
     list_issues,
 )
 from augint_tools.github.cli import run_gh
-from augint_tools.output import CommandResponse, emit_response, emit_stub
+from augint_tools.output import CommandResponse, emit_response
 
 
 def _get_output_opts(ctx: click.Context) -> dict:
@@ -231,14 +231,6 @@ def pick(ctx, query, limit):
     )
 
 
-@issues.command()
-@click.argument("number", type=int)
-@click.pass_context
-def view(ctx, number):
-    """View issue details."""
-    emit_stub("repo issues view", "repo", json_mode=_get_output_opts(ctx)["json_mode"])
-
-
 # --- repo branch ---
 
 
@@ -400,11 +392,8 @@ def check_run(ctx, preset, skip, fix_mechanical):
 @click.option("--preset", default="default", type=click.Choice(["quick", "default", "full", "ci"]))
 @click.option("--skip", help="Comma-separated check phases to skip.")
 @click.option("--draft", is_flag=True, default=False, help="Create PR as draft.")
-@click.option(
-    "--update-strategy", type=click.Choice(["rebase", "merge"]), help="Branch update strategy."
-)
 @click.pass_context
-def submit(ctx, preset, skip, draft, update_strategy):
+def submit(ctx, preset, skip, draft):
     """Push branch and create PR with checks."""
     cwd = _require_git(ctx, "repo submit")
     context = detect(cwd)
@@ -768,46 +757,3 @@ def _classify_failures(log_lines: list[str]) -> list[dict]:
             )
 
     return failures[:30]  # cap
-
-
-# --- repo promote ---
-
-
-@repo.command()
-@click.pass_context
-def promote(ctx):
-    """Handle dev -> main promotion flow."""
-    emit_stub("repo promote", "repo", json_mode=_get_output_opts(ctx)["json_mode"])
-
-
-# --- repo rollback ---
-
-
-@repo.group()
-def rollback():
-    """Rollback commands."""
-    pass
-
-
-@rollback.command("plan")
-@click.pass_context
-def rollback_plan(ctx):
-    """Inspect rollback plan."""
-    emit_stub("repo rollback plan", "repo", json_mode=_get_output_opts(ctx)["json_mode"])
-
-
-@rollback.command("apply")
-@click.pass_context
-def rollback_apply(ctx):
-    """Execute rollback."""
-    emit_stub("repo rollback apply", "repo", json_mode=_get_output_opts(ctx)["json_mode"])
-
-
-# --- repo health ---
-
-
-@repo.command()
-@click.pass_context
-def health(ctx):
-    """Structured repo hygiene audit."""
-    emit_stub("repo health", "repo", json_mode=_get_output_opts(ctx)["json_mode"])

--- a/src/augint_tools/cli/commands/workspace.py
+++ b/src/augint_tools/cli/commands/workspace.py
@@ -26,7 +26,7 @@ from augint_tools.github import (
     is_gh_available,
     list_issues,
 )
-from augint_tools.output import CommandResponse, emit_response, emit_stub
+from augint_tools.output import CommandResponse, emit_response
 
 
 def _get_output_opts(ctx: click.Context) -> dict:
@@ -289,16 +289,6 @@ def issues(ctx, query):
         ),
         **opts,
     )
-
-
-# --- workspace graph ---
-
-
-@workspace.command()
-@click.pass_context
-def graph(ctx):
-    """Emit dependency order and affected downstream closures."""
-    emit_stub("workspace graph", "workspace", json_mode=_get_output_opts(ctx)["json_mode"])
 
 
 # --- workspace branch ---
@@ -598,16 +588,6 @@ def submit(ctx, monitor):
         ),
         **opts,
     )
-
-
-# --- workspace update ---
-
-
-@workspace.command()
-@click.pass_context
-def update(ctx):
-    """Update downstream repos after upstream changes."""
-    emit_stub("workspace update", "workspace", json_mode=_get_output_opts(ctx)["json_mode"])
 
 
 # --- workspace foreach ---

--- a/src/augint_tools/output/__init__.py
+++ b/src/augint_tools/output/__init__.py
@@ -3,7 +3,6 @@
 from augint_tools.output.formatter import (
     emit_error,
     emit_response,
-    emit_stub,
     emit_warning,
 )
 from augint_tools.output.response import CommandResponse, ExitCode
@@ -13,6 +12,5 @@ __all__ = [
     "ExitCode",
     "emit_error",
     "emit_response",
-    "emit_stub",
     "emit_warning",
 ]

--- a/src/augint_tools/output/formatter.py
+++ b/src/augint_tools/output/formatter.py
@@ -220,7 +220,6 @@ _HUMAN_FORMATTERS: dict[str, Any] = {
     "repo status": _format_repo_status,
     "repo inspect": _format_inspect,
     "repo issues pick": _format_issues,
-    "repo issues view": _format_issues,
     "repo branch prepare": _format_branch,
     "repo check plan": _format_check_plan,
     "repo check run": _format_check_run,
@@ -247,18 +246,3 @@ def emit_error(message: str, exit_code: int | None = None) -> None:
 def emit_warning(message: str) -> None:
     """Emit warning message to stderr."""
     click.echo(click.style(f"Warning: {message}", fg="yellow"), err=True)
-
-
-def emit_stub(command: str, scope: str, *, json_mode: bool = False) -> None:
-    """Emit a stub response for unimplemented commands."""
-    response = CommandResponse(
-        command=command,
-        scope=scope,
-        status="error",
-        summary=f"{command} is not yet implemented",
-        errors=["Not yet implemented"],
-        result={"implemented": False},
-    )
-    if not json_mode:
-        emit_warning(f"{command} is not yet implemented")
-    emit_response(response, json_mode=json_mode)

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -35,9 +35,6 @@ class TestCli:
         assert "check" in result.output
         assert "submit" in result.output
         assert "ci" in result.output
-        assert "promote" in result.output
-        assert "rollback" in result.output
-        assert "health" in result.output
 
     def test_repo_inspect(self):
         runner = CliRunner()
@@ -104,18 +101,3 @@ class TestCli:
         assert result.exit_code == 1
         data = json.loads(result.output)
         assert data["status"] == "error"
-
-    def test_stub_commands(self):
-        """Test that P1/P2 stubs emit the right output."""
-        runner = CliRunner()
-        stubs = [
-            ["repo", "promote"],
-            ["repo", "rollback", "plan"],
-            ["repo", "rollback", "apply"],
-            ["repo", "health"],
-            ["workspace", "graph"],
-            ["workspace", "update"],
-        ]
-        for args in stubs:
-            result = runner.invoke(cli, args)
-            assert "not yet implemented" in result.output.lower(), f"Stub failed for {args}"


### PR DESCRIPTION
## Summary
- Removed 7 unimplemented stub commands: `repo promote`, `repo rollback plan/apply`, `repo health`, `repo issues view`, `workspace graph`, `workspace update`
- Removed `emit_stub()` function and all references (no longer needed)
- Removed unused `--update-strategy` parameter from `repo submit`
- Updated README command reference to match actual CLI surface
- Updated CLAUDE.md to remove stub entries and stub pattern principle

## BREAKING CHANGE
Removed `repo promote`, `repo rollback`, `repo health`, `repo issues view`, `workspace graph`, and `workspace update` commands. These were unimplemented stubs that returned errors.

## Test plan
- [x] All 93 tests pass (1 removed: stub test)
- [x] ruff, mypy, pre-commit all pass
- [x] No remaining references to `emit_stub` in source
- [x] README and CLAUDE.md command lists match actual CLI registration