### PR TITLE
fix(dashboard): restore Claude usage widget with 5h and 7d windows

### DIFF
--- a/src/augint_tools/dashboard/app.py
+++ b/src/augint_tools/dashboard/app.py
@@ -826,29 +826,84 @@ class MainScreen(Screen[None]):
             return
         t.append("usage\n", style="bold")
         for stats in configured:
-            t.append(f"  {stats.display_name:<12}")
-            fraction = stats.usage_fraction
-            if fraction is not None and stats.limit:
-                bar = _progress_bar(fraction, 14)
-                color = _usage_status_color(stats.status, spec)
-                t.append(bar, style=color)
+            if stats.provider == "claude_code":
+                self._append_claude_usage_rows(t, stats, spec)
+            else:
+                self._append_single_usage_row(t, stats, spec)
+        t.append("\n")
+
+    def _append_single_usage_row(self, t: Text, stats, spec) -> None:
+        """Render a one-line provider row (used for OpenAI / Copilot)."""
+        t.append(f"  {stats.display_name:<12}")
+        fraction = stats.usage_fraction
+        if fraction is not None and stats.limit:
+            bar = _progress_bar(fraction, 14)
+            color = _usage_status_color(stats.status, spec)
+            t.append(bar, style=color)
+            pct = int(fraction * 100)
+            t.append(f" {pct}%", style="dim")
+            if stats.tier:
+                t.append(f" {stats.tier}", style="dim")
+        elif stats.status == "empty":
+            t.append("no data", style="dim")
+        elif stats.status == "unknown":
+            if stats.tier:
+                t.append(f"{stats.tier}", style="dim")
+            elif stats.note:
+                t.append(stats.note, style="dim")
+        else:
+            t.append(f"{stats.messages} msgs", style="dim")
+            if stats.tier:
+                t.append(f" {stats.tier}", style="dim")
+        t.append("\n")
+
+    def _append_claude_usage_rows(self, t: Text, stats, spec) -> None:
+        """Render Claude with both 5-hour and 7-day rolling windows.
+
+        A single provider row is not enough context on a Max plan -- the user
+        needs to see both the session window (5h) and the weekly window (7d)
+        so they can tell which one they're about to hit. We render a header
+        line with the tier label, then an indented line per window.
+        """
+        t.append(f"  {stats.display_name:<12}", style="bold")
+        if stats.tier:
+            t.append(f"{stats.tier}", style="dim")
+        t.append("\n")
+
+        windows = (
+            ("5h", stats.hour5_used, stats.hour5_limit, stats.hour5_fraction),
+            ("7d", stats.week7_used, stats.week7_limit, stats.week7_fraction),
+        )
+        color = _usage_status_color(stats.status, spec)
+        rendered_any = False
+        for label, used, win_limit, fraction in windows:
+            if used is None and win_limit is None:
+                continue
+            rendered_any = True
+            t.append(f"    {label:<3}")
+            if fraction is not None:
+                t.append(_progress_bar(fraction, 10), style=color)
                 pct = int(fraction * 100)
                 t.append(f" {pct}%", style="dim")
-                if stats.tier:
-                    t.append(f" {stats.tier}", style="dim")
-            elif stats.status == "empty":
+                if used is not None and win_limit:
+                    t.append(f"  {used}/{win_limit}", style="dim")
+            elif used is not None and used > 0:
+                # Known count but unknown limit -- show the raw number.
+                t.append(f"{used} msgs", style="dim")
+            else:
                 t.append("no data", style="dim")
-            elif stats.status == "unknown":
-                if stats.tier:
-                    t.append(f"{stats.tier}", style="dim")
-                elif stats.note:
-                    t.append(stats.note, style="dim")
+            t.append("\n")
+
+        if not rendered_any:
+            # Extreme fallback: no window data at all.
+            t.append("    ")
+            if stats.status == "empty":
+                t.append("no data", style="dim")
+            elif stats.note:
+                t.append(stats.note, style="dim")
             else:
                 t.append(f"{stats.messages} msgs", style="dim")
-                if stats.tier:
-                    t.append(f" {stats.tier}", style="dim")
             t.append("\n")
