### PR TITLE
fix(ide): always write bookmarks to workspace.xml using legacy format

### DIFF
--- a/src/augint_tools/ide/steps.py
+++ b/src/augint_tools/ide/steps.py
@@ -513,22 +513,25 @@ def step_bookmarks(
     project_dir: str,
     project_name: str,
     workspace_xml_path: str,
-    product_workspace_path: str | None = None,
+    product_workspace_path: str | None = None,  # kept for API compat; not used
     dry_run: bool = False,
 ) -> StepResult:
-    """Write mnemonic bookmarks to the active IDEA bookmark store."""
+    """Write mnemonic bookmarks to .idea/workspace.xml using the legacy BookmarkManager format.
+
+    The newer BookmarksManager format written to the product workspace is not reliably
+    picked up by IDEA — the legacy format in workspace.xml is what IDEA 2022.1+ reads and
+    migrates on first open.  ``product_workspace_path`` is accepted for backward
+    compatibility but is intentionally ignored.
+    """
     from augint_tools.ide.bookmarks import (
-        bookmarks_already_set,
         build_legacy_bookmarks_xml,
         discover_bookmarks,
         format_bookmark_table,
-        inject_bookmark_group,
         inject_bookmarks,
     )
     from augint_tools.ide.xml import read_xml
 
     name = "bookmarks"
-    group_name = project_name
 
     slots = discover_bookmarks(project_dir)
     if not slots:
@@ -536,36 +539,6 @@ def step_bookmarks(
 
     table = format_bookmark_table(slots)
     bm_data = [{"mnemonic": s.mnemonic, "file": s.rel} for s in slots]
-
-    if product_workspace_path and os.path.exists(product_workspace_path):
-        if bookmarks_already_set(product_workspace_path, slots, project_dir, group_name):
-            return _skipped(
-                name,
-                f"{len(slots)} mnemonic bookmarks already configured in '{group_name}'",
-                bookmarks=bm_data,
-                table=table,
-                workspace_file=product_workspace_path,
-                group_name=group_name,
-            )
-
-        inject_bookmark_group(
-            product_workspace_path,
-            slots,
-            project_dir,
-            group_name,
-            dry_run,
-        )
-        return _ok(
-            name,
-            (
-                f"{len(slots)} mnemonic bookmarks "
-                f"{'would be ' if dry_run else ''}set in bookmark list '{group_name}'"
-            ),
-            bookmarks=bm_data,
-            table=table,
-            workspace_file=product_workspace_path,
-            group_name=group_name,
-        )
 
     if not os.path.exists(workspace_xml_path):
         result = _action_required(
@@ -604,7 +577,6 @@ def step_bookmarks(
         bookmarks=bm_data,
         table=table,
         workspace_file=workspace_xml_path,
-        group_name=group_name,
     )
 
 

--- a/tests/unit/test_ide.py
+++ b/tests/unit/test_ide.py
@@ -722,9 +722,10 @@ class TestBookmarks:
         assert 'mnemonic="1"' in content
         assert "pyproject.toml" in content
 
-    def test_step_bookmarks_writes_native_group_when_product_workspace_exists(
+    def test_step_bookmarks_always_uses_workspace_xml_even_when_product_workspace_exists(
         self, tmp_path: Path
     ) -> None:
+        """product_workspace_path is ignored; legacy format always goes to workspace.xml."""
         from augint_tools.ide.xml import minimal_project_xml, write_xml
 
         (tmp_path / "pyproject.toml").write_text('[project]\nname="x"\n')
@@ -737,17 +738,18 @@ class TestBookmarks:
         product_ws = tmp_path / "product-workspace.xml"
         tree, _root = minimal_project_xml()
         write_xml(tree, str(product_ws))
+        original_product = product_ws.read_text()
 
         res = step_bookmarks(str(tmp_path), "x", str(ws_path), str(product_ws))
         assert res.status == "ok"
-        content = product_ws.read_text()
-        assert "BookmarksManager" in content
-        assert 'value="x"' in content
-        assert "DIGIT_1" in content
+        # Bookmarks written to workspace.xml in legacy format
+        ws_content = ws_path.read_text()
+        assert '<component name="BookmarkManager">' in ws_content
+        assert 'mnemonic="1"' in ws_content
+        # Product workspace must NOT be modified
+        assert product_ws.read_text() == original_product
 
     def test_step_bookmarks_idempotent(self, tmp_path: Path) -> None:
-        from augint_tools.ide.xml import minimal_project_xml, write_xml
-
         (tmp_path / "pyproject.toml").write_text('[project]\nname="x"\n')
         idea = tmp_path / ".idea"
         idea.mkdir()
@@ -755,12 +757,9 @@ class TestBookmarks:
         ws_path.write_text(
             '<?xml version="1.0" encoding="UTF-8"?>\n<project version="4"></project>\n'
         )
-        product_ws = tmp_path / "product-workspace.xml"
-        tree, _root = minimal_project_xml()
-        write_xml(tree, str(product_ws))
 
-        step_bookmarks(str(tmp_path), "x", str(ws_path), str(product_ws))
-        res = step_bookmarks(str(tmp_path), "x", str(ws_path), str(product_ws))
+        step_bookmarks(str(tmp_path), "x", str(ws_path))
+        res = step_bookmarks(str(tmp_path), "x", str(ws_path))
         assert res.status == "skipped"
 
     def test_find_product_workspace_file(self, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- `step_bookmarks` was writing bookmarks to the product workspace file in the newer `BookmarksManager` format, which IDEA does not reliably display
- Fixed by always writing the legacy `BookmarkManager` format to `.idea/workspace.xml`, which IDEA 2022.1+ reads and migrates on first open
- `product_workspace_path` parameter kept for API backward compatibility but is now a no-op

## Root cause
The idempotency check was passing (it found the `BookmarksManager` entries in the product workspace XML) so subsequent runs said "already configured", but IDEA never showed the bookmarks because it reads the legacy component from `workspace.xml`, not the new format from the per-product workspace file.

## Test plan
- [x] All 288 existing tests pass
- [x] `test_step_bookmarks_writes_legacy_format` — confirms legacy format written to workspace.xml
- [x] `test_step_bookmarks_always_uses_workspace_xml_even_when_product_workspace_exists` — confirms product_ws is not touched when it exists
- [x] `test_step_bookmarks_idempotent` — confirms second run skips when workspace.xml already has matching bookmarks
- [ ] Manual: run `ai-tools ide setup`, close and reopen IDEA, confirm bookmarks appear in the Bookmarks tool window

Closes #14