### PR TITLE
feat: add repo visibility management to dashboard

### DIFF
--- a/src/augint_tools/dashboard/_data.py
+++ b/src/augint_tools/dashboard/_data.py
@@ -110,6 +110,8 @@ class RepoStatus:
     is_workspace: bool = False
     # Autodetected technology tags (e.g. "py", "sam", "tf").
     tags: tuple[str, ...] = ()
+    # Whether the repo is private on GitHub.
+    private: bool = False
 
 
 # ---------------------------------------------------------------------------
@@ -295,6 +297,7 @@ def fetch_repo_status_with_pulls(
                 dev_failing_since=dev_failing_since,
                 is_workspace=is_workspace,
                 tags=tags,
+                private=getattr(repo, "private", False) or False,
             ),
             pulls_list,
         )

--- a/src/augint_tools/dashboard/app.py
+++ b/src/augint_tools/dashboard/app.py
@@ -33,6 +33,7 @@ from .prefs import DashboardPrefs, save_prefs
 from .screens.drilldown import DrillDownScreen
 from .screens.filter_panel import FilterPanel
 from .screens.help import HelpScreen
+from .screens.repo_manager import RepoManager
 from .state import (
     PANEL_WIDTH_MAX,
     PANEL_WIDTH_MIN,
@@ -950,6 +951,7 @@ class DashboardApp(App[None]):
         Binding("i", "toggle_org", "Org"),
         Binding("e", "toggle_errors", "Errors"),
         Binding("E", "clear_errors", "Clear Errors", show=False),
+        Binding("m", "manage_repos", "Repos"),
         Binding("question_mark", "show_help", "Help"),
         Binding("f5", "full_restart", "Restart", show=False),
         Binding("plus", "widen_card", "Wider", show=False),
@@ -1014,6 +1016,9 @@ class DashboardApp(App[None]):
         self._flash_enabled: bool = True
         self._restart_requested: bool = False
 
+        # Disabled repos -- excluded from refresh and all views.
+        self._disabled_repos: set[str] = set()
+
         # Apply remaining saved preferences (sort, filters, panel width, flash).
         # Theme and layout are already applied via initial_theme/initial_layout
         # which the caller resolves from saved prefs + CLI overrides.
@@ -1022,6 +1027,7 @@ class DashboardApp(App[None]):
             self.state.active_filters = set(saved_prefs.active_filters)
             self.state.panel_width = saved_prefs.panel_width
             self._flash_enabled = saved_prefs.flash_enabled
+            self._disabled_repos = set(saved_prefs.disabled_repos)
 
     # ---- preferences ----
 
@@ -1035,6 +1041,7 @@ class DashboardApp(App[None]):
                 active_filters=sorted(self.state.active_filters),
                 panel_width=self.state.panel_width,
                 flash_enabled=self._flash_enabled,
+                disabled_repos=sorted(self._disabled_repos),
             )
         )
 
@@ -1042,6 +1049,10 @@ class DashboardApp(App[None]):
 
     def on_mount(self) -> None:
         self._load_theme_css(self.state.theme_name)
+        # Exclude disabled repos from the initial repo list so they don't
+        # appear in the first paint and don't get refreshed.
+        if self._disabled_repos:
+            self._repos = [r for r in self._repos if r.full_name not in self._disabled_repos]
         # Cache-first: load before mounting so the first paint shows data.
         restrict = {r.full_name for r in self._repos} if self._repos else None
         bootstrap_from_cache(self.state, restrict_to=restrict)
@@ -1140,11 +1151,16 @@ class DashboardApp(App[None]):
             return  # Keep current list on failure.
 
         if self._auto_discover:
-            self._repos = fresh
+            self._repos = [r for r in fresh if r.full_name not in self._disabled_repos]
         else:
             # Keep only repos the user originally selected that still exist.
             fresh_names = {r.full_name for r in fresh}
-            self._repos = [r for r in fresh if r.full_name in self._original_repo_names]
+            self._repos = [
+                r
+                for r in fresh
+                if r.full_name in self._original_repo_names
+                and r.full_name not in self._disabled_repos
+            ]
             # Log removals so they're visible in the error drawer.
             gone = self._original_repo_names - fresh_names
             for name in sorted(gone):
@@ -1509,6 +1525,36 @@ class DashboardApp(App[None]):
 
     def action_show_help(self) -> None:
         self.push_screen(HelpScreen())
