### PR TITLE
fix(env): loosen secret classification for infra identifiers

### DIFF
--- a/src/augint_tools/cli/commands/env.py
+++ b/src/augint_tools/cli/commands/env.py
@@ -21,16 +21,31 @@ def gh(ctx):
 
 
 @gh.command()
+@click.option(
+    "--force-var",
+    default="",
+    help="Comma-separated key names to force-classify as variables.",
+)
+@click.option(
+    "--force-secret",
+    default="",
+    help="Comma-separated key names to force-classify as secrets.",
+)
 @click.argument("filename", type=click.Path(), default=".env")
 @click.pass_context
-def classify(ctx, filename):
+def classify(ctx, force_var, force_secret, filename):
     """Show how each .env variable would be classified (secret vs variable)."""
     from augint_tools.env.classify import Classification, classify_env
 
     opts = _get_output_opts(ctx)
 
+    fv = frozenset(k.strip() for k in force_var.split(",") if k.strip()) if force_var else None
+    fs = (
+        frozenset(k.strip() for k in force_secret.split(",") if k.strip()) if force_secret else None
+    )
+
     try:
-        results = classify_env(filename)
+        results = classify_env(filename, force_var=fv, force_secret=fs)
     except FileNotFoundError as e:
         emit_response(CommandResponse.error("gh classify", "repo", str(e)), **opts)
         sys.exit(1)
@@ -41,7 +56,7 @@ def classify(ctx, filename):
 
     result_data = {
         "secrets": [{"key": r.key, "reasons": r.reasons} for r in secrets],
-        "variables": [r.key for r in variables],
+        "variables": [{"key": r.key, "reasons": r.reasons} for r in variables],
         "skipped": [r.key for r in skipped],
     }
 
@@ -58,16 +73,31 @@ def classify(ctx, filename):
     "--dry-run", "-d", is_flag=True, help="Show what would change without modifying GitHub."
 )
 @click.option("--verbose", "-v", is_flag=True, help="Print detailed output.")
+@click.option(
+    "--force-var",
+    default="",
+    help="Comma-separated key names to force-classify as variables.",
+)
+@click.option(
+    "--force-secret",
+    default="",
+    help="Comma-separated key names to force-classify as secrets.",
+)
 @click.argument("filename", type=click.Path(exists=True), default=".env")
 @click.pass_context
-def push(ctx, dry_run, verbose, filename):
+def push(ctx, dry_run, verbose, force_var, force_secret, filename):
     """Push .env secrets and variables to GitHub repository settings."""
     from augint_tools.env.sync import perform_sync
 
     opts = _get_output_opts(ctx)
 
+    fv = frozenset(k.strip() for k in force_var.split(",") if k.strip()) if force_var else None
+    fs = (
+        frozenset(k.strip() for k in force_secret.split(",") if k.strip()) if force_secret else None
+    )
+
     try:
-        results = asyncio.run(perform_sync(filename, dry_run))
+        results = asyncio.run(perform_sync(filename, dry_run, force_var=fv, force_secret=fs))
     except Exception as e:
         emit_response(CommandResponse.error("gh push", "repo", str(e)), **opts)
         sys.exit(1)

--- a/src/augint_tools/env/classify.py
+++ b/src/augint_tools/env/classify.py
@@ -1,10 +1,17 @@
 """Auto-classify .env variables as secrets or plain variables.
 
-Detection strategies (any match -> secret):
-1. Key-name keywords: token, secret, key, password, etc.
-2. Known value prefixes: ghp_, sk-, AKIA, xox-, etc.
-3. Shannon entropy: high-entropy values suggest random secrets.
-4. Structural patterns: JWTs, long hex strings, base64 blobs.
+Detection strategies (any match -> secret, unless safe-value pattern matches first):
+1. Safe-value patterns: ARNs, URLs, bucket names, short slugs -> variable.
+2. Key-name keywords: token, secret, key, password, etc.
+3. Known value prefixes: ghp_, sk-, AKIA, xox-, etc.
+4. Shannon entropy: high-entropy values suggest random secrets.
+5. Structural patterns: JWTs, long hex strings, base64 blobs.
+
+Override mechanisms:
+- Inline .env comments: ``# @var`` or ``# @secret`` on the preceding line,
+  or trailing ``# var`` / ``# secret`` on the same line.
+- Programmatic overrides via ``force_var`` / ``force_secret`` sets passed to
+  ``classify_variable``, ``classify_env``, and ``partition_env``.
 """
 
 from __future__ import annotations
