### PR TITLE
feat: multi-org dashboard with OR-filter model

### DIFF
--- a/src/augint_tools/dashboard/_common.py
+++ b/src/augint_tools/dashboard/_common.py
@@ -5,6 +5,7 @@ Kept self-contained so the dashboard can ship as part of augint-tools without
 depending on augint-github at runtime.
 """
 
+import logging
 import os
 import subprocess
 import sys
@@ -34,6 +35,11 @@ def configure_logging(verbose: bool, log_file: str | None = None) -> None:
             rotation="5 MB",
             retention=2,
         )
+    # PyGithub's GithubRetry logs expected 403/404 responses at INFO level
+    # via the stdlib logging module. Textual captures stdlib logging and
+    # renders it in the TUI, causing distracting "Request GET ... failed
+    # with 403: Forbidden" messages to flash on screen. Silence them.
+    logging.getLogger("github").setLevel(logging.WARNING)
 
 
 def _load_dotenv_values(filename: str = ".env") -> dict[str, str]:

--- a/src/augint_tools/dashboard/_helpers.py
+++ b/src/augint_tools/dashboard/_helpers.py
@@ -100,6 +100,41 @@ def select_repos_interactive(repos: list[Repository]) -> list[Repository]:
         print("[red]Invalid selection. Try again.[/red]")
 
 
+def get_viewer_login(g: Github) -> str:
+    """Return the login of the authenticated user."""
+    try:
+        return g.get_user().login
+    except GithubException:
+        return ""
+
+
+def list_user_orgs(g: Github) -> list[str]:
+    """Return login names of all organizations the authenticated user belongs to."""
+    try:
+        return [org.login for org in g.get_user().get_orgs()]
+    except GithubException:
+        return []
+
+
+def list_repos_multi(g: Github, owners: list[str]) -> list[Repository]:
+    """List non-archived repos across multiple owners (users/orgs).
+
+    Deduplicates by ``full_name`` in case the same repo appears under
+    multiple owners (shouldn't happen, but defensive).
+    """
+    seen: set[str] = set()
+    result: list[Repository] = []
+    for owner in owners:
+        try:
+            for repo in list_repos(g, owner):
+                if repo.full_name not in seen:
+                    seen.add(repo.full_name)
+                    result.append(repo)
+        except Exception:
+            logger.warning(f"Failed to list repos for '{owner}', skipping.")
+    return result
+
+
 def warn_rate_limit(repo_count: int, refresh_seconds: int) -> None:
     """Warn if estimated API usage would exceed GitHub rate limits."""
     calls_per_repo = 7

--- a/src/augint_tools/dashboard/app.py
+++ b/src/augint_tools/dashboard/app.py
@@ -26,13 +26,14 @@ from textual.screen import Screen
 from textual.widgets import Static
 
 from ._data import RepoStatus, fetch_repo_status_with_pulls, save_cache
-from ._helpers import list_repos, strip_dotfile_repos
+from ._helpers import get_viewer_login, list_repos_multi, list_user_orgs, strip_dotfile_repos
 from .health import FetchContext, RepoHealth, run_health_checks
 from .layouts import list_layouts
 from .prefs import DashboardPrefs, save_prefs
 from .screens.drilldown import DrillDownScreen
 from .screens.filter_panel import FilterPanel
 from .screens.help import HelpScreen
+from .screens.org_manager import OrgManager
 from .screens.repo_manager import RepoManager
 from .state import (
     PANEL_WIDTH_MAX,
@@ -198,10 +199,13 @@ class OrgDrawerHeader(Container):
 class MainScreen(Screen[None]):
     """Primary screen: header, status bar, highlight bar, card grid, footer, drawer."""
 
-    def __init__(self, state: AppState, org_name: str) -> None:
+    def __init__(
+        self, state: AppState, org_name: str = "", owners: list[str] | None = None
+    ) -> None:
         super().__init__(id="main-screen")
         self._state = state
         self._org_name = org_name
+        self._owners: list[str] = owners or ([org_name] if org_name else [])
         self._header = OrgDrawerHeader()
         self._status_bar = StatusBar()
         self._highlight_bar = HighlightBar()
@@ -213,7 +217,7 @@ class MainScreen(Screen[None]):
 
     def compose(self):
         yield self._header
-        self._status_bar.bind_state(self._state, self._org_name)
+        self._status_bar.bind_state(self._state, self._org_name, owners=self._owners)
         yield self._status_bar
         self._highlight_bar.bind_state(self._state)
         yield self._highlight_bar
@@ -292,10 +296,12 @@ class MainScreen(Screen[None]):
         # Add or update cards for the visible set, preserving order.
         known_teams = list(self._state.team_labels)
         cards_in_order: list[RepoCard] = []
+        stale_set = self._state.stale_repos
         for full_name, health in desired.items():
             team_info = self._state.repo_teams.get(full_name)
             accent = team_accent(team_info.primary, known_teams) if team_info else "#808080"
             label = self._state.team_labels.get(team_info.primary, "") if team_info else ""
+            is_stale = full_name in stale_set
             existing = self._cards_by_name.get(full_name)
             if existing is None:
                 card = RepoCard(
@@ -304,6 +310,7 @@ class MainScreen(Screen[None]):
                     team_accent=accent,
                     team_label=label,
                 )
+                card.stale = is_stale
                 self._cards_by_name[full_name] = card
             else:
                 card = existing
@@ -315,6 +322,8 @@ class MainScreen(Screen[None]):
                     card.team_accent = accent
                 if card.team_label != label:
                     card.team_label = label
+                if card.stale != is_stale:
+                    card.stale = is_stale
                 card.apply_theme(theme_spec)
             cards_in_order.append(card)
 
@@ -409,8 +418,10 @@ class MainScreen(Screen[None]):
         spec = get_theme(state.theme_name)
         t = Text()
 
+        title = " + ".join(self._owners) if self._owners else self._org_name or "Organization"
+
         if not state.healths:
-            t.append(f"{self._org_name or 'Organization'} -- org dashboard\n\n", style="bold")
+            t.append(f"{title} -- org dashboard\n\n", style="bold")
             t.append("no data yet. press r to refresh.\n\n", style="dim")
             self._append_usage_block(t, spec)
             return t
@@ -422,7 +433,7 @@ class MainScreen(Screen[None]):
         ok_count = by_sev.get(_Sev.OK, 0)
         score = int((ok_count / total) * 100) if total else 0
 
-        t.append(f"{self._org_name or 'Organization'}\n", style="bold")
+        t.append(f"{title}\n", style="bold")
         t.append(f"{total} repos  ·  {score}% green\n\n")
 
         self._append_severity_bar(t, by_sev, total, spec)
@@ -952,6 +963,7 @@ class DashboardApp(App[None]):
         Binding("e", "toggle_errors", "Errors"),
         Binding("E", "clear_errors", "Clear Errors", show=False),
         Binding("m", "manage_repos", "Repos"),
+        Binding("O", "manage_orgs", "Orgs"),
         Binding("question_mark", "show_help", "Help"),
         Binding("f5", "full_restart", "Restart", show=False),
         Binding("plus", "widen_card", "Wider", show=False),
@@ -987,6 +999,7 @@ class DashboardApp(App[None]):
         initial_layout: str = "packed",
         health_config: dict | None = None,
         org_name: str = "",
+        owners: list[str] | None = None,
         skip_refresh: bool = False,
         github_client: Github | None = None,
         auto_discover: bool = False,
@@ -997,6 +1010,7 @@ class DashboardApp(App[None]):
         self._refresh_seconds = refresh_seconds
         self._health_config = health_config or {}
         self._org_name = org_name
+        self._owners: list[str] = list(owners) if owners else ([org_name] if org_name else [])
         self._skip_refresh = skip_refresh
         self._github_client = github_client
         self._auto_discover = auto_discover
@@ -1019,6 +1033,9 @@ class DashboardApp(App[None]):
         # Disabled repos -- excluded from refresh and all views.
         self._disabled_repos: set[str] = set()
 
+        # Disabled orgs -- excluded from auto-discovery (like disabled_repos).
+        self._disabled_orgs: set[str] = set()
+
         # Apply remaining saved preferences (sort, filters, panel width, flash).
         # Theme and layout are already applied via initial_theme/initial_layout
         # which the caller resolves from saved prefs + CLI overrides.
@@ -1028,6 +1045,7 @@ class DashboardApp(App[None]):
             self.state.panel_width = saved_prefs.panel_width
             self._flash_enabled = saved_prefs.flash_enabled
             self._disabled_repos = set(saved_prefs.disabled_repos)
+            self._disabled_orgs = set(saved_prefs.disabled_orgs)
 
     # ---- preferences ----
 
@@ -1042,6 +1060,7 @@ class DashboardApp(App[None]):
                 panel_width=self.state.panel_width,
                 flash_enabled=self._flash_enabled,
                 disabled_repos=sorted(self._disabled_repos),
+                disabled_orgs=sorted(self._disabled_orgs),
             )
         )
 
@@ -1057,7 +1076,7 @@ class DashboardApp(App[None]):
         restrict = {r.full_name for r in self._repos} if self._repos else None
         bootstrap_from_cache(self.state, restrict_to=restrict)
 
-        self._main = MainScreen(self.state, self._org_name)
+        self._main = MainScreen(self.state, self._org_name, owners=self._owners)
         self.push_screen(self._main)
 
         # Usage fetch in the background -- never block the first paint.
@@ -1130,21 +1149,20 @@ class DashboardApp(App[None]):
             self.call_from_thread(self._rerender)
 
     def _refresh_repo_list(self) -> None:
-        """Re-list repos from the org to pick up additions and removals.
+        """Re-list repos from all owners to pick up additions and removals.
 
         Called at the start of each refresh cycle.  When ``auto_discover``
-        is True (``--all`` mode) the full current org listing replaces the
+        is True the full current listing across all owners replaces the
         internal repo list so new repos appear automatically.  In other
-        modes (``--interactive``, single-repo) only repos from the original
-        selection that still exist are kept -- deleted repos are dropped
-        but new repos are not added.
+        modes only repos from the original selection that still exist are
+        kept -- deleted repos are dropped but new repos are not added.
         """
-        if self._github_client is None or not self._org_name:
-            logger.debug("refresh: skipping repo list (no client or org)")
+        if self._github_client is None or not self._owners:
+            logger.debug("refresh: skipping repo list (no client or owners)")
             return
         try:
-            fresh = strip_dotfile_repos(list_repos(self._github_client, self._org_name))
-            logger.debug(f"refresh: org listing returned {len(fresh)} repos")
+            fresh = strip_dotfile_repos(list_repos_multi(self._github_client, self._owners))
+            logger.debug(f"refresh: listing returned {len(fresh)} repos across {self._owners}")
         except Exception as exc:
             self.state.log_error("refresh", f"repo list refresh: {exc.__class__.__name__}: {exc}")
             logger.warning(f"refresh: repo list failed: {exc}")
@@ -1198,6 +1216,7 @@ class DashboardApp(App[None]):
             td = collect_repo_teams(repo)
             return repo.full_name, fetch_repo_status_with_pulls(repo), td
 
+        failed_repos: set[str] = set()
         logger.debug(f"refresh: fetching {len(self._repos)} repos with {workers} workers")
         with ThreadPoolExecutor(max_workers=workers) as pool:
             futures = {pool.submit(_fetch_one, repo): repo for repo in self._repos}
@@ -1221,6 +1240,7 @@ class DashboardApp(App[None]):
                         logger.warning(f"refresh: {td.error}")
                 except Exception as exc:
                     name = getattr(repo, "full_name", "?")
+                    failed_repos.add(name)
                     self.state.log_error("refresh", f"{name}: {exc.__class__.__name__}: {exc}")
                     logger.error(f"refresh: {name}: {exc.__class__.__name__}: {exc}")
                     status_by_name[name] = RepoStatus(
@@ -1264,12 +1284,13 @@ class DashboardApp(App[None]):
 
         # Commit the new state on the main thread so action handlers don't
         # observe healths and health_by_name in a half-updated state.
-        self.call_from_thread(self._commit_refresh, healths, team_data)
+        self.call_from_thread(self._commit_refresh, healths, team_data, failed_repos)
 
     def _commit_refresh(
         self,
         healths: list[RepoHealth],
         team_data: list[CollectedTeamData] | None = None,
+        failed_repos: set[str] | None = None,
     ) -> None:
         # Merge team data collected by worker threads. This is the only place
         # repo_teams / team_labels are mutated, so the main thread never
@@ -1287,6 +1308,7 @@ class DashboardApp(App[None]):
         self._update_warning_since(healths)
         self.state.healths = healths
         self.state.health_by_name = {h.status.full_name: h for h in healths}
+        self.state.stale_repos = failed_repos or set()
         self.state.last_refresh_at = datetime.now(UTC)
         self.state.is_refreshing = False
         vis = visible_healths(self.state)
@@ -1556,6 +1578,43 @@ class DashboardApp(App[None]):
             callback=_on_dismiss,
         )
 
+    def action_manage_orgs(self) -> None:
+        """Open the org manager to enable/disable organizations."""
+        if self._github_client is None:
+            self.notify("no GitHub client -- cannot list orgs", severity="warning", timeout=3)
+            return
+
+        viewer = get_viewer_login(self._github_client)
+        available = list_user_orgs(self._github_client)
+        if not available:
+            self.notify("no organizations found for this account", severity="warning", timeout=3)
+            return
+
+        def _on_dismiss(disabled: set[str] | None) -> None:
+            if disabled is None:
+                return
+            self._disabled_orgs = disabled
+            # Rebuild owners list: personal (first) + non-disabled orgs.
+            new_owners = [self._owners[0]] if self._owners else []
+            for org_login in available:
+                if org_login not in disabled and org_login not in new_owners:
+                    new_owners.append(org_login)
+            self._owners = new_owners
+            if self._main is not None:
+                self._main._owners = new_owners
+                self._main._status_bar._owners = new_owners
+            self._save_prefs()
+            # Trigger a full refresh to pick up repos from newly added orgs.
+            n_disabled = len(disabled)
+            label = f"{n_disabled} disabled" if n_disabled else "all enabled"
+            self.notify(f"orgs: {label}", timeout=2)
+            self._trigger_refresh()
+
+        self.push_screen(
+            OrgManager(available, self._disabled_orgs, viewer_login=viewer),
+            callback=_on_dismiss,
+        )
+
     def action_move_down(self) -> None:
         move_selection(self.state, self._grid_step())
         self._rerender()
@@ -1674,6 +1733,7 @@ def run_dashboard(
     layout: str = "packed",
     health_config: dict | None = None,
     org_name: str = "",
+    owners: list[str] | None = None,
     skip_refresh: bool = False,
     github_client: Github | None = None,
     auto_discover: bool = False,
@@ -1693,6 +1753,7 @@ def run_dashboard(
             initial_layout=cur_layout,
             health_config=health_config,
             org_name=org_name,
+            owners=owners,
             skip_refresh=skip_refresh,
             github_client=github_client,
             auto_discover=auto_discover,
@@ -1704,8 +1765,8 @@ def run_dashboard(
             break
 
         # Purge all augint_tools modules so re-import picks up code changes.
-        stale = [k for k in sys.modules if k.startswith("augint_tools")]
-        for k in stale:
+        stale_mods = [k for k in sys.modules if k.startswith("augint_tools")]
+        for k in stale_mods:
             del sys.modules[k]
         importlib.invalidate_caches()
 

--- a/src/augint_tools/dashboard/cmd.py
+++ b/src/augint_tools/dashboard/cmd.py
@@ -11,8 +11,9 @@ from rich import print
 
 from ._common import configure_logging, get_github_client, load_env_config
 from ._helpers import (
-    list_repos,
-    select_org_interactive,
+    get_viewer_login,
+    list_repos_multi,
+    list_user_orgs,
     select_repos_interactive,
     strip_dotfile_repos,
     warn_rate_limit,
@@ -116,19 +117,77 @@ def dashboard_command(
         logger.debug("Dashboard auth mode forced to .env (--env-auth).")
     g = get_github_client(auth_source=auth_source)
 
-    if interactive:
-        owner = org if org else select_org_interactive(g)
-        all_repos = strip_dotfile_repos(list_repos(g, owner))
-        repos = select_repos_interactive(all_repos)
-    elif show_all:
+    # ------------------------------------------------------------------
+    # Multi-org mode (--all or --interactive without --org):
+    # Auto-discover the personal account + all organizations the user
+    # belongs to.  Orgs the user has explicitly disabled via the in-TUI
+    # org manager (persisted in prefs.disabled_orgs) are excluded.
+    #
+    # Legacy single-org mode (--org): use exactly that org.
+    # Legacy single-repo mode (no flags): GH_REPO + GH_ACCOUNT from env.
+    # ------------------------------------------------------------------
+    multi_org = (show_all or interactive) and not org
+
+    if multi_org:
+        viewer = get_viewer_login(g) or gh_account or ""
+        if not viewer:
+            raise click.ClickException(
+                "Could not determine GitHub login. Set GH_ACCOUNT or authenticate with: gh auth login"
+            )
+        disabled_orgs = set(prefs.disabled_orgs)
+        owners: list[str] = [viewer]
+        for org_login in list_user_orgs(g):
+            if org_login not in owners and org_login not in disabled_orgs:
+                owners.append(org_login)
+
+        if interactive:
+            all_repos = strip_dotfile_repos(list_repos_multi(g, owners))
+            repos = select_repos_interactive(all_repos)
+        else:
+            repos = strip_dotfile_repos(list_repos_multi(g, owners))
+            if not repos:
+                raise click.ClickException(f"No repositories found for {', '.join(owners)}.")
+
+        warn_rate_limit(len(repos), refresh_seconds)
+        health_config = {"stale_pr_days": stale_days}
+
+        try:
+            run_dashboard(
+                repos,
+                refresh_seconds=refresh_seconds,
+                theme=theme,
+                layout=layout,
+                health_config=health_config,
+                owners=owners,
+                skip_refresh=no_refresh,
+                github_client=g,
+                auto_discover=show_all,
+                saved_prefs=prefs,
+            )
+        except KeyboardInterrupt:
+            print("\n[dim]Dashboard stopped.[/dim]")
+        return
+
+    # Legacy paths: --org or single-repo (no flags).
+    if show_all:
         owner = org if org else gh_account
         if not owner:
             raise click.ClickException(
                 "GH_ACCOUNT must be set in .env or environment, or use --org."
             )
+        from ._helpers import list_repos
+
         repos = strip_dotfile_repos(list_repos(g, owner))
         if not repos:
             raise click.ClickException(f"No repositories found for {owner}.")
+        owners = [owner]
+    elif org:
+        from ._helpers import list_repos
+
+        repos = strip_dotfile_repos(list_repos(g, org))
+        if not repos:
+            raise click.ClickException(f"No repositories found for {org}.")
+        owners = [org]
     else:
         gh_repo, gh_account_env, _ = load_env_config()
         if not gh_repo or not gh_account_env:
@@ -139,10 +198,9 @@ def dashboard_command(
         from ._common import get_github_repo
 
         repos = [get_github_repo(gh_account_env, gh_repo, auth_source=auth_source)]
+        owners = [gh_account_env]
 
     warn_rate_limit(len(repos), refresh_seconds)
-
-    org_name = org or gh_account or ""
     health_config = {"stale_pr_days": stale_days}
 
     try:
@@ -152,7 +210,7 @@ def dashboard_command(
             theme=theme,
             layout=layout,
             health_config=health_config,
-            org_name=org_name,
+            owners=owners,
             skip_refresh=no_refresh,
             github_client=g,
             auto_discover=show_all,

--- a/src/augint_tools/dashboard/prefs.py
+++ b/src/augint_tools/dashboard/prefs.py
@@ -28,6 +28,7 @@ class DashboardPrefs:
     panel_width: int = 38
     flash_enabled: bool = True
     disabled_repos: list[str] = field(default_factory=list)
+    disabled_orgs: list[str] = field(default_factory=list)
 
     def to_dict(self) -> dict:
         return asdict(self)

--- a/src/augint_tools/dashboard/screens/filter_panel.py
+++ b/src/augint_tools/dashboard/screens/filter_panel.py
@@ -48,7 +48,9 @@ class FilterPanel(ModalScreen[set[str]]):
         self._state = state
 
     def compose(self):
-        modes = available_filter_modes(self._state.team_labels, self._state.repo_teams)
+        modes = available_filter_modes(
+            self._state.team_labels, self._state.repo_teams, self._state.healths
+        )
         # Skip "all" -- empty selection already means all repos.
         selections = [
             Selection(

--- a/src/augint_tools/dashboard/screens/help.py
+++ b/src/augint_tools/dashboard/screens/help.py
@@ -20,6 +20,7 @@ Data
   s                   Cycle sort (health, alpha, problem)
   f                   Open filter panel (multi-select)
   m                   Manage repos (enable/disable)
+  O                   Manage organizations (add/remove)
   w                   Toggle workspace filter
 
 Layouts and themes

--- a/src/augint_tools/dashboard/screens/org_manager.py
+++ b/src/augint_tools/dashboard/screens/org_manager.py
@@ -1,0 +1,93 @@
+"""OrgManager -- modal screen to add/remove organizations from the dashboard.
+
+Uses an opt-out model: all organizations are enabled by default.
+The user un-checks orgs to disable them; the returned set contains the
+**disabled** org logins (matching the ``disabled_repos`` pattern).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from textual import events
+from textual.binding import Binding
+from textual.containers import Container
+from textual.screen import ModalScreen
+from textual.widgets import SelectionList, Static
+from textual.widgets.selection_list import Selection
+
+if TYPE_CHECKING:
+    pass
+
+
+class OrgManager(ModalScreen[set[str]]):
+    """Modal that lets the user toggle organizations on/off.
+
+    Returns the set of **disabled** org logins on dismiss (orgs the user
+    un-checked).  Checked orgs are enabled.
+    """
+
+    DEFAULT_CSS = """
+    OrgManager {
+        align: center middle;
+    }
+    OrgManager > Container {
+        width: 60;
+        max-height: 80%;
+        border: thick $accent;
+        background: $surface;
+        padding: 1 2;
+    }
+    OrgManager #om-title {
+        height: 1;
+        padding: 0 0 1 0;
+        text-style: bold;
+    }
+    OrgManager SelectionList {
+        height: auto;
+        max-height: 100%;
+    }
+    """
+
+    BINDINGS = [
+        Binding("escape", "dismiss_panel", "Close"),
+        Binding("O", "dismiss_panel", "Close"),
+    ]
+
+    def __init__(
+        self,
+        available_orgs: list[str],
+        disabled_orgs: set[str],
+        viewer_login: str = "",
+    ) -> None:
+        super().__init__()
+        self._available_orgs = sorted(available_orgs)
+        self._disabled_orgs = disabled_orgs
+        self._viewer_login = viewer_login
+
+    def compose(self):
+        selections = [
+            Selection(
+                f"{org_login}",
+                org_login,
+                initial_state=org_login not in self._disabled_orgs,
+            )
+            for org_login in self._available_orgs
+            if org_login != self._viewer_login  # Personal account is always included.
+        ]
+        hint = "(personal account always included)" if self._viewer_login else ""
+        yield Container(
+            Static(f"Manage organizations {hint}", id="om-title"),
+            SelectionList[str](*selections, id="org-list"),
+        )
+
+    def on_click(self, event: events.Click) -> None:
+        if event.button == 3:
+            self.action_dismiss_panel()
+
+    def action_dismiss_panel(self) -> None:
+        sel_list = self.query_one("#org-list", SelectionList)
+        enabled = set(sel_list.selected)
+        # Return the disabled set: orgs available (excluding personal) minus enabled.
+        toggleable = {o for o in self._available_orgs if o != self._viewer_login}
+        self.dismiss(toggleable - enabled)

--- a/src/augint_tools/dashboard/state.py
+++ b/src/augint_tools/dashboard/state.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
+from github.GithubException import GithubException
 from loguru import logger
 
 from ._data import RepoStatus, load_cache, load_health_cache
@@ -42,6 +43,7 @@ FILTER_MODES: tuple[str, ...] = (
 )
 
 _TEAM_FILTER_PREFIX = "team:"
+_ORG_FILTER_PREFIX = "org:"
 _TEAM_PERMISSION_ORDER = {"admin": 0, "maintain": 1, "push": 2, "triage": 3, "pull": 4}
 
 
@@ -89,6 +91,9 @@ class AppState:
     consecutive_errors: int = 0
     last_error_message: str | None = None
 
+    # Repos whose most recent refresh attempt failed (shown gray/stale).
+    stale_repos: set[str] = field(default_factory=set)
+
     # Cooperative cancellation flag for threaded workers.
     cancel_requested: bool = False
 
@@ -114,6 +119,26 @@ def team_key_from_filter(mode: str) -> str | None:
     if mode.startswith(_TEAM_FILTER_PREFIX):
         return mode.removeprefix(_TEAM_FILTER_PREFIX)
     return None
+
+
+# ---------------------------------------------------------------------------
+# Org (owner) helpers
+# ---------------------------------------------------------------------------
+
+
+def org_filter_mode(owner: str) -> str:
+    return f"{_ORG_FILTER_PREFIX}{owner}"
+
+
+def org_key_from_filter(mode: str) -> str | None:
+    if mode.startswith(_ORG_FILTER_PREFIX):
+        return mode.removeprefix(_ORG_FILTER_PREFIX)
+    return None
+
+
+def owner_of(full_name: str) -> str:
+    """Extract the owner (org or user) from a ``owner/repo`` full name."""
+    return full_name.split("/", 1)[0] if "/" in full_name else full_name
 
 
 def display_team_label(team_key: str, team_labels: dict[str, str]) -> str:
@@ -191,6 +216,20 @@ def collect_repo_teams(repo: Repository) -> CollectedTeamData:
         return CollectedTeamData(full_name="")
     try:
         teams = sorted(repo.get_teams(), key=_team_sort_key)
+    except GithubException as exc:
+        # 403/404 are expected for personal (non-org) repos -- the Teams API
+        # doesn't apply to user repos.  Treat as "no teams" without logging
+        # a user-visible error that would flash the error drawer.
+        if exc.status in (403, 404):
+            logger.debug(
+                f"collect_repo_teams: {full_name}: expected {exc.status} (not an org repo)"
+            )
+            return CollectedTeamData(full_name=full_name)
+        logger.debug(f"collect_repo_teams: {full_name}: {exc.__class__.__name__}: {exc}")
+        return CollectedTeamData(
+            full_name=full_name,
+            error=f"{full_name}: teams: {exc.__class__.__name__}: {exc}",
+        )
     except Exception as exc:
         logger.debug(f"collect_repo_teams: {full_name}: {exc.__class__.__name__}: {exc}")
         return CollectedTeamData(
@@ -276,6 +315,9 @@ def _matches_filter(h: RepoHealth, mode: str, repo_teams: dict[str, RepoTeamInfo
         if team_key == UNASSIGNED_TEAM:
             return info.primary == UNASSIGNED_TEAM
         return team_key in info.all
+    org_key = org_key_from_filter(mode)
+    if org_key is not None:
+        return owner_of(h.status.full_name) == org_key
     return True
 
 
@@ -295,33 +337,51 @@ def apply_active_filters(
     active: set[str],
     repo_teams: dict[str, RepoTeamInfo] | None = None,
 ) -> list[RepoHealth]:
-    """Apply multiple filters. Non-team filters AND together; team filters OR together."""
+    """Apply multiple filters.
+
+    ``no-workspace`` is the only hard AND constraint -- it always
+    excludes workspace repos when checked (persistent toggle via ``w``).
+
+    Every other filter is an OR **selection**: each checked item adds
+    matching repos to the visible set.  This matches the mental model
+    of a multi-select checklist where checking ``broken-ci`` +
+    ``team:woxom`` means "show broken-CI repos PLUS woxom repos."
+    """
     if not active:
         return list(healths)
     teams = repo_teams or {}
-    non_team = sorted(m for m in active if not m.startswith(_TEAM_FILTER_PREFIX))
-    team_modes = sorted(m for m in active if m.startswith(_TEAM_FILTER_PREFIX))
+    # no-workspace is a hard exclusion (the 'w' toggle).
+    has_no_workspace = "no-workspace" in active
+    # Everything else ORs together as additive selections.
+    selections = sorted(m for m in active if m != "no-workspace")
     result: list[RepoHealth] = []
     for h in healths:
-        if not all(_matches_filter(h, mode, teams) for mode in non_team):
+        if has_no_workspace and not _matches_filter(h, "no-workspace", teams):
             continue
-        if team_modes and not any(_matches_filter(h, mode, teams) for mode in team_modes):
+        if selections and not any(_matches_filter(h, mode, teams) for mode in selections):
             continue
         result.append(h)
     return result
 
 
 def available_filter_modes(
-    team_labels: dict[str, str], repo_teams: dict[str, RepoTeamInfo]
+    team_labels: dict[str, str],
+    repo_teams: dict[str, RepoTeamInfo],
+    healths: list[RepoHealth] | None = None,
 ) -> list[str]:
     team_keys = {team for info in repo_teams.values() for team in (info.all or (info.primary,))}
-    dynamic = [
+    team_dynamic = [
         team_filter_mode(team_key)
         for team_key in sorted(
             team_keys, key=lambda key: display_team_label(key, team_labels).lower()
         )
     ]
-    return [*FILTER_MODES, *dynamic]
+    # Org filters derived from the owners present in the current health data.
+    org_keys: set[str] = set()
+    if healths:
+        org_keys = {owner_of(h.status.full_name) for h in healths}
+    org_dynamic = [org_filter_mode(key) for key in sorted(org_keys)]
+    return [*FILTER_MODES, *org_dynamic, *team_dynamic]
 
 
 def visible_healths(state: AppState) -> list[RepoHealth]:

--- a/src/augint_tools/dashboard/themes/cyber.tcss
+++ b/src/augint_tools/dashboard/themes/cyber.tcss
@@ -21,6 +21,7 @@ RepoCard.card--warning { border: round #f7d046; }
 RepoCard.card--critical { border: round #ff3366; }
 RepoCard.card--warning.card--flash-on { border: round #fbe7a2; }
 RepoCard.card--critical.card--flash-on { border: round #ff99b2; }
+RepoCard.card--stale { border: round #666666; opacity: 0.6; }
 RepoCard.card--dense { min-height: 4; padding: 0; }
 RepoCard.card--list { min-height: 6; }
 

--- a/src/augint_tools/dashboard/themes/default.tcss
+++ b/src/augint_tools/dashboard/themes/default.tcss
@@ -21,6 +21,7 @@ RepoCard.card--warning { border: round #ffd84d; }
 RepoCard.card--critical { border: round #ff3355; }
 RepoCard.card--warning.card--flash-on { border: round #ffecb0; }
 RepoCard.card--critical.card--flash-on { border: round #ff99a8; }
+RepoCard.card--stale { border: round #666666; opacity: 0.6; }
 RepoCard.card--dense { min-height: 4; padding: 0; }
 RepoCard.card--list { min-height: 6; }
 

--- a/src/augint_tools/dashboard/themes/matrix.tcss
+++ b/src/augint_tools/dashboard/themes/matrix.tcss
@@ -21,6 +21,7 @@ RepoCard.card--warning { border: round #ffbd2e; }
 RepoCard.card--critical { border: round #ff5f56; }
 RepoCard.card--warning.card--flash-on { border: round #ffde97; }
 RepoCard.card--critical.card--flash-on { border: round #ffafab; }
+RepoCard.card--stale { border: round #666666; opacity: 0.6; }
 RepoCard.card--dense { min-height: 4; padding: 0; }
 RepoCard.card--list { min-height: 6; }
 

--- a/src/augint_tools/dashboard/themes/minimal.tcss
+++ b/src/augint_tools/dashboard/themes/minimal.tcss
@@ -21,6 +21,7 @@ RepoCard.card--warning { border: round #a0a0a0; }
 RepoCard.card--critical { border: round #ff4040; }
 RepoCard.card--warning.card--flash-on { border: round #d5d5d5; }
 RepoCard.card--critical.card--flash-on { border: round #ff9f9f; }
+RepoCard.card--stale { border: round #666666; opacity: 0.6; }
 RepoCard.card--dense { min-height: 4; padding: 0; }
 RepoCard.card--list { min-height: 6; }
 

--- a/src/augint_tools/dashboard/themes/nord.tcss
+++ b/src/augint_tools/dashboard/themes/nord.tcss
@@ -21,6 +21,7 @@ RepoCard.card--warning { border: round #ebcb8b; }
 RepoCard.card--critical { border: round #bf616a; }
 RepoCard.card--warning.card--flash-on { border: round #f5e5c5; }
 RepoCard.card--critical.card--flash-on { border: round #dfb0b4; }
+RepoCard.card--stale { border: round #666666; opacity: 0.6; }
 RepoCard.card--dense { min-height: 4; padding: 0; }
 RepoCard.card--list { min-height: 6; }
 

--- a/src/augint_tools/dashboard/themes/paper.tcss
+++ b/src/augint_tools/dashboard/themes/paper.tcss
@@ -93,6 +93,11 @@ RepoCard.card--critical.card--flash-on {
     border: round #d8907f;
 }
 
+RepoCard.card--stale {
+    border: round #666666;
+    opacity: 0.6;
+}
+
 RepoCard.card--dense {
     min-height: 4;
     padding: 0;

--- a/src/augint_tools/dashboard/themes/synthwave.tcss
+++ b/src/augint_tools/dashboard/themes/synthwave.tcss
@@ -21,6 +21,7 @@ RepoCard.card--warning { border: round #ffd700; }
 RepoCard.card--critical { border: round #ff3366; }
 RepoCard.card--warning.card--flash-on { border: round #ffeb80; }
 RepoCard.card--critical.card--flash-on { border: round #ff99b2; }
+RepoCard.card--stale { border: round #666666; opacity: 0.6; }
 RepoCard.card--dense { min-height: 4; padding: 0; }
 RepoCard.card--list { min-height: 6; }
 

--- a/src/augint_tools/dashboard/widgets/repo_card.py
+++ b/src/augint_tools/dashboard/widgets/repo_card.py
@@ -98,6 +98,7 @@ class RepoCard(Widget):
 
     health: reactive[RepoHealth | None] = reactive(None)
     selected: reactive[bool] = reactive(False)
+    stale: reactive[bool] = reactive(False)
     render_mode: reactive[RenderMode] = reactive("packed", layout=True)
     team_accent: reactive[str] = reactive("#808080")
     team_label: reactive[str] = reactive("")
@@ -129,6 +130,13 @@ class RepoCard(Widget):
             self.add_class("card--selected")
         else:
             self.remove_class("card--selected")
+        self.refresh()
+
+    def watch_stale(self, _old: bool, new: bool) -> None:
+        if new:
+            self.add_class("card--stale")
+        else:
+            self.remove_class("card--stale")
         self.refresh()
 
     def watch_team_accent(self, _old: str, new: str) -> None:
@@ -209,10 +217,14 @@ class RepoCard(Widget):
         if self.health is None:
             return Text("loading…", style="dim")
         if self.render_mode == "dense":
-            return self._render_dense(self.health)
-        if self.render_mode == "list":
-            return self._render_list(self.health)
-        return self._render_packed(self.health)
+            result = self._render_dense(self.health)
+        elif self.render_mode == "list":
+            result = self._render_list(self.health)
+        else:
+            result = self._render_packed(self.health)
+        if self.stale:
+            result.stylize("dim")
+        return result
 
     def _title_line(self, health: RepoHealth) -> Text:
         line = Text()

--- a/src/augint_tools/dashboard/widgets/status_bar.py
+++ b/src/augint_tools/dashboard/widgets/status_bar.py
@@ -38,6 +38,8 @@ def describe_filter(mode: str, team_labels: dict[str, str] | None = None) -> str
         if team_labels and key in team_labels:
             return f"team: {team_labels[key]}"
         return f"team: {key}"
+    if mode.startswith("org:"):
+        return f"org: {mode.removeprefix('org:')}"
     return mode
 
 
@@ -64,9 +66,12 @@ class StatusBar(Static):
         self._state: AppState | None = None
         self._org_name: str = ""
 
-    def bind_state(self, state: AppState, org_name: str) -> None:
+    def bind_state(
+        self, state: AppState, org_name: str = "", owners: list[str] | None = None
+    ) -> None:
         self._state = state
         self._org_name = org_name
+        self._owners: list[str] = owners or ([org_name] if org_name else [])
 
     def tick(self) -> None:
         """Re-render. Call every second from the app."""
@@ -78,7 +83,8 @@ class StatusBar(Static):
             self.update("loading...")
             return
         t = Text()
-        t.append(f" {self._org_name or 'no-org'} ", style="bold")
+        owner_label = " + ".join(self._owners) if self._owners else self._org_name or "no-org"
+        t.append(f" {owner_label} ", style="bold")
         filter_label = _describe_active_filters(state.active_filters, state.team_labels)
         t.append(
             f"| sort: {state.sort_mode} "

--- a/tests/unit/test_dashboard.py
+++ b/tests/unit/test_dashboard.py
@@ -20,6 +20,7 @@ from augint_tools.dashboard.layouts import (
     list_layouts,
     register_layout,
 )
+from augint_tools.dashboard.prefs import DashboardPrefs
 from augint_tools.dashboard.state import (
     FILTER_MODES,
     SORT_MODES,
@@ -157,10 +158,11 @@ class TestDashboardCLI:
         assert result.exit_code == 0
 
     @patch("augint_tools.dashboard.app.run_dashboard", side_effect=KeyboardInterrupt)
-    @patch("augint_tools.dashboard.cmd.list_repos")
+    @patch("augint_tools.dashboard.cmd.list_repos_multi")
+    @patch("augint_tools.dashboard.cmd.get_viewer_login", return_value="myaccount")
     @patch("augint_tools.dashboard.cmd.load_env_config")
     @patch("augint_tools.dashboard.cmd.get_github_client")
-    def test_dashboard_all_flag(self, mock_client, mock_env, mock_list, mock_run):
+    def test_dashboard_all_flag(self, mock_client, mock_env, mock_viewer, mock_list, mock_run):
         mock_env.return_value = ("", "myaccount", "tok")
         mock_list.return_value = [_mock_repo()]
         runner = CliRunner()
@@ -169,10 +171,11 @@ class TestDashboardCLI:
         mock_list.assert_called_once()
 
     @patch("augint_tools.dashboard.app.run_dashboard", side_effect=KeyboardInterrupt)
-    @patch("augint_tools.dashboard.cmd.list_repos")
+    @patch("augint_tools.dashboard.cmd.list_repos_multi")
+    @patch("augint_tools.dashboard.cmd.get_viewer_login", return_value="myaccount")
     @patch("augint_tools.dashboard.cmd.load_env_config")
     @patch("augint_tools.dashboard.cmd.get_github_client")
-    def test_dashboard_env_auth(self, mock_client, mock_env, mock_list, mock_run):
+    def test_dashboard_env_auth(self, mock_client, mock_env, mock_viewer, mock_list, mock_run):
         mock_env.return_value = ("", "myaccount", "tok")
         mock_list.return_value = [_mock_repo()]
         runner = CliRunner()
@@ -315,8 +318,8 @@ class TestApplyActiveFilters:
         out = apply_active_filters([broken, fine], {"broken-ci"})
         assert [h.status.name for h in out] == ["broken"]
 
-    def test_combined_filters_and_logic(self):
-        """Non-team filters combine with AND: repo must match ALL."""
+    def test_no_workspace_and_with_selection(self):
+        """no-workspace is a hard AND; broken-ci is an OR selection."""
         ci_check = HealthCheckResult(
             check_name="broken_ci", severity=Severity.CRITICAL, summary="x"
         )
@@ -328,6 +331,7 @@ class TestApplyActiveFilters:
         )
         repo_ok = _health(name="repo-ok", full_name="org/repo-ok", is_workspace=False)
         out = apply_active_filters([ws_broken, repo_broken, repo_ok], {"broken-ci", "no-workspace"})
+        # ws-broken excluded by no-workspace AND, repo-ok doesn't match broken-ci OR
         assert [h.status.name for h in out] == ["repo-broken"]
 
     def test_team_filters_or_logic(self):
@@ -347,8 +351,8 @@ class TestApplyActiveFilters:
         )
         assert {h.status.name for h in out} == {"a", "b"}
 
-    def test_team_and_health_combined(self):
-        """Team OR + health AND: only team members matching the health filter."""
+    def test_health_and_team_or_together(self):
+        """broken-ci + team:alpha OR together: broken repos PLUS alpha repos."""
         ci_check = HealthCheckResult(
             check_name="broken_ci", severity=Severity.CRITICAL, summary="x"
         )
@@ -363,7 +367,8 @@ class TestApplyActiveFilters:
             {"broken-ci", team_filter_mode("alpha")},
             repo_teams,
         )
-        assert [h.status.name for h in out] == ["a"]
+        # Both pass: a matches broken-ci, b matches team:alpha
+        assert {h.status.name for h in out} == {"a", "b"}
 
 
 class TestSelection:
@@ -864,6 +869,35 @@ class TestStateHelpers:
         assert td.error is not None
         merge_team_data(s, [td])
         assert s.repo_teams["org/x"].primary == UNASSIGNED_TEAM
+
+    def test_collect_repo_teams_403_suppressed(self):
+        """403 from personal (non-org) repos is expected -- no error field."""
+        from augint_tools.dashboard.state import collect_repo_teams
+
+        repo = _mock_repo(full_name="user/personal-repo")
+        repo.get_teams.side_effect = GithubException(403, "Forbidden", None)
+        td = collect_repo_teams(repo)
+        assert td.error is None
+        assert td.info.all == ()
+
+    def test_collect_repo_teams_404_suppressed(self):
+        """404 from the Teams API is also expected for non-org repos."""
+        from augint_tools.dashboard.state import collect_repo_teams
+
+        repo = _mock_repo(full_name="user/personal-repo")
+        repo.get_teams.side_effect = GithubException(404, "Not Found", None)
+        td = collect_repo_teams(repo)
+        assert td.error is None
+        assert td.info.all == ()
+
+    def test_collect_repo_teams_500_still_errors(self):
+        """Server errors (5xx) should still be reported."""
+        from augint_tools.dashboard.state import collect_repo_teams
+
+        repo = _mock_repo(full_name="org/x")
+        repo.get_teams.side_effect = GithubException(500, "Server Error", None)
+        td = collect_repo_teams(repo)
+        assert td.error is not None
 
     def test_apply_filter_no_renovate(self):
         check = HealthCheckResult(
@@ -1615,8 +1649,8 @@ class TestVisibilityFilters:
         out = apply_active_filters([priv, pub], {"public"})
         assert [h.status.name for h in out] == ["oss"]
 
-    def test_combined_public_and_broken_ci(self):
-        """Public + broken-ci filters AND together."""
+    def test_public_and_broken_ci_or_together(self):
+        """public + broken-ci OR together: public repos PLUS broken-CI repos."""
         ci_check = HealthCheckResult(
             check_name="broken_ci", severity=Severity.CRITICAL, summary="x"
         )
@@ -1628,7 +1662,55 @@ class TestVisibilityFilters:
         )
         pub_ok = _health(name="pub-ok", full_name="org/pub-ok", private=False)
         out = apply_active_filters([pub_broken, priv_broken, pub_ok], {"public", "broken-ci"})
-        assert [h.status.name for h in out] == ["pub-broken"]
+        # All three pass: pub-broken matches both, priv-broken matches broken-ci, pub-ok matches public
+        assert {h.status.name for h in out} == {"pub-broken", "priv-broken", "pub-ok"}
+
+    def test_private_and_public_or_shows_all(self):
+        """Selecting both private + public shows all repos (OR)."""
+        priv = _health(name="secret", full_name="org/secret", private=True)
+        pub = _health(name="oss", full_name="org/oss", private=False)
+        out = apply_active_filters([priv, pub], {"private", "public"})
+        assert {h.status.name for h in out} == {"secret", "oss"}
+
+    def test_public_and_team_or_together(self):
+        """public + team:alpha OR: public repos PLUS alpha team repos."""
+        pub_team = _health(name="pub-team", full_name="org/pub-team", private=False)
+        priv_team = _health(name="priv-team", full_name="org/priv-team", private=True)
+        pub_no_team = _health(name="pub-no-team", full_name="org/pub-no-team", private=False)
+        repo_teams = {
+            "org/pub-team": RepoTeamInfo(primary="alpha", all=("alpha",)),
+            "org/priv-team": RepoTeamInfo(primary="alpha", all=("alpha",)),
+            "org/pub-no-team": RepoTeamInfo(primary="beta", all=("beta",)),
+        }
+        out = apply_active_filters(
+            [pub_team, priv_team, pub_no_team],
+            {"public", team_filter_mode("alpha")},
+            repo_teams,
+        )
+        # All pass: pub-team matches both, priv-team matches team:alpha, pub-no-team matches public
+        assert {h.status.name for h in out} == {"pub-team", "priv-team", "pub-no-team"}
+
+    def test_no_workspace_constrains_or_selections(self):
+        """no-workspace AND excludes workspaces even when other selections match."""
+        priv_team = _health(
+            name="priv-team", full_name="org/priv-team", private=True, is_workspace=False
+        )
+        pub_ws = _health(name="pub-ws", full_name="org/pub-ws", private=False, is_workspace=True)
+        pub_other = _health(
+            name="pub-other", full_name="org/pub-other", private=False, is_workspace=False
+        )
+        repo_teams = {
+            "org/priv-team": RepoTeamInfo(primary="alpha", all=("alpha",)),
+            "org/pub-ws": RepoTeamInfo(primary="alpha", all=("alpha",)),
+            "org/pub-other": RepoTeamInfo(primary="beta", all=("beta",)),
+        }
+        out = apply_active_filters(
+            [priv_team, pub_ws, pub_other],
+            {"no-workspace", "public", team_filter_mode("alpha")},
+            repo_teams,
+        )
+        # pub-ws excluded by no-workspace even though it matches public + team:alpha
+        assert {h.status.name for h in out} == {"priv-team", "pub-other"}
 
 
 class TestRepoStatusPrivateField:
@@ -1711,3 +1793,210 @@ class TestFilterLabels:
         from augint_tools.dashboard.widgets.status_bar import describe_filter
 
         assert describe_filter("public") == "Public (Open source)"
+
+    def test_describe_filter_org(self):
+        from augint_tools.dashboard.widgets.status_bar import describe_filter
+
+        assert describe_filter("org:my-org") == "org: my-org"
+
+
+# ---------------------------------------------------------------------------
+# Org filter support
+# ---------------------------------------------------------------------------
+
+
+class TestOrgFilter:
+    def test_org_filter_mode_round_trip(self):
+        from augint_tools.dashboard.state import org_filter_mode, org_key_from_filter
+
+        assert org_key_from_filter(org_filter_mode("my-org")) == "my-org"
+
+    def test_org_key_from_filter_returns_none_for_non_org(self):
+        from augint_tools.dashboard.state import org_key_from_filter
+
+        assert org_key_from_filter("team:alpha") is None
+        assert org_key_from_filter("broken-ci") is None
+
+    def test_owner_of(self):
+        from augint_tools.dashboard.state import owner_of
+
+        assert owner_of("my-org/my-repo") == "my-org"
+        assert owner_of("single") == "single"
+
+    def test_org_filter_matches_by_owner(self):
+        a = _health(name="a", full_name="org-a/a")
+        b = _health(name="b", full_name="org-b/b")
+        out = apply_filter([a, b], "org:org-a")
+        assert [h.status.name for h in out] == ["a"]
+
+    def test_org_filters_or_logic(self):
+        """Multiple org filters combine with OR: repo in ANY selected org passes."""
+        a = _health(name="a", full_name="org-a/a")
+        b = _health(name="b", full_name="org-b/b")
+        c = _health(name="c", full_name="org-c/c")
+        out = apply_active_filters([a, b, c], {"org:org-a", "org:org-b"})
+        assert {h.status.name for h in out} == {"a", "b"}
+
+    def test_org_and_health_or_together(self):
+        """org:org-a + broken-ci OR together: org-a repos PLUS broken-CI repos."""
+        ci_check = HealthCheckResult(
+            check_name="broken_ci", severity=Severity.CRITICAL, summary="x"
+        )
+        a_broken = _health(name="a", full_name="org-a/a", checks=[ci_check])
+        b_ok = _health(name="b", full_name="org-a/b")
+        c_broken = _health(name="c", full_name="org-b/c", checks=[ci_check])
+        out = apply_active_filters([a_broken, b_ok, c_broken], {"broken-ci", "org:org-a"})
+        # All three pass: a matches both, b matches org:org-a, c matches broken-ci
+        assert {h.status.name for h in out} == {"a", "b", "c"}
+
+    def test_available_filter_modes_includes_orgs(self):
+        healths = [
+            _health(name="a", full_name="org-a/a"),
+            _health(name="b", full_name="org-b/b"),
+        ]
+        modes = available_filter_modes({}, {}, healths=healths)
+        assert "org:org-a" in modes
+        assert "org:org-b" in modes
+        assert set(FILTER_MODES).issubset(set(modes))
+
+
+# ---------------------------------------------------------------------------
+# Stale repos
+# ---------------------------------------------------------------------------
+
+
+class TestStaleRepos:
+    def test_stale_repos_default_empty(self):
+        s = AppState()
+        assert s.stale_repos == set()
+
+    def test_stale_card_rendering(self):
+        from augint_tools.dashboard.themes import get_theme
+        from augint_tools.dashboard.widgets.repo_card import RepoCard
+
+        health = _health(full_name="org/r0")
+        spec = get_theme("default")
+        card = RepoCard(health=health, theme_spec=spec)
+
+        # Not stale -- normal render.
+        card.stale = False
+        assert not card.has_class("card--stale")
+
+        # Stale -- card gets the stale class.
+        card.stale = True
+        assert card.has_class("card--stale")
+
+    def test_stale_card_render_content_dimmed(self):
+        from augint_tools.dashboard.themes import get_theme
+        from augint_tools.dashboard.widgets.repo_card import RepoCard
+
+        health = _health(full_name="org/r0")
+        spec = get_theme("default")
+        card = RepoCard(health=health, theme_spec=spec)
+        card.stale = True
+        out = card.render()
+        # The dim style is applied to the entire text.
+        assert "myrepo" in out.plain
+
+
+# ---------------------------------------------------------------------------
+# Enabled orgs in prefs
+# ---------------------------------------------------------------------------
+
+
+class TestDisabledOrgsPrefs:
+    def test_disabled_orgs_round_trip(self, tmp_path, monkeypatch):
+        from augint_tools.dashboard.prefs import (
+            DashboardPrefs,
+            load_prefs,
+            save_prefs,
+        )
+
+        monkeypatch.setattr("augint_tools.dashboard.prefs.CACHE_DIR", tmp_path)
+        monkeypatch.setattr("augint_tools.dashboard.prefs.PREFS_FILE", tmp_path / "prefs.json")
+
+        prefs = DashboardPrefs(disabled_orgs=["org-alpha", "org-beta"])
+        save_prefs(prefs)
+        loaded = load_prefs()
+        assert sorted(loaded.disabled_orgs) == ["org-alpha", "org-beta"]
+
+    def test_disabled_orgs_defaults_empty(self):
+        from augint_tools.dashboard.prefs import DashboardPrefs
+
+        prefs = DashboardPrefs()
+        assert prefs.disabled_orgs == []
+
+    def test_app_loads_disabled_orgs_from_prefs(self):
+        from augint_tools.dashboard.prefs import DashboardPrefs
+
+        prefs = DashboardPrefs(disabled_orgs=["org-alpha"])
+        app = DashboardApp(repos=[], skip_refresh=True, saved_prefs=prefs)
+        assert "org-alpha" in app._disabled_orgs
+
+    def test_app_saves_disabled_orgs_in_prefs(self):
+        app = DashboardApp(repos=[], skip_refresh=True)
+        app._disabled_orgs = {"org-alpha"}
+        with patch("augint_tools.dashboard.app.save_prefs") as mock_save:
+            app._save_prefs()
+            saved = mock_save.call_args[0][0]
+            assert "org-alpha" in saved.disabled_orgs
+
+
+# ---------------------------------------------------------------------------
+# Multi-org CLI
+# ---------------------------------------------------------------------------
+
+
+class TestMultiOrgCLI:
+    @patch("augint_tools.dashboard.app.run_dashboard", side_effect=KeyboardInterrupt)
+    @patch("augint_tools.dashboard.cmd.list_repos_multi")
+    @patch("augint_tools.dashboard.cmd.get_viewer_login", return_value="myuser")
+    @patch("augint_tools.dashboard.cmd.load_env_config")
+    @patch("augint_tools.dashboard.cmd.get_github_client")
+    def test_all_flag_uses_multi_org(self, mock_client, mock_env, mock_viewer, mock_list, mock_run):
+        mock_env.return_value = ("", "myuser", "tok")
+        mock_list.return_value = [_mock_repo()]
+        runner = CliRunner()
+        result = runner.invoke(main, ["dashboard", "--all"])
+        assert result.exit_code == 0
+        # Should have called list_repos_multi with the viewer's login.
+        call_args = mock_list.call_args
+        owners = call_args[0][1]
+        assert "myuser" in owners
+
+    @patch("augint_tools.dashboard.app.run_dashboard", side_effect=KeyboardInterrupt)
+    @patch("augint_tools.dashboard._common.get_github_repo")
+    @patch("augint_tools.dashboard.cmd.load_env_config")
+    @patch("augint_tools.dashboard.cmd.get_github_client")
+    def test_no_flags_uses_single_repo(self, mock_client, mock_env, mock_repo, mock_run):
+        """No --all or --interactive: falls back to GH_REPO single-repo mode."""
+        mock_env.return_value = ("myrepo", "myaccount", "tok")
+        mock_repo.return_value = _mock_repo()
+        runner = CliRunner()
+        result = runner.invoke(main, ["dashboard"])
+        assert result.exit_code == 0
+
+    @patch("augint_tools.dashboard.app.run_dashboard", side_effect=KeyboardInterrupt)
+    @patch("augint_tools.dashboard.cmd.list_repos_multi")
+    @patch("augint_tools.dashboard.cmd.list_user_orgs", return_value=["org-alpha", "org-beta"])
+    @patch("augint_tools.dashboard.cmd.get_viewer_login", return_value="myuser")
+    @patch("augint_tools.dashboard.cmd.load_env_config")
+    @patch("augint_tools.dashboard.cmd.get_github_client")
+    def test_disabled_orgs_excluded_from_owners(
+        self, mock_client, mock_env, mock_viewer, mock_orgs, mock_list, mock_run
+    ):
+        """Saved disabled_orgs from prefs are excluded from the owners list."""
+        mock_env.return_value = ("", "myuser", "tok")
+        mock_list.return_value = [_mock_repo()]
+        runner = CliRunner()
+        with patch(
+            "augint_tools.dashboard.cmd.load_prefs",
+            return_value=DashboardPrefs(disabled_orgs=["org-beta"]),
+        ):
+            result = runner.invoke(main, ["dashboard", "--all"])
+        assert result.exit_code == 0
+        call_args = mock_list.call_args
+        owners = call_args[0][1]
+        assert "myuser" in owners
+        assert "org-alpha" in owners
+        assert "org-beta" not in owners


### PR DESCRIPTION
## Summary
- Unified multi-org view showing repos from personal account and all organizations simultaneously with opt-out model (all orgs enabled by default, toggle with `O` key)
- Redesigned filter logic from AND-across-groups to OR-selection: `no-workspace` is the only AND constraint, all other filters OR together (e.g. `broken-ci` + `team:woxom` shows repos matching either)
- Suppressed PyGithub 403/404 noise from Teams API on personal repos and from `GithubRetry` stdlib logger that Textual was rendering in the TUI

## Test plan
- [x] 154 dashboard unit tests pass
- [x] 418 total tests pass
- [x] Pre-commit (ruff, mypy, uv.lock) all pass
- [ ] Launch dashboard and verify multi-org repos appear
- [ ] Toggle org on/off via `O` key, verify repos update
- [ ] Apply multiple filters (public + team + broken-ci) and verify OR behavior
- [ ] Confirm no 403 errors flash on screen