### PR TITLE
feat: Next.js framework-aware detection and opinionated init

### DIFF
--- a/src/augint_tools/cli/commands/init.py
+++ b/src/augint_tools/cli/commands/init.py
@@ -155,12 +155,42 @@ def _scaffold_cdk_ts(_name: str, _desc: str, target: Path) -> int:
     return _run(["cdk", "init", "app", "--language", "typescript"], cwd=target)
 
 
-def _scaffold_react(name: str, _desc: str, target: Path) -> int:
-    return _run(["npx", "create-react-app", name], cwd=target.parent)
-
-
 def _scaffold_nextjs(name: str, _desc: str, target: Path) -> int:
-    return _run(["npx", "create-next-app@latest", name], cwd=target.parent)
+    rc = _run(
+        [
+            "npx",
+            "create-next-app@latest",
+            name,
+            "--typescript",
+            "--tailwind",
+            "--eslint",
+            "--app",
+            "--src-dir",
+            "--import-alias",
+            "@/*",
+            "--use-npm",
+        ],
+        cwd=target.parent,
+    )
+    if rc != 0:
+        return rc
+    # Post-scaffold setup
+    project_dir = target if target.is_dir() else target.parent / name
+
+    # Install prettier (CI and pre-commit require it; create-next-app omits it)
+    _run(["npm", "install", "-D", "prettier"], cwd=project_dir)
+
+    # Initialize shadcn/ui component library
+    shadcn_rc = _run(["npx", "shadcn@latest", "init", "--defaults"], cwd=project_dir)
+    if shadcn_rc != 0:
+        click.echo(
+            click.style(
+                "\nshadcn/ui init failed (non-fatal). Run manually later:\n"
+                "  npx shadcn@latest init --defaults",
+                fg="yellow",
+            )
+        )
+    return 0
 
 
 PROJECT_TYPES: list[ProjectType] = [
@@ -204,16 +234,9 @@ PROJECT_TYPES: list[ProjectType] = [
         tool_creates_dir=False,
     ),
     ProjectType(
-        id="react",
-        name="React app",
-        description="React single-page application (create-react-app)",
-        prereqs=["npx"],
-        scaffold=_scaffold_react,
-    ),
-    ProjectType(
         id="nextjs",
         name="Next.js app",
-        description="Next.js full-stack React framework",
+        description="Next.js with TypeScript, Tailwind CSS, shadcn/ui, App Router",
         prereqs=["npx"],
         scaffold=_scaffold_nextjs,
     ),
@@ -247,6 +270,17 @@ def _print_install_hint(tool: str) -> None:
 def _slugify(name: str) -> str:
     """Lower-case, replace spaces and underscores with hyphens."""
     return name.strip().lower().replace(" ", "-").replace("_", "-")
+
+
+_TYPE_IDS = {pt.id for pt in PROJECT_TYPES}
+
+
+def _find_type(type_id: str) -> ProjectType | None:
+    """Look up a project type by its id string."""
+    for pt in PROJECT_TYPES:
+        if pt.id == type_id:
+            return pt
+    return None
 
 
 # ---------------------------------------------------------------------------
@@ -346,26 +380,69 @@ def _print_next_steps(project_dir: Path) -> None:
 
 @click.command("init")
 @click.argument("path", default=None, required=False)
+@click.option(
+    "--type",
+    "type_id",
+    type=click.Choice(sorted(_TYPE_IDS), case_sensitive=False),
+    default=None,
+    help="Project type (skips interactive selection).",
+)
+@click.option(
+    "--name",
+    "proj_name",
+    default=None,
+    help="Project name (skips interactive prompt).",
+)
+@click.option(
+    "-y",
+    "--yes",
+    is_flag=True,
+    default=False,
+    help="Skip confirmation prompts.",
+)
+@click.option(
+    "--no-git-init",
+    is_flag=True,
+    default=False,
+    help="Skip git init (useful when called from /ai-new-project).",
+)
 @click.pass_context
-def init(ctx: click.Context, path: str | None) -> None:
+def init(
+    ctx: click.Context,
+    path: str | None,
+    type_id: str | None,
+    proj_name: str | None,
+    yes: bool,
+    no_git_init: bool,
+) -> None:
     """New project scaffold wizard.
 
     Guides you through selecting a project type (Python library, npm package,
-    SAM, CDK, React, Next.js) and running the appropriate toolchain to create
+    SAM, CDK, Next.js) and running the appropriate toolchain to create
     the project structure.  After scaffolding, prints next-step instructions.
 
     Optional PATH sets the target directory (use . for the current directory).
     When omitted, you are prompted for a name and the project is created in a
     subdirectory of the current directory.
+
+    Non-interactive mode: pass --type, --name, and --yes to skip all prompts.
     """
     path_override = Path(path).expanduser().resolve() if path else None
 
     _print_header()
 
     # 1. Pick project type
-    pt = _select_project_type()
-    click.echo("")
-    click.echo(f"  Selected: {click.style(pt.name, bold=True)}")
+    if type_id:
+        pt = _find_type(type_id)
+        if pt is None:
+            click.echo(click.style(f"Unknown project type: {type_id}", fg="red"))
+            ctx.exit(1)
+            return
+        click.echo(f"  Selected: {click.style(pt.name, bold=True)}")
+    else:
+        pt = _select_project_type()
+        click.echo("")
+        click.echo(f"  Selected: {click.style(pt.name, bold=True)}")
 
     # 2. Check prereqs
     missing = _missing_prereqs(pt)
@@ -395,18 +472,23 @@ def init(ctx: click.Context, path: str | None) -> None:
             click.echo(click.style(f"\nScaffolding exited with code {rc}.", fg="yellow"))
         return
 
-    # 3b. Collect project details
-    name, desc, target = _collect_details(pt, path_override)
+    # 3b. Collect project details (or use CLI args)
+    if proj_name and (path_override or yes):
+        name = _slugify(proj_name)
+        target = path_override if path_override else Path.cwd() / name
+        desc = ""
+    else:
+        name, desc, target = _collect_details(pt, path_override)
 
     # 4. Confirm
-    if not _confirm_plan(pt, name, target):
+    if not yes and not _confirm_plan(pt, name, target):
         click.echo("Aborted.")
         return
 
     # 5. Check target directory
     if target.exists() and any(target.iterdir()):
         click.echo(click.style(f"\nDirectory already exists and is not empty: {target}", fg="red"))
-        if not click.confirm("Continue anyway?", default=False):
+        if not yes and not click.confirm("Continue anyway?", default=False):
             return
 
     # 6. Run scaffolding
@@ -422,7 +504,15 @@ def init(ctx: click.Context, path: str | None) -> None:
         return
 
     # 7. Git init (when not already handled by scaffolding tool)
-    _git_init(target)
+    if not no_git_init:
+        if yes:
+            git_dir = target / ".git"
+            if not git_dir.is_dir():
+                _run(["git", "init"], cwd=target)
+                _run(["git", "add", "."], cwd=target)
+                _run(["git", "commit", "-m", "chore: initial scaffolding"], cwd=target)
+        else:
+            _git_init(target)
 
     # 8. Next steps
     _print_next_steps(target)

--- a/src/augint_tools/detection/commands.py
+++ b/src/augint_tools/detection/commands.py
@@ -16,12 +16,14 @@ class CommandPlan:
     build: str | None = None
 
 
-def resolve_command_plan(toolchain: ToolchainInfo, language: str) -> CommandPlan:
+def resolve_command_plan(
+    toolchain: ToolchainInfo, language: str, framework: str = "plain"
+) -> CommandPlan:
     """Resolve the command plan from ecosystem defaults."""
     if language == "python":
         return _python_defaults(toolchain)
     elif language in ("typescript", "mixed"):
-        return _typescript_defaults(toolchain)
+        return _typescript_defaults(toolchain, framework)
     return CommandPlan()
 
 
@@ -60,10 +62,14 @@ def _python_defaults(toolchain: ToolchainInfo) -> CommandPlan:
     )
 
 