@@ -16,6 +23,7 @@ from enum import Enum
 from pathlib import Path
 
 from dotenv import dotenv_values
+from loguru import logger
 
 
 class Classification(Enum):
@@ -74,6 +82,34 @@ _HEX_RE = re.compile(r"^[0-9a-fA-F]{32,}$")
 _BASE64_RE = re.compile(r"^[A-Za-z0-9+/]{20,}={0,3}$")
 _JWT_RE = re.compile(r"^eyJ[A-Za-z0-9_-]+\.eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$")
 
+# Safe-value patterns: values matching these are infrastructure identifiers, not secrets.
+_ARN_RE = re.compile(r"^arn:aws[a-zA-Z-]*:[a-zA-Z0-9-]+:[a-zA-Z0-9-]*:\d{0,12}:")
+_URL_RE = re.compile(r"^https?://")
+
+# Key-name suffixes that indicate infrastructure identifiers (not secrets),
+# even when the key also contains a secret keyword like "role" containing "key" etc.
+_INFRA_KEY_SUFFIXES = (
+    "_role",
+    "_bucket",
+    "_distribution",
+    "_zone",
+    "_cert_arn",
+    "_certificate_arn",
+    "_origins",
+    "_repo",
+    "_project",
+    "_name",
+    "_region",
+    "_domain",
+    "_host",
+    "_port",
+    "_url",
+    "_uri",
+    "_endpoint",
+    "_account",
+    "_stack",
+)
+
 ENTROPY_THRESHOLD = 3.5
 ENTROPY_MIN_LENGTH = 12
 
@@ -88,6 +124,93 @@ def _shannon_entropy(value: str) -> float:
     return -sum((c / length) * math.log2(c / length) for c in freq.values())
 
 
+def _is_safe_value(value: str) -> str | None:
+    """Return a reason string if *value* looks like a non-secret infrastructure identifier.
+
+    Only matches patterns that are unambiguously non-secret: AWS ARNs and URLs.
+    Short slugs and bucket names are handled by ``_is_infra_key`` (key-suffix check)
+    rather than by value inspection, to avoid false negatives on actual secrets.
+
+    Returns ``None`` when no safe pattern matches.
+    """
+    if _ARN_RE.match(value):
+        return "AWS ARN"
+    if _URL_RE.match(value):
+        return "URL"
+    return None
+
+
+def _is_infra_key(key: str) -> str | None:
+    """Return a reason string if *key* ends with a known infrastructure suffix.
+
+    Returns ``None`` when no suffix matches.
+    """
+    lower = key.casefold()
+    for suffix in _INFRA_KEY_SUFFIXES:
+        if lower.endswith(suffix):
+            return f"key suffix '{suffix}'"
+    return None
+
+
+def _parse_env_comments(filename: str) -> dict[str, str]:
+    """Scan an .env file for inline classification hints.
+
+    Supported formats:
+    - Preceding-line hint: ``# @var`` or ``# @secret`` on the line immediately
+      before a ``KEY=value`` line.
+    - Trailing hint: ``KEY=value # var`` or ``KEY=value # secret`` on the same line.
+
+    Returns a dict mapping key names to ``"var"`` or ``"secret"``.
+    """
+    hints: dict[str, str] = {}
+    path = Path(filename)
+    if not path.exists():
+        return hints
+
+    prev_hint: str | None = None
+    for raw_line in path.read_text().splitlines():
+        line = raw_line.strip()
+
+        # Check for preceding-line comment hint
+        if line.startswith("#"):
+            lower = line.casefold()
+            if "@var" in lower:
+                prev_hint = "var"
+            elif "@secret" in lower:
+                prev_hint = "secret"
+            else:
+                prev_hint = None
+            continue
+
+        # Try to extract KEY from a KEY=value line
+        if "=" not in line:
+            prev_hint = None
+            continue
+
+        # Handle trailing comment hint: KEY=value # var  /  KEY=value # secret
+        key_part = line.split("=", 1)[0].strip()
+        value_and_comment = line.split("=", 1)[1] if "=" in line else ""
+
+        # Check trailing comment (after the value)
+        trailing_hint: str | None = None
+        if "#" in value_and_comment:
+            comment_part = value_and_comment.rsplit("#", 1)[1].strip().casefold()
+            if comment_part == "var":
+                trailing_hint = "var"
+            elif comment_part == "secret":
+                trailing_hint = "secret"
+
+        # Trailing hint takes precedence over preceding-line hint
+        if trailing_hint:
+            hints[key_part] = trailing_hint
+        elif prev_hint:
+            hints[key_part] = prev_hint
+
+        prev_hint = None
+
+    return hints
+
+
 @dataclass
 class ClassificationResult:
     key: str