+
+    def action_manage_repos(self) -> None:
+        """Open the repo manager to enable/disable individual repos."""
+        # Build the full list of known repo names (including disabled ones).
+        known: set[str] = {r.full_name for r in self._repos}
+        known |= set(self.state.health_by_name.keys())
+        known |= self._disabled_repos
+        if not known:
+            self.notify("no repos known yet -- refresh first", severity="warning", timeout=3)
+            return
+
+        def _on_dismiss(disabled: set[str] | None) -> None:
+            if disabled is None:
+                return
+            self._disabled_repos = disabled
+            # Remove disabled repos from state so they vanish immediately.
+            self.state.healths = [
+                h for h in self.state.healths if h.status.full_name not in disabled
+            ]
+            self.state.health_by_name = {h.status.full_name: h for h in self.state.healths}
+            self._rerender()
+            self._save_prefs()
+            n_disabled = len(disabled)
+            label = f"{n_disabled} disabled" if n_disabled else "all enabled"
+            self.notify(f"repos: {label}", timeout=2)
+
+        self.push_screen(
+            RepoManager(sorted(known), self._disabled_repos),
+            callback=_on_dismiss,
+        )
 
     def action_move_down(self) -> None:
         move_selection(self.state, self._grid_step())

--- a/src/augint_tools/dashboard/layouts/grouped.py
+++ b/src/augint_tools/dashboard/layouts/grouped.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from ..state import (
     PANEL_WIDTH_DEFAULT,
+    UNASSIGNED_TEAM,
     RepoTeamInfo,
     display_team_label,
 )
@@ -30,19 +31,29 @@ class GroupedLayout:
             pass
 
         # Bucket cards by their repo's primary team.
+        # Public repos without a team are grouped under a synthetic
+        # "open-source" key so the grouped view labels them clearly.
+        _OPEN_SOURCE_KEY = "__open_source__"
         buckets: dict[str, list] = {}
         order: list[str] = []
         for card in cards:
             info = ctx.state.repo_teams.get(card.repo_full_name, RepoTeamInfo())
             team_key = info.primary
+            # Promote public + unassigned repos into an "Open source" group.
+            health = ctx.state.health_by_name.get(card.repo_full_name)
+            if team_key == UNASSIGNED_TEAM and health and not health.status.private:
+                team_key = _OPEN_SOURCE_KEY
             if team_key not in buckets:
                 buckets[team_key] = []
                 order.append(team_key)
             buckets[team_key].append(card)
 
-        headers: dict[str, str] = {
-            team_key: display_team_label(team_key, ctx.state.team_labels) for team_key in order
-        }
+        headers: dict[str, str] = {}
+        for team_key in order:
+            if team_key == _OPEN_SOURCE_KEY:
+                headers[team_key] = "Open source"
+            else:
+                headers[team_key] = display_team_label(team_key, ctx.state.team_labels)
         container.set_group_headers(order, headers, buckets)
 
         for card in cards:

--- a/src/augint_tools/dashboard/prefs.py
+++ b/src/augint_tools/dashboard/prefs.py
@@ -27,6 +27,7 @@ class DashboardPrefs:
     active_filters: list[str] = field(default_factory=list)
     panel_width: int = 38
     flash_enabled: bool = True
+    disabled_repos: list[str] = field(default_factory=list)
 
     def to_dict(self) -> dict:
         return asdict(self)

--- a/src/augint_tools/dashboard/screens/__init__.py
+++ b/src/augint_tools/dashboard/screens/__init__.py
@@ -1,1 +1,5 @@
 """Modal screens for the v2 dashboard."""
+
+from .repo_manager import RepoManager
+
+__all__ = ["RepoManager"]

--- a/src/augint_tools/dashboard/screens/help.py
+++ b/src/augint_tools/dashboard/screens/help.py
@@ -19,6 +19,7 @@ Data
   r                   Refresh now
   s                   Cycle sort (health, alpha, problem)
   f                   Open filter panel (multi-select)
+  m                   Manage repos (enable/disable)
   w                   Toggle workspace filter
 
 Layouts and themes