-        t.append("\n")
 
     def _append_system_block(self, t: Text, spec) -> None:
         """Host-system meters: RAM (always, when /proc/meminfo is readable)

--- a/src/augint_tools/dashboard/usage.py
+++ b/src/augint_tools/dashboard/usage.py
@@ -17,8 +17,25 @@ from dataclasses import dataclass, field
 from datetime import UTC, date, datetime, timedelta
 from pathlib import Path
 
-# Rough per-tier weekly message estimates for Claude subscription tiers.
-# These are conservative/approximate; users can still see raw counts when unknown.
+# Approximate Claude subscription caps. Anthropic publishes these in messages
+# per rolling window and they change periodically -- keep them here so they're
+# easy to adjust, and fall back to "no bar, raw count only" when the tier is
+# unknown.
+#
+# Sources (checked 2026-04; re-verify when Anthropic updates the help centre):
+#   https://support.anthropic.com/en/articles/8324991-about-claude-pro-and-team-plans
+#   https://support.anthropic.com/en/articles/11145838-using-claude-code-with-your-subscription
+#
+# The 5-hour window is the active-session cap (resets 5 hours after the first
+# message in a session). The 7-day window is the rolling weekly cap.
+_CLAUDE_TIER_5H_LIMITS: dict[str, int] = {
+    "default_claude_pro": 45,
+    "default_claude_max_5x": 225,
+    "default_claude_max_20x": 900,
+    "default_claude_team": 225,
+    "default_claude_enterprise": 900,
+}
+
 _CLAUDE_TIER_WEEKLY_LIMITS: dict[str, int] = {
     "default_claude_pro": 1500,
     "default_claude_max_5x": 7500,
@@ -26,6 +43,10 @@ _CLAUDE_TIER_WEEKLY_LIMITS: dict[str, int] = {
     "default_claude_team": 10000,
     "default_claude_enterprise": 50000,
 }
+
+# Legacy default weekly window used when a caller doesn't specify one.
+_DEFAULT_WINDOW_DAYS = 7
+_FIVE_HOUR_SECONDS = 5 * 3600
 
 
 @dataclass(frozen=True)
@@ -51,6 +72,14 @@ class UsageStats:
     error: str | None = None
     # Free-form note shown under the progress bar (e.g. data source).
     note: str | None = None
+    # Claude-specific: messages and limits in the rolling 5-hour session window.
+    hour5_used: int | None = None
+    hour5_limit: int | None = None
+    # Claude-specific: messages and limits in the rolling 7-day window.
+    # These mirror ``messages`` / ``limit`` but are named explicitly so the
+    # widget can render both windows side by side.
+    week7_used: int | None = None
+    week7_limit: int | None = None
 
     @property
     def usage_fraction(self) -> float | None:
@@ -58,6 +87,20 @@ class UsageStats:
         if self.limit is None or self.limit <= 0:
             return None
         return min(1.0, self.messages / self.limit)
+
+    @property
+    def hour5_fraction(self) -> float | None:
+        """5-hour window usage as fraction of limit, or None when unknown."""
+        if self.hour5_used is None or self.hour5_limit is None or self.hour5_limit <= 0:
+            return None
+        return min(1.0, self.hour5_used / self.hour5_limit)
+
+    @property
+    def week7_fraction(self) -> float | None:
+        """7-day window usage as fraction of limit, or None when unknown."""
+        if self.week7_used is None or self.week7_limit is None or self.week7_limit <= 0:
+            return None
+        return min(1.0, self.week7_used / self.week7_limit)
 
     @property
     def time_elapsed_fraction(self) -> float | None:
@@ -82,14 +125,17 @@ class _ClaudeSessionAggregate:
     source: str = "session-meta"
 
 
-def _read_claude_sessions(window_days: int = 7) -> _ClaudeSessionAggregate:
-    """Aggregate session-meta files from the last N days, tracking oldest message."""
+def _read_claude_sessions(
+    window_days: int = 7, cutoff: datetime | None = None
+) -> _ClaudeSessionAggregate:
+    """Aggregate session-meta files newer than ``cutoff`` (or last ``window_days``)."""
     agg = _ClaudeSessionAggregate()
     meta_dir = Path.home() / ".claude" / "usage-data" / "session-meta"
     if not meta_dir.is_dir():
         return agg
 
-    cutoff = datetime.now(UTC) - timedelta(days=window_days)
+    if cutoff is None:
+        cutoff = datetime.now(UTC) - timedelta(days=window_days)
 
     for path in meta_dir.glob("*.json"):
         try:
@@ -116,7 +162,9 @@ def _read_claude_sessions(window_days: int = 7) -> _ClaudeSessionAggregate:
     return agg
 
 
-def _read_claude_history(window_days: int = 7) -> _ClaudeSessionAggregate:
+def _read_claude_history(
+    window_days: int = 7, cutoff: datetime | None = None
+) -> _ClaudeSessionAggregate:
     """Parse ``~/.claude/history.jsonl`` for recent message activity.
 
     Claude Code writes one line per user/assistant turn to history.jsonl with