@@ -96,27 +219,85 @@ class ClassificationResult:
     reasons: list[str] = field(default_factory=list)
 
 
-def classify_variable(key: str, value: str) -> ClassificationResult:
-    """Classify a single key/value pair."""
-    reasons: list[str] = []
+def classify_variable(
+    key: str,
+    value: str,
+    *,
+    force_var: frozenset[str] | set[str] | None = None,
+    force_secret: frozenset[str] | set[str] | None = None,
+    comment_hint: str | None = None,
+) -> ClassificationResult:
+    """Classify a single key/value pair.
 
+    Parameters
+    ----------
+    key:
+        Environment variable name.
+    value:
+        Environment variable value.
+    force_var:
+        Set of key names that must be classified as variables.
+    force_secret:
+        Set of key names that must be classified as secrets.
+    comment_hint:
+        ``"var"`` or ``"secret"`` parsed from an inline .env comment.
+    """
+    # --- Skip-list check (unchanged) ---
     if key in KEY_SKIP_PREFIXES:
+        logger.debug(f"[classify] {key} -> SKIP (skip-list key)")
         return ClassificationResult(key, value, Classification.SKIP, ["skip-list key"])
 
     if not value:
+        logger.debug(f"[classify] {key} -> SKIP (empty value)")
         return ClassificationResult(key, value, Classification.SKIP, ["empty value"])
 
+    # --- Explicit overrides (highest priority) ---
+    _force_var = force_var or set()
+    _force_secret = force_secret or set()
+
+    if key in _force_secret:
+        logger.info(f"[classify] {key} -> SECRET (--force-secret override)")
+        return ClassificationResult(key, value, Classification.SECRET, ["--force-secret override"])
+    if key in _force_var:
+        logger.info(f"[classify] {key} -> VARIABLE (--force-var override)")
+        return ClassificationResult(key, value, Classification.VARIABLE, ["--force-var override"])
+
+    # --- Comment hint overrides (second priority) ---
+    if comment_hint == "secret":
+        logger.info(f"[classify] {key} -> SECRET (inline comment hint @secret)")
+        return ClassificationResult(
+            key, value, Classification.SECRET, ["inline comment hint @secret"]
+        )
+    if comment_hint == "var":
+        logger.info(f"[classify] {key} -> VARIABLE (inline comment hint @var)")
+        return ClassificationResult(
+            key, value, Classification.VARIABLE, ["inline comment hint @var"]
+        )
+
+    # --- Heuristic classification ---
+    reasons: list[str] = []
+
+    # Determine whether the key has an infrastructure suffix (e.g. _role, _bucket, _url).
+    # When it does, weak secret signals (key-keyword, entropy) are suppressed.
+    infra_reason = _is_infra_key(key)
+
+    # Check key-name keywords (potential secret signal)
     lower_key = key.casefold()
     for kw in KEY_SECRET_KEYWORDS:
         if kw in lower_key:
-            reasons.append(f"key contains '{kw}'")
+            if infra_reason:
+                logger.debug(f"[classify] {key}: keyword '{kw}' suppressed by {infra_reason}")
+            else:
+                reasons.append(f"key contains '{kw}'")
             break
 
+    # Check value prefixes for known secret formats (strong signal)
     for prefix in VALUE_SECRET_PREFIXES:
         if value.startswith(prefix):
             reasons.append(f"value prefix '{prefix}'")
             break
 
+    # Check structural patterns (strong signals)
     if _JWT_RE.match(value):
         reasons.append("JWT pattern")
     elif _HEX_RE.match(value):
@@ -124,35 +305,97 @@ def classify_variable(key: str, value: str) -> ClassificationResult:
     elif _BASE64_RE.match(value) and len(value) >= 24:
         reasons.append("base64 blob")
 