--- a/src/augint_tools/dashboard/screens/repo_manager.py
+++ b/src/augint_tools/dashboard/screens/repo_manager.py
@@ -1,0 +1,82 @@
+"""RepoManager -- modal screen to enable/disable repos for the dashboard.
+
+Disabled repos are excluded from API refresh cycles (saving rate-limit
+budget) and hidden from every filter view.
+"""
+
+from __future__ import annotations
+
+from textual import events
+from textual.binding import Binding
+from textual.containers import Container
+from textual.screen import ModalScreen
+from textual.widgets import SelectionList, Static
+from textual.widgets.selection_list import Selection
+
+
+class RepoManager(ModalScreen[set[str]]):
+    """Modal that lets the user toggle individual repos on/off.
+
+    Returns the set of **disabled** repo full-names on dismiss.
+    """
+
+    DEFAULT_CSS = """
+    RepoManager {
+        align: center middle;
+    }
+    RepoManager > Container {
+        width: 60;
+        max-height: 80%;
+        border: thick $accent;
+        background: $surface;
+        padding: 1 2;
+    }
+    RepoManager #rm-title {
+        height: 1;
+        padding: 0 0 1 0;
+        text-style: bold;
+    }
+    RepoManager SelectionList {
+        height: auto;
+        max-height: 100%;
+    }
+    """
+
+    BINDINGS = [
+        Binding("escape", "dismiss_panel", "Close"),
+        Binding("m", "dismiss_panel", "Close"),
+    ]
+
+    def __init__(
+        self,
+        all_repo_names: list[str],
+        disabled_repos: set[str],
+    ) -> None:
+        super().__init__()
+        self._all_repo_names = sorted(all_repo_names)
+        self._disabled_repos = disabled_repos
+
+    def compose(self):
+        # Each repo is a selection entry.  Selected = enabled, unselected = disabled.
+        selections = [
+            Selection(
+                name,
+                name,
+                initial_state=name not in self._disabled_repos,
+            )
+            for name in self._all_repo_names
+        ]
+        yield Container(
+            Static("Manage repos (selected = enabled, unselected = disabled)", id="rm-title"),
+            SelectionList[str](*selections, id="repo-list"),
+        )
+
+    def on_click(self, event: events.Click) -> None:
+        if event.button == 3:
+            self.action_dismiss_panel()
+
+    def action_dismiss_panel(self) -> None:
+        sel_list = self.query_one("#repo-list", SelectionList)
+        enabled = set(sel_list.selected)
+        disabled = {name for name in self._all_repo_names if name not in enabled}
+        self.dismiss(disabled)