@@ -130,7 +178,9 @@ def _read_claude_history(window_days: int = 7) -> _ClaudeSessionAggregate:
     if not hist_path.is_file():
         return agg
 
-    cutoff_ms = int((datetime.now(UTC) - timedelta(days=window_days)).timestamp() * 1000)
+    if cutoff is None:
+        cutoff = datetime.now(UTC) - timedelta(days=window_days)
+    cutoff_ms = int(cutoff.timestamp() * 1000)
     session_ids: set[str] = set()
     oldest_ms: int | None = None
     count = 0
@@ -210,17 +260,60 @@ def _read_claude_subscription() -> dict[str, str | None]:
         return {"subscription": None, "tier": None}
 
 
+def _read_claude_window(
+    cutoff: datetime, *, allow_stats_cache: bool = True
+) -> _ClaudeSessionAggregate:
+    """Aggregate Claude activity newer than ``cutoff`` from the freshest source.
+
+    Tries session-meta first, then history.jsonl, and finally stats-cache
+    (day-granularity, so only useful for multi-day windows -- callers with a
+    sub-day window should pass ``allow_stats_cache=False``).
+    """
+    agg = _read_claude_sessions(cutoff=cutoff)
+    if agg.messages == 0 and agg.sessions == 0:
+        agg = _read_claude_history(cutoff=cutoff)
+    if allow_stats_cache and agg.messages == 0 and agg.sessions == 0:
+        # stats-cache is day-granular; the window_days arg is what it expects.
+        # The caller only enables this for windows that are >= 1 day.
+        days = max(1, int((datetime.now(UTC) - cutoff).total_seconds() // 86400))
+        agg = _read_claude_stats_cache(window_days=days)
+    return agg
+
+
+def _derive_status(messages: int, sessions: int, limit: int | None) -> str:
+    """Map raw counts + limit to a status bucket used by the renderer."""
+    if messages == 0 and sessions == 0:
+        return "empty"
+    if limit is not None and limit > 0:
+        fraction = messages / limit
+        if fraction >= 0.9:
+            return "critical"
+        if fraction >= 0.7:
+            return "warning"
+    return "ok"
+
+
 def fetch_claude_code_usage(
-    window_days: int = 7,
+    window_days: int = _DEFAULT_WINDOW_DAYS,
     limit: int | None = None,
 ) -> UsageStats:
-    """Claude Code activity from local session-meta (or stats-cache fallback)."""
+    """Claude Code activity with both 5-hour and 7-day rolling windows.
+
+    Claude Max caps apply over two rolling windows: a 5-hour active-session
+    window and a 7-day weekly window. This reads the local session-meta and
+    history.jsonl (stats-cache as a day-granular fallback for the weekly
+    window only) and returns both usages side by side.
+
+    ``window_days`` controls the longer (weekly) window; it stays parametric
+    so test fixtures can shrink it. The 5-hour window is fixed at 5 hours.
+    """
+    now = datetime.now(UTC)
+    week_cutoff = now - timedelta(days=window_days)
+    hour5_cutoff = now - timedelta(seconds=_FIVE_HOUR_SECONDS)
+
     try:
-        agg = _read_claude_sessions(window_days)
-        if agg.messages == 0 and agg.sessions == 0:
-            agg = _read_claude_history(window_days)
-        if agg.messages == 0 and agg.sessions == 0:
-            agg = _read_claude_stats_cache(window_days)
+        week_agg = _read_claude_window(week_cutoff)
+        hour5_agg = _read_claude_window(hour5_cutoff, allow_stats_cache=False)
         sub = _read_claude_subscription()
     except Exception:
         return UsageStats(
@@ -232,26 +325,33 @@ def fetch_claude_code_usage(
         )
 
     tier = sub.get("tier")
-    if limit is None and tier:
-        limit = _CLAUDE_TIER_WEEKLY_LIMITS.get(tier)
+    week_limit = limit
+    if week_limit is None and tier:
+        week_limit = _CLAUDE_TIER_WEEKLY_LIMITS.get(tier)
+    hour5_limit: int | None = None
+    if tier:
+        hour5_limit = _CLAUDE_TIER_5H_LIMITS.get(tier)
 
     window_total_seconds = window_days * 86400
     time_remaining_seconds: int | None = None
-    if agg.oldest_in_window is not None:
-        age = (datetime.now(UTC) - agg.oldest_in_window).total_seconds()
+    if week_agg.oldest_in_window is not None:
+        age = (now - week_agg.oldest_in_window).total_seconds()
         time_remaining_seconds = max(0, int(window_total_seconds - age))
     else:
         time_remaining_seconds = window_total_seconds
 
-    status = "ok"
-    if agg.messages == 0 and agg.sessions == 0:
+    # The overall status is driven by the tighter of the two windows so the
+    # widget's severity colour matches the window the user is actually about
+    # to hit first.
+    week_status = _derive_status(week_agg.messages, week_agg.sessions, week_limit)
+    hour5_status = _derive_status(hour5_agg.messages, hour5_agg.sessions, hour5_limit)
+    severity_order = {"empty": 0, "ok": 1, "warning": 2, "critical": 3}
+    status = (
+        hour5_status if severity_order[hour5_status] >= severity_order[week_status] else week_status
+    )
+    # If both windows are empty, keep the "empty" label.
+    if week_agg.messages == 0 and week_agg.sessions == 0 and hour5_agg.messages == 0:
         status = "empty"
-    elif limit is not None and limit > 0:
-        fraction = agg.messages / limit
-        if fraction >= 0.9:
-            status = "critical"
-        elif fraction >= 0.7:
-            status = "warning"
 
     tier_label = None
     if sub.get("subscription"):
@@ -264,24 +364,28 @@ def fetch_claude_code_usage(
     note: str | None = None
     if status == "empty":
         note = "no local activity tracked (account usage is not exposed via SSO)"
-    elif agg.source == "stats-cache":
+    elif week_agg.source == "stats-cache":
         note = "from stats-cache (session-meta empty)"
 
     return UsageStats(
         provider="claude_code",
         display_name="Claude Code",
         window_days=window_days,
-        messages=agg.messages,
-        sessions=agg.sessions,
-        tool_calls=agg.tool_calls,
-        input_tokens=agg.input_tokens,
-        output_tokens=agg.output_tokens,
-        limit=limit,
+        messages=week_agg.messages,
+        sessions=week_agg.sessions,
+        tool_calls=week_agg.tool_calls,
+        input_tokens=week_agg.input_tokens,
+        output_tokens=week_agg.output_tokens,
+        limit=week_limit,
         time_remaining_seconds=time_remaining_seconds,
         window_total_seconds=window_total_seconds,
         tier=tier_label,
         status=status,
         note=note,
+        hour5_used=hour5_agg.messages,
+        hour5_limit=hour5_limit,
+        week7_used=week_agg.messages,
+        week7_limit=week_limit,
     )
 
 

--- a/tests/unit/test_dashboard.py
+++ b/tests/unit/test_dashboard.py
@@ -1294,6 +1294,10 @@ class TestAppMisc:
                     limit=1000,
                     status="ok",
                     tier="Pro 5x",
+                    hour5_used=10,
+                    hour5_limit=50,
+                    week7_used=500,
+                    week7_limit=1000,
                 ),
                 UsageStats(
                     provider="openai",
@@ -1307,7 +1311,11 @@ class TestAppMisc:
                 assert app._main is not None
                 plain = app._main._org_drawer_middle_content().plain
                 assert "Claude Code" in plain
-                assert "50%" in plain
+                # Both rolling windows are surfaced with labels + percentages.
+                assert "5h" in plain
+                assert "7d" in plain
+                assert "20%" in plain  # 10/50 in 5h window
+                assert "50%" in plain  # 500/1000 in 7d window
                 # The progress bar uses full-block and light-shade characters.
                 assert "\u2588" in plain
                 assert "\u2591" in plain
@@ -1433,6 +1441,88 @@ class TestAppMisc:
         # Buckets API hits the same file; total equals recent entries.
         buckets = panel_usage.claude_daily_message_buckets(window_days=7)
         assert sum(buckets) == 2
+
+    def test_panel_usage_claude_both_windows_from_history(self, tmp_path, monkeypatch):
+        """fetch_claude_code_usage returns distinct 5h and 7d window counts."""
+        import json
+        from datetime import UTC, datetime, timedelta
+
+        from augint_tools.dashboard import usage as panel_usage
+
+        home = tmp_path
+        claude_dir = home / ".claude"
+        claude_dir.mkdir()
+        # Credentials expose the rateLimitTier so both limits resolve.
+        (claude_dir / ".credentials.json").write_text(
+            json.dumps(
+                {
+                    "claudeAiOauth": {
+                        "subscriptionType": "max",
+                        "rateLimitTier": "default_claude_max_20x",
+                    }
+                }
+            )
+        )
+        hist = claude_dir / "history.jsonl"
+        now = datetime.now(UTC)
+        # Three entries inside the 5h window + three outside 5h but inside 7d.
+        inside_5h = [now - timedelta(minutes=30), now - timedelta(hours=1), now]
+        outside_5h = [now - timedelta(hours=8), now - timedelta(days=2), now - timedelta(days=4)]
+        stale = [now - timedelta(days=30)]
+        lines = []
+        for idx, ts in enumerate(inside_5h + outside_5h + stale):
+            ms = int(ts.timestamp() * 1000)
+            lines.append(json.dumps({"timestamp": ms, "sessionId": f"s{idx}", "display": "/x"}))
+        hist.write_text("\n".join(lines))
+        monkeypatch.setattr(panel_usage.Path, "home", classmethod(lambda cls: home))
+
+        stats = panel_usage.fetch_claude_code_usage()
+        assert stats.provider == "claude_code"
+        # 5h window: 3 entries.
+        assert stats.hour5_used == 3
+        # 7d window: 6 entries (3 inside 5h + 3 outside 5h but inside 7d).
+        assert stats.week7_used == 6
+        # Both limits resolved from the tier table.
+        assert stats.hour5_limit == panel_usage._CLAUDE_TIER_5H_LIMITS["default_claude_max_20x"]
+        assert stats.week7_limit == panel_usage._CLAUDE_TIER_WEEKLY_LIMITS["default_claude_max_20x"]
+        # Fractions come out > 0 and <= 1.
+        assert stats.hour5_fraction is not None and 0 < stats.hour5_fraction <= 1.0
+        assert stats.week7_fraction is not None and 0 < stats.week7_fraction <= 1.0
+
+    def test_panel_usage_claude_unknown_tier_leaves_limits_none(self, tmp_path, monkeypatch):
+        """Unknown subscription tier => no bar, raw counts still populated."""
+        import json
+        from datetime import UTC, datetime
+
+        from augint_tools.dashboard import usage as panel_usage
+
+        home = tmp_path
+        claude_dir = home / ".claude"
+        claude_dir.mkdir()
+        (claude_dir / ".credentials.json").write_text(
+            json.dumps(
+                {
+                    "claudeAiOauth": {
+                        "subscriptionType": "mystery",
+                        "rateLimitTier": "some_new_tier_we_dont_know",
+                    }
+                }
+            )
+        )
+        hist = claude_dir / "history.jsonl"
+        now_ms = int(datetime.now(UTC).timestamp() * 1000)
+        hist.write_text(json.dumps({"timestamp": now_ms, "sessionId": "s1", "display": "/x"}))
+        monkeypatch.setattr(panel_usage.Path, "home", classmethod(lambda cls: home))
+
+        stats = panel_usage.fetch_claude_code_usage()
+        # Raw counts are still filled, but limits stay None so the widget
+        # renders the number without a bogus bar.
+        assert stats.hour5_used == 1
+        assert stats.week7_used == 1
+        assert stats.hour5_limit is None
+        assert stats.week7_limit is None
+        assert stats.hour5_fraction is None
+        assert stats.week7_fraction is None
 
     def test_panel_usage_openai_unconfigured_clear_message(self, monkeypatch, tmp_path):
         """Without env/keyring/config, OpenAI reports the SSO-less hint clearly."""


### PR DESCRIPTION
## Summary
- Adds a 5-hour session window alongside the existing 7-day rolling window for Claude Code usage, since Max-plan users typically hit the 5h cap first and a single window lacked context.
- New `_CLAUDE_TIER_5H_LIMITS` table (Pro=45, Max-5x=225, Max-20x=900, Team=225, Enterprise=900) with an inline citation comment and re-verify date.
- `UsageStats` extended with `hour5_used`/`hour5_limit`/`week7_used`/`week7_limit` and companion fraction properties. Overall status uses whichever window has higher severity.
- `_append_usage_block` split so Claude gets its own two-line renderer (`5h`/`7d` rows); OpenAI/Copilot still use the single-line path.
- Unknown rateLimitTier leaves limits `None` and falls back to raw counts (no bogus bar).

## Caveat
- The 5h/7d limit constants are best-effort from Anthropic help docs as of 2026-04 and should be treated as approximate; update them if Anthropic changes quotas.

## Test plan
- [x] `uv run pytest` (479 passed), including two new tests for dual-window parsing and unknown-tier fallback
- [x] `uv run ruff check src/ tests/` / `uv run mypy src/` / `uv run pre-commit run --all-files`
- [ ] Manual: run dashboard on a Max plan, confirm both 5h and 7d bars display with sensible percentages