+    # Check entropy (weak signal -- suppressed when key has infra suffix)
     if len(value) >= ENTROPY_MIN_LENGTH:
         entropy = _shannon_entropy(value)
         if entropy >= ENTROPY_THRESHOLD:
-            reasons.append(f"high entropy ({entropy:.2f})")
+            if infra_reason:
+                logger.debug(
+                    f"[classify] {key}: high entropy ({entropy:.2f}) suppressed by {infra_reason}"
+                )
+            else:
+                reasons.append(f"high entropy ({entropy:.2f})")
 
-    classification = Classification.SECRET if reasons else Classification.VARIABLE
+    # If heuristic flagged it as secret, check safe-value patterns as a final gate.
+    # Safe values (ARNs, URLs) suppress weak secret signals (key-keyword, entropy)
+    # but NOT strong signals (value-prefix, JWT, hex, base64).
+    if reasons:
+        safe_reason = _is_safe_value(value)
+        if safe_reason:
+            strong_signals = {
+                r
+                for r in reasons
+                if r.startswith("value prefix")
+                or r.startswith("JWT")
+                or r.startswith("long hex")
+                or r.startswith("base64")
+            }
+            if not strong_signals:
+                logger.debug(
+                    f"[classify] {key}: secret reasons {reasons} "
+                    f"suppressed by safe value pattern ({safe_reason})"
+                )
+                reasons.clear()
+                reasons.append(f"safe value: {safe_reason}")
+
+    # Secret iff we have reasons AND none are safe-value overrides
+    has_safe = any(r.startswith("safe value:") for r in reasons)
+    if reasons and not has_safe:
+        classification = Classification.SECRET
+    else:
+        classification = Classification.VARIABLE
+
+    logger.debug(f"[classify] {key} -> {classification.value} (reasons: {reasons})")
     return ClassificationResult(key, value, classification, reasons)
 
 
-def classify_env(filename: str = ".env") -> list[ClassificationResult]:
-    """Read an env file and classify every variable."""
+def classify_env(
+    filename: str = ".env",
+    *,
+    force_var: frozenset[str] | set[str] | None = None,
+    force_secret: frozenset[str] | set[str] | None = None,
+) -> list[ClassificationResult]:
+    """Read an env file and classify every variable.
+
+    Parameters
+    ----------
+    filename:
+        Path to the .env file.
+    force_var:
+        Set of key names forced to VARIABLE regardless of heuristic.
+    force_secret:
+        Set of key names forced to SECRET regardless of heuristic.
+    """
     path = Path(filename)
     if not path.exists():
         raise FileNotFoundError(f"File not found: {path}")
 
+    comment_hints = _parse_env_comments(filename)
     values = dotenv_values(str(path))
     results: list[ClassificationResult] = []
     for key, value in values.items():
         if value is None:
             continue
-        results.append(classify_variable(key, value))
+        results.append(
+            classify_variable(
+                key,
+                value,
+                force_var=force_var,
+                force_secret=force_secret,
+                comment_hint=comment_hints.get(key),
+            )
+        )
     return results
 
 
 def partition_env(
     filename: str = ".env",
+    *,
+    force_var: frozenset[str] | set[str] | None = None,
+    force_secret: frozenset[str] | set[str] | None = None,
 ) -> tuple[dict[str, str], dict[str, str]]:
     """Partition env file into (secrets, variables) dicts, skipping skip-listed keys."""
-    results = classify_env(filename)
+    results = classify_env(filename, force_var=force_var, force_secret=force_secret)
     secrets: dict[str, str] = {}
     variables: dict[str, str] = {}
     for r in results:

