### PR TITLE
fix(env): skip empty-value .env entries in gh push

### DIFF
--- a/src/augint_tools/env/classify.py
+++ b/src/augint_tools/env/classify.py
@@ -103,6 +103,9 @@ def classify_variable(key: str, value: str) -> ClassificationResult:
     if key in KEY_SKIP_PREFIXES:
         return ClassificationResult(key, value, Classification.SKIP, ["skip-list key"])
 
+    if not value:
+        return ClassificationResult(key, value, Classification.SKIP, ["empty value"])
+
     lower_key = key.casefold()
     for kw in KEY_SECRET_KEYWORDS:
         if kw in lower_key:

--- a/tests/unit/test_env_classify.py
+++ b/tests/unit/test_env_classify.py
@@ -156,6 +156,33 @@ class TestPartitionEnv:
         assert "AWS_PROFILE" not in variables
 
 
+class TestEmptyValueSkip:
+    def test_empty_string_classified_as_skip(self):
+        r = classify_variable("STAGING_VAR", "")
+        assert r.classification == Classification.SKIP
+        assert "empty value" in r.reasons
+
+    def test_classify_env_skips_empty_values(self, tmp_path):
+        env_file = tmp_path / ".env"
+        env_file.write_text(
+            'NORMAL_VAR=hello\nSTAGING_VAR=\nEMPTY_QUOTED=""\nSECRET_TOKEN=ghp_abc123\n'
+        )
+        results = classify_env(str(env_file))
+        classifications = {r.key: r.classification for r in results}
+        assert classifications["NORMAL_VAR"] == Classification.VARIABLE
+        assert classifications.get("STAGING_VAR") == Classification.SKIP
+        assert classifications["SECRET_TOKEN"] == Classification.SECRET
+
+    def test_partition_env_excludes_empty_values(self, tmp_path):
+        env_file = tmp_path / ".env"
+        env_file.write_text("NORMAL_VAR=hello\nSTAGING_VAR=\nSECRET_TOKEN=ghp_abc123\n")
+        secrets, variables = partition_env(str(env_file))
+        assert "STAGING_VAR" not in secrets
+        assert "STAGING_VAR" not in variables
+        assert "NORMAL_VAR" in variables
+        assert "SECRET_TOKEN" in secrets
+
+
 class TestMultipleReasons:
     def test_key_and_value_match(self):
         r = classify_variable("GH_TOKEN", "ghp_abc123def456ghi789jkl012mno345pqr678stu")


### PR DESCRIPTION
## Summary
- `ai-tools gh push` crashes when `.env` contains entries like `STAGING_VAR=` (key with trailing `=` but no value)
- Adds early return in `classify_variable()` that classifies empty-string values as `SKIP`, preventing them from being pushed to GitHub as secrets/variables
- Adds comprehensive test coverage for the classification module

## Test plan
- [x] `classify_variable("STAGING_VAR", "")` returns `Classification.SKIP`
- [x] `classify_env()` on a file with `STAGING_VAR=` classifies it as SKIP
- [x] `partition_env()` excludes empty values from both secrets and variables dicts
- [x] Existing classification behavior unchanged (secrets, variables, skip-list keys)
- [x] Pre-commit hooks pass