### PR TITLE
feat(dashboard): click top-drawer widgets for explanations

### DIFF
--- a/src/augint_tools/dashboard/app.py
+++ b/src/augint_tools/dashboard/app.py
@@ -35,6 +35,7 @@ from .screens.filter_panel import FilterPanel
 from .screens.help import HelpScreen
 from .screens.org_manager import OrgManager
 from .screens.repo_manager import RepoManager
+from .screens.widget_help import WidgetHelpScreen
 from .state import (
     PANEL_WIDTH_MAX,
     PANEL_WIDTH_MIN,
@@ -77,6 +78,19 @@ def _progress_bar(fraction: float, width: int) -> str:
 
 # Unicode 'lower N eighth blocks' for sparkline rendering (U+2581..U+2588).
 _SPARK_GLYPHS = " \u2581\u2582\u2583\u2584\u2585\u2586\u2587\u2588"
+
+
+def _concat_sections(sections: list[tuple[str, Text]]) -> Text:
+    """Concatenate a list of named sections into a single ``Text``.
+
+    Used to keep the original single-``Text`` drawer accessors working
+    after the drawer column renderers were split into per-section chunks.
+    Section ids are discarded -- they only matter for click routing.
+    """
+    out = Text()
+    for _, chunk in sections:
+        out.append_text(chunk)
+    return out
 
 
 def _sparkline(values: list[int]) -> str:
@@ -241,9 +255,9 @@ class MainScreen(Screen[None]):
         self._header.set_countdown(self._countdown_text())
         if self._top_drawer.is_open:
             self._top_drawer.set_content(
-                self._org_drawer_content(),
-                self._org_drawer_middle_content(),
-                self._org_drawer_right_content(),
+                self._org_drawer_left_sections(),
+                self._org_drawer_middle_sections(),
+                self._org_drawer_right_sections(),
             )
 
     def rerender_usage_only(self) -> None:
@@ -254,9 +268,9 @@ class MainScreen(Screen[None]):
         if self._top_drawer.is_open:
             # Org drawer embeds a usage block; refresh it in place.
             self._top_drawer.set_content(
-                self._org_drawer_content(),
-                self._org_drawer_middle_content(),
-                self._org_drawer_right_content(),
+                self._org_drawer_left_sections(),
+                self._org_drawer_middle_sections(),
+                self._org_drawer_right_sections(),
             )
 
     def tick_status(self) -> None:
@@ -372,13 +386,19 @@ class MainScreen(Screen[None]):
         self._drawer.toggle("usage", content)
 
     def toggle_org_drawer(self) -> None:
-        left = self._org_drawer_content()
-        middle = self._org_drawer_middle_content()
-        right = self._org_drawer_right_content()
-        self._top_drawer.toggle(left, middle, right)
+        self._top_drawer.toggle(
+            self._org_drawer_left_sections(),
+            self._org_drawer_middle_sections(),
+            self._org_drawer_right_sections(),
+        )
 
     def on_org_drawer_header_toggle(self, _message: OrgDrawerHeader.Toggle) -> None:
         self.toggle_org_drawer()
+
+    def on_top_drawer_section_clicked(self, message: TopDrawer.SectionClicked) -> None:
+        """Open the per-widget help modal when a drawer section is clicked."""
+        message.stop()
+        self.app.push_screen(WidgetHelpScreen(message.section_id))
 
     def _detail_drawer_content(self, health: RepoHealth) -> Text:
         status = health.status
@@ -398,33 +418,58 @@ class MainScreen(Screen[None]):
         t.append("\npress d to close, enter for full drilldown.", style="dim")
         return t
 
-    def _org_drawer_content(self) -> Text:
-        """Left column: system meters (GPU/RAM) + CI matrix."""
+    # ------------------------------------------------------------------
+    # Org drawer content
+    # ------------------------------------------------------------------
+    #
+    # Each column of the org drawer is composed from a list of named
+    # "sections". Splitting the columns this way lets the TopDrawer render
+    # each section as its own Static widget so clicks can be attributed to
+    # a specific widget (and open an explanatory modal). The section ids
+    # used below must stay in sync with the keys in
+    # ``augint_tools.dashboard.screens.widget_help.WIDGET_HELP``.
+
+    def _org_drawer_left_sections(self) -> list[tuple[str, Text]]:
+        """Sections that make up the left column of the org drawer."""
         state = self._state
         spec = get_theme(state.theme_name)
-        t = Text()
-        self._append_system_block(t, spec)
-        if not state.healths:
-            t.append("no data yet. press r to refresh.\n", style="dim")
-            return t
-        self._append_ci_matrix(t, state.healths, spec)
-        return t
+        sections: list[tuple[str, Text]] = []
 
-    def _org_drawer_middle_content(self) -> Text:
-        """Middle column: org-wide stats, weather, activity, usage."""
+        system = Text()
+        self._append_system_block(system, spec)
+        if system.plain:
+            sections.append(("system", system))
+
+        if not state.healths:
+            empty = Text()
+            empty.append("no data yet. press r to refresh.\n", style="dim")
+            sections.append(("empty", empty))
+            return sections
+
+        ci = Text()
+        self._append_ci_matrix(ci, state.healths, spec)
+        sections.append(("ci_matrix", ci))
+        return sections
+
+    def _org_drawer_middle_sections(self) -> list[tuple[str, Text]]:
+        """Sections that make up the middle column of the org drawer."""
         from .health import Severity as _Sev
 
         state = self._state
         spec = get_theme(state.theme_name)
-        t = Text()
-
         title = " + ".join(self._owners) if self._owners else self._org_name or "Organization"
+        sections: list[tuple[str, Text]] = []
 
         if not state.healths:
-            t.append(f"{title} -- org dashboard\n\n", style="bold")
-            t.append("no data yet. press r to refresh.\n\n", style="dim")
-            self._append_usage_block(t, spec)
-            return t
+            header = Text()
+            header.append(f"{title} -- org dashboard\n\n", style="bold")
+            header.append("no data yet. press r to refresh.\n\n", style="dim")
+            sections.append(("empty", header))
+            usage = Text()
+            self._append_usage_block(usage, spec)
+            if usage.plain:
+                sections.append(("usage", usage))
+            return sections
 
         by_sev: dict[_Sev, int] = {}
         for h in state.healths:
@@ -433,38 +478,95 @@ class MainScreen(Screen[None]):
         ok_count = by_sev.get(_Sev.OK, 0)
         score = int((ok_count / total) * 100) if total else 0
 
-        t.append(f"{title}\n", style="bold")
-        t.append(f"{total} repos  ·  {score}% green\n\n")
+        header = Text()
+        header.append(f"{title}\n", style="bold")
+        header.append(f"{total} repos  ·  {score}% green\n\n")
+        sections.append(("header", header))
 
-        self._append_severity_bar(t, by_sev, total, spec)
+        sev_bar = Text()
+        self._append_severity_bar(sev_bar, by_sev, total, spec)
+        sections.append(("severity_bar", sev_bar))
 
-        t.append("repos    ", style="bold")
-        self._append_repo_glyphs(t, spec)
-        t.append("\n\n")
+        glyphs = Text()
+        glyphs.append("repos    ", style="bold")
+        self._append_repo_glyphs(glyphs, spec)
+        glyphs.append("\n\n")
+        sections.append(("repo_glyphs", glyphs))
 
-        self._append_weather(t, by_sev, state.healths, spec)
-        self._append_activity_spark(t, spec)
-        self._append_pr_ages(t, state.healths, spec)
-        self._append_team_mix(t, state, spec)
-        self._append_usage_block(t, spec)
-        t.append("press i or click header to close.", style="dim")
-        return t
+        weather = Text()
+        self._append_weather(weather, by_sev, state.healths, spec)
+        sections.append(("weather", weather))
 
-    def _org_drawer_right_content(self) -> Text:
-        """Right column: check failures, service/lib mix, score histogram,
-        recent errors, worst-repos leaderboard."""
+        activity = Text()
+        self._append_activity_spark(activity, spec)
+        sections.append(("activity", activity))
+
+        pr_ages = Text()
+        self._append_pr_ages(pr_ages, state.healths, spec)
+        sections.append(("pr_ages", pr_ages))
+
+        team_mix = Text()
+        self._append_team_mix(team_mix, state, spec)
+        if team_mix.plain:
+            sections.append(("team_mix", team_mix))
+
+        usage = Text()
+        self._append_usage_block(usage, spec)
+        if usage.plain:
+            sections.append(("usage", usage))
+
+        hint = Text()
+        hint.append("press i or click header to close.", style="dim")
+        sections.append(("hint", hint))
+        return sections
+
+    def _org_drawer_right_sections(self) -> list[tuple[str, Text]]:
+        """Sections that make up the right column of the org drawer."""
         state = self._state
         spec = get_theme(state.theme_name)
-        t = Text()
+        sections: list[tuple[str, Text]] = []
         if not state.healths:
-            t.append("--\n", style="dim")
-            return t
-        self._append_check_breakdown(t, state.healths, spec)
-        self._append_service_lib(t, state.healths, spec)
-        self._append_score_histogram(t, state.healths, spec)
-        self._append_recent_errors(t, state, spec)
-        self._append_leaderboard(t, state.healths, spec)
-        return t
+            empty = Text()
+            empty.append("--\n", style="dim")
+            sections.append(("empty", empty))
+            return sections
+
+        check = Text()
+        self._append_check_breakdown(check, state.healths, spec)
+        sections.append(("check_breakdown", check))
+
+        svc = Text()
+        self._append_service_lib(svc, state.healths, spec)
+        sections.append(("service_lib", svc))
+
+        score = Text()
+        self._append_score_histogram(score, state.healths, spec)
+        sections.append(("score_histogram", score))
+
+        errors = Text()
+        self._append_recent_errors(errors, state, spec)
+        sections.append(("recent_errors", errors))
+
+        leader = Text()
+        self._append_leaderboard(leader, state.healths, spec)
+        if leader.plain:
+            sections.append(("leaderboard", leader))
+        return sections
+
+    # Backwards-compatible accessors -- concatenate sections into a single
+    # Text so older call sites (and tests) keep working unchanged.
+
+    def _org_drawer_content(self) -> Text:
+        """Left column as a single Text (concatenation of all sections)."""
+        return _concat_sections(self._org_drawer_left_sections())
+
+    def _org_drawer_middle_content(self) -> Text:
+        """Middle column as a single Text (concatenation of all sections)."""
+        return _concat_sections(self._org_drawer_middle_sections())
+
+    def _org_drawer_right_content(self) -> Text:
+        """Right column as a single Text (concatenation of all sections)."""
+        return _concat_sections(self._org_drawer_right_sections())
 
     # ------------------------------------------------------------------
     # Right-column widget helpers

--- a/src/augint_tools/dashboard/screens/widget_help.py
+++ b/src/augint_tools/dashboard/screens/widget_help.py
@@ -1,0 +1,199 @@
+"""WidgetHelpScreen -- modal explaining what a top-drawer widget means.
+
+Clicking any section of the org drawer (the ``i``-toggled top drawer) opens
+this screen with a short, plain-English explanation of the chosen widget.
+Each widget is identified by a stable id (e.g. ``activity`` or ``ci_matrix``)
+that maps to a ``(title, body)`` pair in :data:`WIDGET_HELP`.
+"""
+
+from __future__ import annotations
+
+from rich.text import Text
+from textual import events
+from textual.binding import Binding
+from textual.containers import Container
+from textual.screen import ModalScreen
+from textual.widgets import Static
+
+# Section ids used by TopDrawer. Keep in sync with the ids assigned in
+# augint_tools.dashboard.app.MainScreen._org_drawer_*_sections().
+WIDGET_HELP: dict[str, tuple[str, str]] = {
+    "system": (
+        "system",
+        (
+            "Host machine meters for the computer running the dashboard, not the "
+            "GitHub org. RAM shows used/total memory with a severity-coloured bar; "
+            "GPU (when an NVIDIA card is present) shows name, temperature, power, "
+            "utilisation, and VRAM. If neither probe has data, this section is hidden."
+        ),
+    ),
+    "ci_matrix": (
+        "ci matrix",
+        (
+            "One row per repo (up to 24) showing CI status as coloured dots. For "
+            "service repos the left dot is the dev-branch workflow and the right dot "
+            "is main; library repos only show the main dot. Green = passing, red = "
+            "failing, yellow = in progress, grey = unknown. Any overflow is "
+            'summarised as "(+N more)".'
+        ),
+    ),
+    "severity_bar": (
+        "severity bar",
+        (
+            "Horizontal stacked bar showing what fraction of repos sit in each "
+            "severity bucket: critical, high, medium, low, and ok. The legend on "
+            "the right lists every non-zero bucket with its count; if nothing is "
+            'wrong it simply reads "all green".'
+        ),
+    ),
+    "repo_glyphs": (
+        "repo glyphs",
+        (
+            "One coloured dot per repo (up to 50), coloured by that repo's worst "
+            "current severity. Scan left-to-right for red or orange pips to spot "
+            "which repos are dragging the org down. Overflow past 50 is shown as "
+            '"(+N more)".'
+        ),
+    ),
+    "weather": (
+        "weather",
+        (
+            'Single-glance forecast of org health. "Sunny" means every repo is '
+            'green; "partly cloudy" means only low/medium findings; "overcast" '
+            "means there is at least one high-severity repo or a failing main CI; "
+            '"stormy" means critical findings or two-plus CI failures. The tail '
+            "lists the worst contributing counts."
+        ),
+    ),
+    "activity": (
+        "activity",
+        (
+            "Seven-day sparkline of your local Claude Code message volume, one bar "
+            "per day. Taller bars mean busier days. The suffix shows the 7-day "
+            "total and the peak day's count; if no Claude usage data is available "
+            'it reads "no recent Claude activity".'
+        ),
+    ),
+    "pr_ages": (
+        "pr ages",
+        (
+            "Composite bar summarising the org's open PRs. The green segment is "
+            '"active" PRs, the red segment is "stale" PRs (as flagged by the '
+            "stale_prs health check), and the dim segment is drafts. Numbers on "
+            "the right are active / stale-count s / drafts-count d."
+        ),
+    ),
+    "team_mix": (
+        "team mix",
+        (
+            "Breakdown of repos by primary team ownership. The bar is segmented "
+            "and coloured per team in proportion to how many repos each team owns; "
+            "the legend underneath lists the top four teams with counts and "
+            'overflow as "+N".'
+        ),
+    ),
+    "usage": (
+        "usage",
+        (
+            "Your AI tool usage against each configured provider's plan limits: "
+            "Claude Code, OpenAI, GitHub Copilot. Each meter shows a progress bar "
+            "coloured by how close you are to the cap, plus tier and percentage. "
+            "Providers that are not configured are hidden."
+        ),
+    ),
+    "check_breakdown": (
+        "failing checks",
+        (
+            "Tally of health-check failures across the whole org, sorted by how "
+            "many repos each check is failing on (top six). The coloured bar is "
+            "proportional to the failing-check count and coloured by the worst "
+            "severity seen for that check. Use this to spot which check is the "
+            "biggest source of pain."
+        ),
+    ),
+    "service_lib": (
+        "service / lib",
+        (
+            "Split of repos into services versus libraries, with a green/red "
+            'tally of how many are fully green ("ok") versus have at least one '
+            'non-ok finding ("err"). A quick sanity check on whether failures '
+            "cluster on one side or the other."
+        ),
+    ),
+    "score_histogram": (
+        "scores",
+        (
+            "Distribution of repo health scores in ten 10-point buckets from 0 to "
+            "100. Taller glyphs mean more repos in that bucket; the left half "
+            "(below 50) is coloured red to make low-scoring clusters obvious. "
+            'The "avg" line underneath is the mean display score across all '
+            "repos."
+        ),
+    ),
+    "recent_errors": (
+        "recent errors",
+        (
+            "The last three errors the dashboard itself captured -- GitHub API "
+            "failures, token problems, rate limits, etc. Each line shows the "
+            "time, source, and truncated message. If the list is empty the "
+            "dashboard has not hit any errors this session."
+        ),
+    ),
+    "leaderboard": (
+        "worst 5",
+        (
+            "The five unhealthiest repos, ranked by score (lower is worse) then "
+            "severity. Each line shows the rank, repo name, display score "
+            "coloured by severity, and the first non-ok finding's summary. Hidden "
+            "entirely when every repo is green."
+        ),
+    ),
+}
+
+
+class WidgetHelpScreen(ModalScreen[None]):
+    """Modal popup that explains what a single top-drawer widget means."""
+
+    BINDINGS = [
+        Binding("escape", "dismiss", "Close"),
+        Binding("question_mark", "dismiss", "Close"),
+    ]
+
+    def __init__(self, widget_id: str) -> None:
+        super().__init__()
+        self._widget_id = widget_id
+        self._title, self._body = WIDGET_HELP.get(
+            widget_id,
+            (
+                widget_id,
+                "No explanation is available for this widget yet.",
+            ),
+        )
+
+    def compose(self):
+        text = Text()
+        text.append(f"{self._title}\n\n", style="bold")
+        text.append(self._body)
+        text.append("\n\npress esc or click outside to close.", style="dim")
+        body = Static(text, id="widget-help-body")
+        yield Container(body, id="help-body")
+
+    @property
+    def widget_id(self) -> str:
+        return self._widget_id
+
+    @property
+    def title_text(self) -> str:
+        return self._title
+
+    @property
+    def body_text(self) -> str:
+        return self._body
+
+    def action_dismiss(self, result: None = None) -> None:  # type: ignore[override]
+        self.dismiss()
+
+    def on_click(self, event: events.Click) -> None:
+        """Right-click anywhere dismisses, matching other modal screens."""
+        if event.button == 3:
+            self.dismiss()

--- a/src/augint_tools/dashboard/widgets/top_drawer.py
+++ b/src/augint_tools/dashboard/widgets/top_drawer.py
@@ -5,8 +5,12 @@ and docks at the top of the screen. When opened it animates its height
 from 0 to N rows, pushing the card grid downward rather than hovering
 over it. This keeps org-wide context and repo cards visible together.
 
-The body is split into a left and right column so the org drawer can
-pack extra nerdy widgets on the right without crowding the main stack.
+The body is split into a left, middle, and right column. Each column is
+composed of one or more "sections" rendered as individual :class:`Static`
+widgets so that clicks can be attributed to a specific section (e.g. the
+activity sparkline vs the weather line). When a section is clicked the
+drawer posts a :class:`TopDrawer.SectionClicked` message carrying the
+section id, which the app uses to open an explanatory modal.
 """
 
 from __future__ import annotations
@@ -14,7 +18,18 @@ from __future__ import annotations
 from rich.text import Text
 from textual import events
 from textual.containers import Container
+from textual.message import Message
 from textual.widgets import Static
+
+# Prefix used for per-section Static widget ids. A section registered with
+# id "activity" becomes a widget with DOM id "top-drawer-section-activity".
+_SECTION_ID_PREFIX = "top-drawer-section-"
+
+# Column container ids.
+_COLUMN_IDS = ("top-drawer-left", "top-drawer-middle", "top-drawer-right")
+
+# Type alias: a column is a list of (section_id, rich_text) pairs.
+Section = tuple[str, Text]
 
 
 class TopDrawer(Container):
@@ -36,22 +51,39 @@ class TopDrawer(Container):
     TopDrawer > #top-drawer-left {
         width: 1fr;
         padding-right: 1;
+        height: auto;
     }
     TopDrawer > #top-drawer-middle {
         width: 1fr;
         padding: 0 1;
+        height: auto;
     }
     TopDrawer > #top-drawer-right {
         width: 1fr;
         padding-left: 1;
+        height: auto;
+    }
+    TopDrawer .top-drawer-section {
+        height: auto;
+        width: 100%;
+    }
+    TopDrawer .top-drawer-section:hover {
+        background: $boost;
     }
     """
 
+    class SectionClicked(Message):
+        """Posted when a user clicks a specific top-drawer section."""
+
+        def __init__(self, section_id: str) -> None:
+            self.section_id = section_id
+            super().__init__()
+
     def __init__(self, id: str = "top-drawer") -> None:
         super().__init__(id=id)
-        self._left = Static("", id="top-drawer-left")
-        self._middle = Static("", id="top-drawer-middle")
-        self._right = Static("", id="top-drawer-right")
+        self._left = Container(id="top-drawer-left")
+        self._middle = Container(id="top-drawer-middle")
+        self._right = Container(id="top-drawer-right")
 
     def compose(self):
         yield self._left
@@ -62,22 +94,44 @@ class TopDrawer(Container):
     def is_open(self) -> bool:
         return self.has_class("open")
 
+    # ------------------------------------------------------------------
+    # Content management
+    # ------------------------------------------------------------------
+
     def set_content(
         self,
-        left: Text,
-        middle: Text | None = None,
-        right: Text | None = None,
+        left: list[Section] | Text,
+        middle: list[Section] | Text | None = None,
+        right: list[Section] | Text | None = None,
     ) -> None:
-        """Update the body without changing open/closed state."""
-        self._left.update(left)
-        self._middle.update(middle if middle is not None else Text(""))
-        self._right.update(right if right is not None else Text(""))
+        """Replace each column's content.
+
+        Accepts either a list of ``(section_id, Text)`` pairs -- preferred --
+        or a single :class:`~rich.text.Text` for backward compatibility. A
+        raw ``Text`` is treated as a one-section column with a stub id.
+        """
+        self._set_column(self._left, _normalise(left))
+        self._set_column(self._middle, _normalise(middle))
+        self._set_column(self._right, _normalise(right))
+
+    def _set_column(self, column: Container, sections: list[Section]) -> None:
+        """Rebuild a column to host exactly ``sections`` in order."""
+        # Remove any existing child widgets before re-mounting.
+        for child in list(column.children):
+            child.remove()
+        for section_id, text in sections:
+            static = Static(
+                text,
+                id=f"{_SECTION_ID_PREFIX}{section_id}",
+                classes="top-drawer-section",
+            )
+            column.mount(static)
 
     def toggle(
         self,
-        left: Text,
-        middle: Text | None = None,
-        right: Text | None = None,
+        left: list[Section] | Text,
+        middle: list[Section] | Text | None = None,
+        right: list[Section] | Text | None = None,
     ) -> None:
         """Open the drawer with the column contents, or close if already open."""
         if self.is_open:
@@ -88,9 +142,9 @@ class TopDrawer(Container):
 
     def open_with(
         self,
-        left: Text,
-        middle: Text | None = None,
-        right: Text | None = None,
+        left: list[Section] | Text,
+        middle: list[Section] | Text | None = None,
+        right: list[Section] | Text | None = None,
     ) -> None:
         self.set_content(left, middle, right)
         self.add_class("open")
@@ -98,6 +152,35 @@ class TopDrawer(Container):
     def close(self) -> None:
         self.remove_class("open")
 
+    # ------------------------------------------------------------------
+    # Input
+    # ------------------------------------------------------------------
+
     def on_click(self, event: events.Click) -> None:
+        # Right-click closes the drawer, matching the other drawers.
         if event.button == 3:
             self.close()
+            return
+        # Map left-clicks to the nearest clicked section id.
+        widget = event.widget
+        section_id: str | None = None
+        while widget is not None and widget is not self:
+            wid = getattr(widget, "id", None)
+            if wid and wid.startswith(_SECTION_ID_PREFIX):
+                section_id = wid[len(_SECTION_ID_PREFIX) :]
+                break
+            widget = getattr(widget, "parent", None)
+        if section_id:
+            # Post the message so the parent screen/app can react (e.g. open
+            # an explanatory modal). Using a Message keeps TopDrawer unaware
+            # of how the app handles the click.
+            self.post_message(self.SectionClicked(section_id))
+
+
+def _normalise(value: list[Section] | Text | None) -> list[Section]:
+    """Coerce the various accepted content types into a list of sections."""
+    if value is None:
+        return []
+    if isinstance(value, Text):
+        return [("legacy", value)] if value.plain else []
+    return list(value)

--- a/tests/unit/test_dashboard.py
+++ b/tests/unit/test_dashboard.py
@@ -2000,3 +2000,119 @@ class TestMultiOrgCLI:
         assert "myuser" in owners
         assert "org-alpha" in owners
         assert "org-beta" not in owners
+
+
+# ---------------------------------------------------------------------------
+# Widget help modal + top-drawer click routing
+# ---------------------------------------------------------------------------
+
+
+class TestWidgetHelpScreen:
+    """Unit tests for the per-widget help modal (``i``-drawer click popup)."""
+
+    def test_screen_stores_id_and_renders_known_widget(self):
+        from augint_tools.dashboard.screens.widget_help import (
+            WIDGET_HELP,
+            WidgetHelpScreen,
+        )
+
+        screen = WidgetHelpScreen("activity")
+        assert screen.widget_id == "activity"
+        assert screen.title_text == WIDGET_HELP["activity"][0]
+        assert screen.body_text == WIDGET_HELP["activity"][1]
+
+    def test_unknown_widget_id_falls_back_to_placeholder(self):
+        from augint_tools.dashboard.screens.widget_help import WidgetHelpScreen
+
+        screen = WidgetHelpScreen("this-id-does-not-exist")
+        assert screen.title_text == "this-id-does-not-exist"
+        assert "No explanation" in screen.body_text
+
+    def test_widget_help_covers_every_drawer_section_id(self):
+        """Every section id produced by the drawer must have an entry in
+        WIDGET_HELP, otherwise a click would open an empty modal."""
+        from augint_tools.dashboard.screens.widget_help import WIDGET_HELP
+
+        # Section ids that are structural (empty/header/hint) and intentionally
+        # not documented because they don't represent real widgets.
+        structural = {"empty", "header", "hint"}
+
+        app = DashboardApp(repos=[], skip_refresh=True, org_name="acme")
+        crit = HealthCheckResult(check_name="broken_ci", severity=Severity.CRITICAL, summary="boom")
+        app.state.healths = [
+            _health(name="broken", full_name="org/a", checks=[crit]),
+            _health(name="ok", full_name="org/b"),
+        ]
+        app.state.health_by_name = {h.status.full_name: h for h in app.state.healths}
+        app.state.repo_teams = {
+            "org/a": RepoTeamInfo(primary="platform", all=("platform",)),
+            "org/b": RepoTeamInfo(primary="platform", all=("platform",)),
+        }
+        app.state.team_labels = {"platform": "Platform"}
+
+        async def collect() -> set[str]:
+            async with app.run_test() as pilot:
+                await pilot.pause()
+                assert app._main is not None
+                ids: set[str] = set()
+                ids.update(sid for sid, _ in app._main._org_drawer_left_sections())
+                ids.update(sid for sid, _ in app._main._org_drawer_middle_sections())
+                ids.update(sid for sid, _ in app._main._org_drawer_right_sections())
+                return ids
+
+        ids = asyncio.run(collect())
+        meaningful = ids - structural
+        missing = meaningful - set(WIDGET_HELP)
+        assert not missing, f"WIDGET_HELP missing entries for: {sorted(missing)}"
+
+    @tui
+    def test_drawer_sections_have_stable_widget_ids(self):
+        """After opening the drawer, each section becomes a Static with a
+        DOM id prefixed ``top-drawer-section-<key>`` so clicks can be
+        attributed to the correct widget."""
+
+        async def run():
+            app = DashboardApp(repos=[], skip_refresh=True, org_name="acme")
+            app.state.healths = [_health(full_name="org/a")]
+            app.state.health_by_name = {"org/a": app.state.healths[0]}
+            async with app.run_test() as pilot:
+                await pilot.pause()
+                assert app._main is not None
+                app.action_toggle_org()
+                await pilot.pause()
+                drawer = app._main._top_drawer
+                mounted_ids = {
+                    child.id
+                    for column in (drawer._left, drawer._middle, drawer._right)
+                    for child in column.children
+                    if child.id
+                }
+                # At least one meaningful section id is present.
+                assert any(wid.startswith("top-drawer-section-") for wid in mounted_ids)
+
+        asyncio.run(run())
+
+    @tui
+    def test_section_click_opens_widget_help_modal(self):
+        """Posting a SectionClicked message pushes the help modal on top
+        of the app, carrying the section id."""
+
+        async def run():
+            from augint_tools.dashboard.screens.widget_help import WidgetHelpScreen
+            from augint_tools.dashboard.widgets.top_drawer import TopDrawer
+
+            app = DashboardApp(repos=[], skip_refresh=True, org_name="acme")
+            app.state.healths = [_health(full_name="org/a")]
+            app.state.health_by_name = {"org/a": app.state.healths[0]}
+            async with app.run_test() as pilot:
+                await pilot.pause()
+                assert app._main is not None
+                app.action_toggle_org()
+                await pilot.pause()
+                app._main.on_top_drawer_section_clicked(TopDrawer.SectionClicked("activity"))
+                await pilot.pause()
+                top = app.screen
+                assert isinstance(top, WidgetHelpScreen)
+                assert top.widget_id == "activity"
+
+        asyncio.run(run())


### PR DESCRIPTION
## Summary
- Splits each `TopDrawer` column into per-section `Static` widgets with stable ids (`top-drawer-section-<key>`) so clicks can be routed to the section under the cursor.
- Adds `WidgetHelpScreen(ModalScreen)` + `WIDGET_HELP` dict with explanations for 14 widgets (activity, ci matrix, pr ages, check breakdown, recent errors, leaderboard, system, etc.).
- Left-click on a section opens the help modal; right-click still closes the drawer.
- Copy reflects what the code actually does (e.g. activity is a 7-day sparkline, not 24h; pr ages is a composite bar, not a histogram).

## Test plan
- [x] `uv run pytest tests/unit/test_dashboard.py` (159 passed, 5 new)
- [x] `uv run pytest` (482 passed)
- [x] `uv run ruff check src/ tests/` / `uv run mypy src/` / `uv run pre-commit run --all-files`
- [ ] Manual: open dashboard, click each section, verify modal content matches the widget