-def _typescript_defaults(toolchain: ToolchainInfo) -> CommandPlan:
+def _typescript_defaults(toolchain: ToolchainInfo, framework: str = "plain") -> CommandPlan:
     """Default command plan for TypeScript/JavaScript projects."""
+    is_nextjs = framework == "nextjs"
+
     if toolchain.has_biome:
         quality = "npx biome check ."
+    elif is_nextjs:
+        quality = "npx next lint"
     elif toolchain.has_npm:
         quality = "npm run lint"
     else:
@@ -71,10 +77,18 @@ def _typescript_defaults(toolchain: ToolchainInfo) -> CommandPlan:
 
     tests = "npm test" if toolchain.has_npm else None
 
+    build: str | None
+    if is_nextjs:
+        build = "npx next build"
+    elif toolchain.has_npm:
+        build = "npm run build"
+    else:
+        build = None
+
     return CommandPlan(
         quality=quality,
         tests=tests,
         security="npm audit" if toolchain.has_npm else None,
         licenses=None,
-        build="npm run build" if toolchain.has_npm else None,
+        build=build,
     )

--- a/src/augint_tools/detection/engine.py
+++ b/src/augint_tools/detection/engine.py
@@ -93,8 +93,8 @@ def detect(path: Path | None = None) -> RepoContext:
     # Toolchain
     toolchain = detect_toolchain(path)
 
