### PR TITLE
feat(dashboard): color CI matrix names by team and link to Actions

### DIFF
--- a/src/augint_tools/dashboard/app.py
+++ b/src/augint_tools/dashboard/app.py
@@ -471,13 +471,23 @@ class MainScreen(Screen[None]):
     # ------------------------------------------------------------------
 
     def _append_ci_matrix(self, t: Text, healths: list, spec) -> None:
-        """Per-repo CI status as coloured dots (dev + main if service)."""
+        """Per-repo CI status as coloured dots (dev + main if service).
+
+        Repo names are rendered in their team's accent colour and turned into
+        terminal hyperlinks (OSC 8) pointing at the repo's GitHub Actions page.
+        """
         t.append("ci matrix\n", style="bold")
         shown = healths[:24]
+        known_teams = list(self._state.team_labels)
         for h in shown:
             status = h.status
             name = status.name[:16]
-            t.append(f"  {name:<16} ")
+            team_info = self._state.repo_teams.get(status.full_name)
+            accent = team_accent(team_info.primary, known_teams) if team_info else "#808080"
+            link_url = f"https://github.com/{status.full_name}/actions"
+            t.append("  ")
+            t.append(f"{name:<16}", style=f"{accent} link {link_url}")
+            t.append(" ")
             if status.is_service and status.dev_status:
                 t.append("\u25cf", style=self._ci_dot_style(status.dev_status, spec))
                 t.append(" ")

--- a/tests/unit/test_dashboard.py
+++ b/tests/unit/test_dashboard.py
@@ -1279,6 +1279,59 @@ class TestAppMisc:
         asyncio.run(run())
 
     @tui
+    def test_ci_matrix_applies_team_accent_and_link(self):
+        """The top-drawer CI matrix colours repo names by team accent and
+        wraps each as a hyperlink to that repo's Actions page."""
+
+        async def run():
+            app = DashboardApp(repos=[], skip_refresh=True, org_name="nerds")
+            app.state.team_labels = {
+                "platform": "Platform",
+                "growth": "Growth",
+                state.UNASSIGNED_TEAM: "Unassigned",
+            }
+            app.state.repo_teams = {
+                "org/a": RepoTeamInfo(primary="platform", all=("platform",)),
+                "org/b": RepoTeamInfo(primary="growth", all=("growth",)),
+                # deliberately missing entry for org/c -> falls back to grey
+            }
+            app.state.healths = [
+                _health(name="repo-a", full_name="org/a"),
+                _health(name="repo-b", full_name="org/b"),
+                _health(name="repo-c", full_name="org/c"),
+            ]
+            app.state.health_by_name = {h.status.full_name: h for h in app.state.healths}
+            async with app.run_test() as pilot:
+                await pilot.pause()
+                assert app._main is not None
+                content = app._main._org_drawer_content()
+                plain = content.plain
+                assert "ci matrix" in plain
+                # Collect spans that styled each repo name.
+                name_spans: dict[str, str] = {}
+                for span in content.spans:
+                    rendered = plain[span.start : span.end]
+                    stripped = rendered.strip()
+                    if stripped in {"repo-a", "repo-b", "repo-c"}:
+                        name_spans[stripped] = str(span.style)
+                for repo in ("repo-a", "repo-b", "repo-c"):
+                    assert repo in name_spans, f"no styled span for {repo}"
+                    style = name_spans[repo]
+                    assert f"link https://github.com/org/{repo[-1]}/actions" in style
+
+                known = list(app.state.team_labels)
+                platform_accent = team_accent("platform", known)
+                growth_accent = team_accent("growth", known)
+                assert platform_accent in name_spans["repo-a"]
+                assert growth_accent in name_spans["repo-b"]
+                # repo-c has no team entry -> default grey.
+                assert "#808080" in name_spans["repo-c"]
+                # Different teams should produce different accents.
+                assert platform_accent != growth_accent
+
+        asyncio.run(run())
+
+    @tui
     def test_usage_block_renders_meter(self):
         async def run():
             from augint_tools.dashboard.usage import UsageStats


### PR DESCRIPTION
## Summary
- `_append_ci_matrix` now looks up each health's `status.full_name` in `self._state.repo_teams` and applies the corresponding `team_accent(primary, known_teams)` color; falls back to `#808080` when there's no team info.
- Each repo name is rendered as a clickable OSC 8 hyperlink to `https://github.com/{full_name}/actions`, so operators can jump straight to CI from the drawer.
- Dots and the `+N more` overflow line are unchanged.

## Test plan
- [x] New TUI test `test_ci_matrix_applies_team_accent_and_link` asserts accent + link per repo, including the no-team fallback
- [x] `uv run pytest` (478 passed)
- [x] `uv run ruff check src/ tests/` / `uv run mypy src/` / `uv run pre-commit run --all-files`
- [ ] Manual: render dashboard in a terminal that supports OSC 8 links, confirm colors and click behavior