--- a/src/augint_tools/dashboard/state.py
+++ b/src/augint_tools/dashboard/state.py
@@ -31,6 +31,8 @@ UNASSIGNED_TEAM = "unassigned"
 SORT_MODES: tuple[str, ...] = ("health", "alpha", "problem")
 FILTER_MODES: tuple[str, ...] = (
     "all",
+    "private",
+    "public",
     "no-workspace",
     "broken-ci",
     "security",
@@ -244,6 +246,10 @@ def apply_sort(healths: list[RepoHealth], mode: str) -> list[RepoHealth]:
 
 def _matches_filter(h: RepoHealth, mode: str, repo_teams: dict[str, RepoTeamInfo]) -> bool:
     """Check whether a single health entry passes a single filter mode."""
+    if mode == "private":
+        return h.status.private
+    if mode == "public":
+        return not h.status.private
     if mode == "no-workspace":
         return not h.status.is_workspace
     if mode == "broken-ci":

--- a/src/augint_tools/dashboard/widgets/status_bar.py
+++ b/src/augint_tools/dashboard/widgets/status_bar.py
@@ -18,6 +18,8 @@ if TYPE_CHECKING:
 
 _FILTER_LABELS: dict[str, str] = {
     "all": "all repos",
+    "private": "Private",
+    "public": "Public (Open source)",
     "broken-ci": "broken CI",
     "security": "security alerts",
     "no-renovate": "no renovate",

--- a/tests/unit/test_dashboard.py
+++ b/tests/unit/test_dashboard.py
@@ -55,6 +55,7 @@ def _status(
     open_prs=0,
     is_workspace=False,
     tags=(),
+    private=False,
 ) -> RepoStatus:
     return RepoStatus(
         name=name,
@@ -69,6 +70,7 @@ def _status(
         draft_prs=0,
         is_workspace=is_workspace,
         tags=tags,
+        private=private,
     )
 
 
@@ -78,9 +80,16 @@ def _health(
     checks=None,
     is_workspace=False,
     tags=(),
+    private=False,
 ) -> RepoHealth:
     return RepoHealth(
-        status=_status(name=name, full_name=full_name, is_workspace=is_workspace, tags=tags),
+        status=_status(
+            name=name,
+            full_name=full_name,
+            is_workspace=is_workspace,
+            tags=tags,
+            private=private,
+        ),
         checks=checks or [],
     )
 
@@ -1576,3 +1585,129 @@ class TestPrefs:
                 assert app._flash_enabled is False
 
         asyncio.run(run())
+
+
+# ---------------------------------------------------------------------------
+# Visibility filters (private/public)
+# ---------------------------------------------------------------------------
+
+
+class TestVisibilityFilters:
+    def test_private_filter_matches_private_repos(self):
+        priv = _health(name="secret", full_name="org/secret", private=True)
+        pub = _health(name="oss", full_name="org/oss", private=False)
+        out = apply_filter([priv, pub], "private")
+        assert [h.status.name for h in out] == ["secret"]
+
+    def test_public_filter_matches_public_repos(self):
+        priv = _health(name="secret", full_name="org/secret", private=True)
+        pub = _health(name="oss", full_name="org/oss", private=False)
+        out = apply_filter([priv, pub], "public")
+        assert [h.status.name for h in out] == ["oss"]
+
+    def test_private_and_public_in_filter_modes(self):
+        assert "private" in FILTER_MODES
+        assert "public" in FILTER_MODES
+
+    def test_active_filters_public_hides_private(self):
+        priv = _health(name="secret", full_name="org/secret", private=True)
+        pub = _health(name="oss", full_name="org/oss", private=False)
+        out = apply_active_filters([priv, pub], {"public"})
+        assert [h.status.name for h in out] == ["oss"]
+
+    def test_combined_public_and_broken_ci(self):
+        """Public + broken-ci filters AND together."""
+        ci_check = HealthCheckResult(
+            check_name="broken_ci", severity=Severity.CRITICAL, summary="x"
+        )
+        pub_broken = _health(
+            name="pub-broken", full_name="org/pub-broken", checks=[ci_check], private=False
+        )
+        priv_broken = _health(
+            name="priv-broken", full_name="org/priv-broken", checks=[ci_check], private=True
+        )
+        pub_ok = _health(name="pub-ok", full_name="org/pub-ok", private=False)
+        out = apply_active_filters([pub_broken, priv_broken, pub_ok], {"public", "broken-ci"})
+        assert [h.status.name for h in out] == ["pub-broken"]
+
+
+class TestRepoStatusPrivateField:
+    def test_private_field_defaults_false(self):
+        status = _status()
+        assert status.private is False
+
+    def test_private_field_set_true(self):
+        status = _status(private=True)
+        assert status.private is True
+
+    def test_cache_round_trip_preserves_private(self):
+        """Private field survives cache serialization."""
+        from dataclasses import asdict
+
+        status = _status(name="secret", full_name="org/secret", private=True)
+        data = asdict(status)
+        assert data["private"] is True
+        restored = RepoStatus(**data)
+        assert restored.private is True
+
+
+# ---------------------------------------------------------------------------
+# Disabled repos (prefs + app)
+# ---------------------------------------------------------------------------
+
+
+class TestDisabledReposPrefs:
+    def test_disabled_repos_round_trip(self, tmp_path, monkeypatch):
+        from augint_tools.dashboard.prefs import (
+            DashboardPrefs,
+            load_prefs,
+            save_prefs,
+        )
+
+        monkeypatch.setattr("augint_tools.dashboard.prefs.CACHE_DIR", tmp_path)
+        monkeypatch.setattr("augint_tools.dashboard.prefs.PREFS_FILE", tmp_path / "prefs.json")
+
+        prefs = DashboardPrefs(disabled_repos=["org/old-repo", "org/noisy"])
+        save_prefs(prefs)
+        loaded = load_prefs()
+        assert sorted(loaded.disabled_repos) == ["org/noisy", "org/old-repo"]
+
+    def test_disabled_repos_defaults_empty(self):
+        from augint_tools.dashboard.prefs import DashboardPrefs
+
+        prefs = DashboardPrefs()
+        assert prefs.disabled_repos == []
+
+
+class TestDisabledReposApp:
+    def test_app_loads_disabled_repos_from_prefs(self):
+        from augint_tools.dashboard.prefs import DashboardPrefs
+
+        prefs = DashboardPrefs(disabled_repos=["org/disabled"])
+        app = DashboardApp(repos=[], skip_refresh=True, saved_prefs=prefs)
+        assert "org/disabled" in app._disabled_repos
+
+    def test_app_saves_disabled_repos_in_prefs(self):
+        app = DashboardApp(repos=[], skip_refresh=True)
+        app._disabled_repos = {"org/disabled"}
+        with patch("augint_tools.dashboard.app.save_prefs") as mock_save:
+            app._save_prefs()
+            saved = mock_save.call_args[0][0]
+            assert "org/disabled" in saved.disabled_repos
+
+
+# ---------------------------------------------------------------------------
+# Status bar filter labels
+# ---------------------------------------------------------------------------
+
+
+class TestFilterLabels:
+    def test_describe_filter_private(self):
+        from augint_tools.dashboard.widgets.status_bar import describe_filter
+
+        assert describe_filter("private") == "Private"
+
+    def test_describe_filter_public(self):
+        from augint_tools.dashboard.widgets.status_bar import describe_filter
+
+        assert describe_filter("public") == "Public (Open source)"


### PR DESCRIPTION
## Summary
- Adds private/public filter modes to the dashboard -- public repos shown as "Open source" in grouped layout
- New repo manager screen (press `m`) to enable/disable individual repos -- disabled repos skip API refresh, directly saving rate-limit budget
- Disabled repos persisted in dashboard prefs across sessions
- `RepoStatus` now carries a `private` field populated from the GitHub API

## Test plan
- [x] Private/public filter modes correctly match repo visibility
- [x] Disabled repos excluded from prefs round-trip
- [x] Filter labels render correctly for new modes
- [x] RepoStatus private field defaults safely for cached data
- [x] 358 tests pass including 14 new tests
- [x] Pre-commit hooks pass