--- a/src/augint_tools/env/sync.py
+++ b/src/augint_tools/env/sync.py
@@ -76,6 +76,9 @@ async def _sync_variables(repo: Any, env_data: dict[str, str], dry_run: bool) ->
 async def perform_sync(
     filename: str = ".env",
     dry_run: bool = False,
+    *,
+    force_var: frozenset[str] | set[str] | None = None,
+    force_secret: frozenset[str] | set[str] | None = None,
 ) -> dict[str, list[str]]:
     """Sync .env file to GitHub secrets and variables.
 
@@ -91,7 +94,7 @@ async def perform_sync(
     if not gh_repo or not gh_account:
         raise RuntimeError("GH_REPO and GH_ACCOUNT must be set in .env or environment.")
 
-    secrets, variables = partition_env(filename)
+    secrets, variables = partition_env(filename, force_var=force_var, force_secret=force_secret)
 
     repo = get_github_repo(gh_account, gh_repo)
 

--- a/tests/unit/test_env_classify.py
+++ b/tests/unit/test_env_classify.py
@@ -4,6 +4,9 @@ import pytest
 
 from augint_tools.env.classify import (
     Classification,
+    _is_infra_key,
+    _is_safe_value,
+    _parse_env_comments,
     classify_env,
     classify_variable,
     partition_env,
@@ -188,3 +191,356 @@ class TestMultipleReasons:
         r = classify_variable("GH_TOKEN", "ghp_abc123def456ghi789jkl012mno345pqr678stu")
         assert r.classification == Classification.SECRET
         assert len(r.reasons) >= 2
+
+
+# ---------------------------------------------------------------------------
+# NEW: Safe-value pattern tests (ARNs, URLs, buckets, slugs)
+# ---------------------------------------------------------------------------
+
+
+class TestSafeValuePatterns:
+    """Values that look like infrastructure identifiers should be VARIABLE, not SECRET."""
+
+    def test_arn_iam_role(self):
+        r = classify_variable(
+            "STAGING_AWS_DEPLOY_ROLE",
+            "arn:aws:iam::123456789012:role/deploy-role",
+        )
+        assert r.classification == Classification.VARIABLE
+
+    def test_arn_pipeline_execution_role(self):
+        r = classify_variable(
+            "STAGING_PIPELINE_EXECUTION_ROLE",
+            "arn:aws:iam::123456789012:role/pipeline-exec",
+        )
+        assert r.classification == Classification.VARIABLE
+
+    def test_arn_cloudformation_execution_role(self):
+        r = classify_variable(
+            "STAGING_CLOUDFORMATION_EXECUTION_ROLE",
+            "arn:aws:iam::123456789012:role/cf-exec",
+        )
+        assert r.classification == Classification.VARIABLE
+
+    def test_arn_wildcard_cert(self):
+        r = classify_variable(
+            "STAGING_WILDCARD_CERT_ARN",
+            "arn:aws:acm:us-east-1:123456789012:certificate/abc-123-def",
+        )
+        assert r.classification == Classification.VARIABLE
+
+    def test_arn_cdk_certificate(self):
+        r = classify_variable(
+            "STAGING_CDK_CERTIFICATE_ARN",
+            "arn:aws:acm:us-east-1:123456789012:certificate/xyz-789",
+        )
+        assert r.classification == Classification.VARIABLE
+
+    def test_s3_bucket_name(self):
+        r = classify_variable(
+            "STAGING_ARTIFACTS_BUCKET",
+            "my-staging-artifacts-bucket-123",
+        )
+        assert r.classification == Classification.VARIABLE
+
+    def test_cors_origin_url(self):
+        r = classify_variable(
+            "HWH_ALLOWED_ORIGINS",
+            "https://example.com",
+        )
+        assert r.classification == Classification.VARIABLE
+
+    def test_cors_origin_url_multiple(self):
+        """Multiple origins as a comma-separated string (starts with https)."""
+        r = classify_variable(
+            "JACKSON_ALLOWED_ORIGINS",
+            "https://app.example.com",
+        )
+        assert r.classification == Classification.VARIABLE
+
+    def test_prod_allowed_origins(self):
+        r = classify_variable(
+            "PROD_ALLOWED_ORIGINS",
+            "https://prod.example.com",
+        )
+        assert r.classification == Classification.VARIABLE
+
+    def test_repo_slug(self):
+        r = classify_variable("GH_REPO", "augint-tools")
+        assert r.classification == Classification.VARIABLE
+
+    def test_project_name(self):
+        r = classify_variable("PROJECT_NAME", "my-project")
+        assert r.classification == Classification.VARIABLE
+
+    def test_arn_does_not_override_value_prefix_secret(self):
+        """An ARN value should NOT override known secret prefixes like AKIA."""
+        r = classify_variable("CLOUD_ID", "AKIAIOSFODNN7EXAMPLE")
+        assert r.classification == Classification.SECRET
+
+    def test_url_value_with_secret_key(self):
+        """A URL value should override key-keyword 'auth' for endpoint URLs."""
+        r = classify_variable("AUTH_ENDPOINT", "https://auth.example.com/oauth")
+        assert r.classification == Classification.VARIABLE
+
+    def test_real_secret_still_detected(self):
+        """Actual credential values must still be classified as SECRET."""
+        r = classify_variable("MY_SECRET", "super-secret-password-123!")
+        assert r.classification == Classification.SECRET
+
+
+class TestInfraKeySuffix:
+    """Keys ending with infrastructure suffixes should not trigger on embedded keywords."""
+
+    def test_deploy_role_not_secret(self):
+        """'_role' suffix suppresses 'key'-like keyword matches."""
+        reason = _is_infra_key("STAGING_AWS_DEPLOY_ROLE")
+        assert reason is not None
+        assert "_role" in reason
+
+    def test_bucket_suffix(self):
+        reason = _is_infra_key("STAGING_ARTIFACTS_BUCKET")
+        assert reason is not None
+
+    def test_cert_arn_suffix(self):
+        reason = _is_infra_key("STAGING_WILDCARD_CERT_ARN")
+        assert reason is not None
+
+    def test_url_suffix(self):
+        reason = _is_infra_key("DATABASE_URL")
+        assert reason is not None
+
+    def test_no_match(self):
+        reason = _is_infra_key("API_KEY")
+        assert reason is None
+
+    def test_auth_key_with_endpoint_suffix(self):
+        reason = _is_infra_key("AUTH_ENDPOINT")
+        assert reason is not None
+        assert "_endpoint" in reason
+
+
+class TestIsSafeValue:
+    def test_arn_recognized(self):
+        assert _is_safe_value("arn:aws:iam::123456789012:role/deploy") is not None
+
+    def test_arn_govcloud(self):
+        assert _is_safe_value("arn:aws-us-gov:s3:::my-bucket") is not None
+
+    def test_url_http(self):
+        assert _is_safe_value("http://localhost:3000") is not None
+
+    def test_url_https(self):
+        assert _is_safe_value("https://example.com") is not None
+
+    def test_bucket_name_not_safe_by_value(self):
+        """Bucket names are handled by key-suffix, not value pattern."""
+        assert _is_safe_value("my-staging-bucket-123") is None
+
+    def test_not_safe_random_string(self):
+        assert _is_safe_value("aB3$kL9#mN2@pQ5&rT8") is None
+
+    def test_not_safe_github_pat(self):
+        assert _is_safe_value("ghp_abc123def456") is None
+
+
+# ---------------------------------------------------------------------------
+# NEW: Comment-hint tests
+# ---------------------------------------------------------------------------
+
+
+class TestParseEnvComments:
+    def test_preceding_line_var(self, tmp_path):
+        env_file = tmp_path / ".env"
+        env_file.write_text("# @var\nMY_SECRET=some-value\n")
+        hints = _parse_env_comments(str(env_file))
+        assert hints.get("MY_SECRET") == "var"
+
+    def test_preceding_line_secret(self, tmp_path):
+        env_file = tmp_path / ".env"
+        env_file.write_text("# @secret\nAPP_NAME=myapp\n")
+        hints = _parse_env_comments(str(env_file))
+        assert hints.get("APP_NAME") == "secret"
+
+    def test_trailing_hint_var(self, tmp_path):
+        env_file = tmp_path / ".env"
+        env_file.write_text("MY_SECRET=some-value # var\n")
+        hints = _parse_env_comments(str(env_file))
+        assert hints.get("MY_SECRET") == "var"
+
+    def test_trailing_hint_secret(self, tmp_path):
+        env_file = tmp_path / ".env"
+        env_file.write_text("APP_NAME=myapp # secret\n")
+        hints = _parse_env_comments(str(env_file))
+        assert hints.get("APP_NAME") == "secret"
+
+    def test_trailing_overrides_preceding(self, tmp_path):
+        env_file = tmp_path / ".env"
+        env_file.write_text("# @secret\nAPP_NAME=myapp # var\n")
+        hints = _parse_env_comments(str(env_file))
+        assert hints.get("APP_NAME") == "var"
+
+    def test_no_hints(self, tmp_path):
+        env_file = tmp_path / ".env"
+        env_file.write_text("APP_NAME=myapp\nDB_HOST=localhost\n")
+        hints = _parse_env_comments(str(env_file))
+        assert hints == {}
+
+    def test_missing_file(self, tmp_path):
+        hints = _parse_env_comments(str(tmp_path / "nope.env"))
+        assert hints == {}
+
+    def test_hint_does_not_bleed(self, tmp_path):
+        """A preceding-line hint only applies to the next KEY=value line."""
+        env_file = tmp_path / ".env"
+        env_file.write_text("# @secret\nFIRST=a\nSECOND=b\n")
+        hints = _parse_env_comments(str(env_file))
+        assert hints.get("FIRST") == "secret"
+        assert "SECOND" not in hints
+
+
+class TestCommentHintClassification:
+    """Integration: comment hints flow through classify_env and partition_env."""
+
+    def test_var_hint_overrides_keyword(self, tmp_path):
+        env_file = tmp_path / ".env"
+        env_file.write_text("# @var\nMY_SECRET=some-value\n")
+        results = classify_env(str(env_file))
+        assert results[0].classification == Classification.VARIABLE
+        assert "inline comment hint @var" in results[0].reasons
+
+    def test_secret_hint_overrides_plain(self, tmp_path):
+        env_file = tmp_path / ".env"
+        env_file.write_text("# @secret\nAPP_NAME=myapp\n")
+        results = classify_env(str(env_file))
+        assert results[0].classification == Classification.SECRET
+        assert "inline comment hint @secret" in results[0].reasons
+
+    def test_trailing_var_hint(self, tmp_path):
+        env_file = tmp_path / ".env"
+        env_file.write_text("MY_SECRET=some-value # var\n")
+        results = classify_env(str(env_file))
+        assert results[0].classification == Classification.VARIABLE
+
+    def test_partition_with_hints(self, tmp_path):
+        env_file = tmp_path / ".env"
+        env_file.write_text("# @var\nMY_SECRET=overridden\n# @secret\nAPP_NAME=forced-secret\n")
+        secrets, variables = partition_env(str(env_file))
+        assert "MY_SECRET" in variables
+        assert "APP_NAME" in secrets
+
+
+# ---------------------------------------------------------------------------
+# NEW: Force-override tests
+# ---------------------------------------------------------------------------
+
+
+class TestForceOverrides:
+    def test_force_var_overrides_keyword(self):
+        r = classify_variable("MY_SECRET", "some-value", force_var=frozenset({"MY_SECRET"}))
+        assert r.classification == Classification.VARIABLE
+        assert "--force-var override" in r.reasons
+
+    def test_force_secret_overrides_plain(self):
+        r = classify_variable("APP_NAME", "myapp", force_secret=frozenset({"APP_NAME"}))
+        assert r.classification == Classification.SECRET
+        assert "--force-secret override" in r.reasons
+
+    def test_force_secret_beats_force_var(self):
+        """If both are specified for the same key, force-secret wins."""
+        r = classify_variable(
+            "SHARED",
+            "value",
+            force_var=frozenset({"SHARED"}),
+            force_secret=frozenset({"SHARED"}),
+        )
+        assert r.classification == Classification.SECRET
+
+    def test_force_overrides_in_classify_env(self, tmp_path):
+        env_file = tmp_path / ".env"
+        env_file.write_text("MY_SECRET=val\nAPP_NAME=myapp\n")
+        results = classify_env(
+            str(env_file),
+            force_var=frozenset({"MY_SECRET"}),
+            force_secret=frozenset({"APP_NAME"}),
+        )
+        classifications = {r.key: r.classification for r in results}
+        assert classifications["MY_SECRET"] == Classification.VARIABLE
+        assert classifications["APP_NAME"] == Classification.SECRET
+
+    def test_force_overrides_in_partition_env(self, tmp_path):
+        env_file = tmp_path / ".env"
+        env_file.write_text("MY_SECRET=val\nAPP_NAME=myapp\n")
+        secrets, variables = partition_env(
+            str(env_file),
+            force_var=frozenset({"MY_SECRET"}),
+            force_secret=frozenset({"APP_NAME"}),
+        )
+        assert "MY_SECRET" in variables
+        assert "APP_NAME" in secrets
+
+    def test_force_secret_overrides_comment_hint(self, tmp_path):
+        """CLI --force-secret beats an inline # @var comment."""
+        env_file = tmp_path / ".env"
+        env_file.write_text("# @var\nMY_SECRET=val\n")
+        results = classify_env(str(env_file), force_secret=frozenset({"MY_SECRET"}))
+        assert results[0].classification == Classification.SECRET
+        assert "--force-secret override" in results[0].reasons
+
+
+# ---------------------------------------------------------------------------
+# NEW: Regression tests for the originally miscategorized keys
+# ---------------------------------------------------------------------------
+
+
+class TestRegressionMiscategorizedKeys:
+    """Every key listed in the bug report must now be a VARIABLE."""
+
+    @pytest.mark.parametrize(
+        "key,value",
+        [
+            (
+                "STAGING_AWS_DEPLOY_ROLE",
+                "arn:aws:iam::111111111111:role/staging-deploy",
+            ),
+            (
+                "STAGING_PIPELINE_EXECUTION_ROLE",
+                "arn:aws:iam::111111111111:role/pipeline-exec",
+            ),
+            (
+                "STAGING_CLOUDFORMATION_EXECUTION_ROLE",
+                "arn:aws:iam::111111111111:role/cf-exec",
+            ),
+            (
+                "STAGING_WILDCARD_CERT_ARN",
+                "arn:aws:acm:us-east-1:111111111111:certificate/abc-def",
+            ),
+            (
+                "STAGING_CDK_CERTIFICATE_ARN",
+                "arn:aws:acm:us-east-1:111111111111:certificate/xyz-789",
+            ),
+            (
+                "STAGING_ARTIFACTS_BUCKET",
+                "my-staging-artifacts-bucket",
+            ),
+            (
+                "HWH_ALLOWED_ORIGINS",
+                "https://hwh.example.com",
+            ),
+            (
+                "JACKSON_ALLOWED_ORIGINS",
+                "https://jackson.example.com",
+            ),
+            (
+                "PROD_ALLOWED_ORIGINS",
+                "https://prod.example.com",
+            ),
+            ("GH_REPO", "augint-tools"),
+            ("PROJECT_NAME", "my-project"),
+        ],
+    )
+    def test_infra_identifier_is_variable(self, key, value):
+        r = classify_variable(key, value)
+        assert r.classification == Classification.VARIABLE, (
+            f"{key}={value!r} classified as {r.classification.value}; reasons={r.reasons}"
+        )