-    # Command plan from ecosystem defaults only
-    command_plan = resolve_command_plan(toolchain, language)
+    # Command plan from ecosystem defaults, framework-aware
+    command_plan = resolve_command_plan(toolchain, language, framework)
 
     # Git state
     default_branch = "main"

--- a/src/augint_tools/detection/framework.py
+++ b/src/augint_tools/detection/framework.py
@@ -1,6 +1,21 @@
 """Framework detection from filesystem markers."""
 
+import json
 from pathlib import Path
+
+
+def _has_next_dependency(path: Path) -> bool:
+    """Check if ``next`` is in package.json dependencies or devDependencies."""
+    pkg_path = path / "package.json"
+    if not pkg_path.exists():
+        return False
+    try:
+        data = json.loads(pkg_path.read_text())
+        deps = data.get("dependencies", {})
+        dev_deps = data.get("devDependencies", {})
+        return "next" in deps or "next" in dev_deps
+    except (json.JSONDecodeError, OSError):
+        return False
 
 
 def detect_framework(path: Path) -> str:
@@ -25,6 +40,7 @@ def detect_framework(path: Path) -> str:
         (path / "next.config.js").exists()
         or (path / "next.config.mjs").exists()
         or (path / "next.config.ts").exists()
+        or _has_next_dependency(path)
     ):
         return "nextjs"
 

--- a/tests/unit/test_detection.py
+++ b/tests/unit/test_detection.py
@@ -45,9 +45,27 @@ class TestFrameworkDetection:
         (tmp_path / "next.config.js").touch()
         assert detect_framework(tmp_path) == "nextjs"
 
+    def test_nextjs_via_config_ts(self, tmp_path):
+        (tmp_path / "next.config.ts").touch()
+        assert detect_framework(tmp_path) == "nextjs"
+
+    def test_nextjs_via_package_json(self, tmp_path):
+        (tmp_path / "package.json").write_text('{"dependencies":{"next":"16.0.0"}}')
+        assert detect_framework(tmp_path) == "nextjs"
+
+    def test_nextjs_via_dev_dependency(self, tmp_path):
+        (tmp_path / "package.json").write_text('{"devDependencies":{"next":"16.0.0"}}')
+        assert detect_framework(tmp_path) == "nextjs"
+
     def test_vite(self, tmp_path):
         (tmp_path / "vite.config.ts").touch()
         assert detect_framework(tmp_path) == "vite"
+
+    def test_nextjs_before_vite(self, tmp_path):
+        """Next.js should win when both markers exist."""
+        (tmp_path / "next.config.ts").touch()
+        (tmp_path / "vite.config.ts").touch()
+        assert detect_framework(tmp_path) == "nextjs"
 
     def test_plain(self, tmp_path):
         assert detect_framework(tmp_path) == "plain"
@@ -87,3 +105,10 @@ class TestCommandPlanResolution:
         assert plan.quality == "npm run lint"
         assert plan.tests == "npm test"
         assert plan.build == "npm run build"
+
+    def test_nextjs_defaults(self):
+        toolchain = ToolchainInfo(package_manager="npm", has_npm=True)
+        plan = resolve_command_plan(toolchain, "typescript", "nextjs")
+        assert plan.quality == "npx next lint"
+        assert plan.tests == "npm test"
+        assert plan.build == "npx next build"


### PR DESCRIPTION
## Summary

- **framework.py**: Detect Next.js via `package.json` dependencies (not just file markers), aligning with the framework-detection knowledge rule
- **commands.py**: Resolve quality/build commands to `npx next lint` / `npx next build` when framework=nextjs
- **init.py**: Opinionated `create-next-app` flags (TypeScript, Tailwind, ESLint, App Router, src/ layout, npm), shadcn/ui + prettier post-scaffold, non-interactive CLI flags (`--type`, `--name`, `--yes`, `--no-git-init`), remove CRA project type

## Test plan

- [x] All 347 tests pass
- [x] Lint, format, and type checks clean
- [ ] Run `ai-tools init --type nextjs --name test-app --yes` and verify scaffold includes TypeScript, Tailwind, src/ layout, prettier, shadcn/ui
- [ ] Verify `ai-tools init` help shows all new flags
- [ ] Verify framework detection picks up `next` in package.json dependencies