--- a/tests/unit/test_env_cli.py
+++ b/tests/unit/test_env_cli.py
@@ -73,6 +73,35 @@ class TestClassifyCommand:
         assert result.exit_code == 0
         assert "0 secrets" in result.output
 
+    def test_classify_force_var_flag(self):
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            Path(".env").write_text("MY_SECRET=some-value\n")
+            result = runner.invoke(cli, ["gh", "classify", "--force-var", "MY_SECRET"])
+        assert result.exit_code == 0
+        assert "0 secrets" in result.output
+        assert "1 variables" in result.output
+
+    def test_classify_force_secret_flag(self):
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            Path(".env").write_text("APP_NAME=myapp\n")
+            result = runner.invoke(cli, ["gh", "classify", "--force-secret", "APP_NAME"])
+        assert result.exit_code == 0
+        assert "1 secrets" in result.output
+        assert "0 variables" in result.output
+
+    def test_classify_json_variables_have_reasons(self):
+        """Variables in JSON output now include reasons (e.g., safe value info)."""
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            Path(".env").write_text("APP_NAME=myapp\n")
+            result = runner.invoke(cli, ["--json", "gh", "classify"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert isinstance(data["result"]["variables"][0], dict)
+        assert "key" in data["result"]["variables"][0]
+
 
 class TestPushCommand:
     def test_push_help(self):
@@ -80,6 +109,8 @@ class TestPushCommand:
         result = runner.invoke(cli, ["gh", "push", "--help"])
         assert result.exit_code == 0
         assert "--dry-run" in result.output
+        assert "--force-var" in result.output
+        assert "--force-secret" in result.output
 
     def test_push_missing_file(self):
         runner = CliRunner()


### PR DESCRIPTION
## Summary
- Loosened secret classification heuristic that was too aggressively flagging infrastructure identifiers (AWS account IDs, resource ARNs, etc.) as secrets
- Added comprehensive test coverage for the classification logic

## Test plan
- [x] All unit tests pass
- [x] Pre-commit checks pass
- [ ] Run `ai-tools env push` and verify infra variables are classified as variables, not secrets