### PR TITLE
fix(dashboard): staleness indicator, live filters, prevent click-trap modal

### DIFF
--- a/src/augint_tools/dashboard/_data.py
+++ b/src/augint_tools/dashboard/_data.py
@@ -183,6 +183,29 @@ def load_health_cache(
         return {}
 
 
+def load_cache_timestamp() -> datetime | None:
+    """Return the timestamp of the cached health data, or ``None``.
+
+    Used by the dashboard to seed ``last_refresh_at`` when bootstrapping
+    from disk, so the staleness indicator ("updated Xm ago") shows a real
+    value from the first paint instead of going blank until the first
+    fresh refresh completes.
+    """
+    if not CACHE_FILE.exists():
+        return None
+    try:
+        data = json.loads(CACHE_FILE.read_text())
+        ts = data.get("health_ts")
+        if not ts:
+            return None
+        parsed = datetime.fromisoformat(ts)
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=UTC)
+        return parsed.astimezone(UTC)
+    except (json.JSONDecodeError, TypeError, KeyError, ValueError):
+        return None
+
+
 # ---------------------------------------------------------------------------
 # Data fetching
 # ---------------------------------------------------------------------------

--- a/src/augint_tools/dashboard/app.py
+++ b/src/augint_tools/dashboard/app.py
@@ -176,9 +176,9 @@ class OrgDrawerHeader(Container):
     }
     OrgDrawerHeader > #hdr-countdown {
         width: auto;
-        max-width: 20;
+        max-width: 24;
         padding: 0 1;
-        color: #8b8b9a;
+        color: #d0d0d8;
         overflow: hidden;
     }
     """
@@ -283,8 +283,16 @@ class MainScreen(Screen[None]):
             card.apply_flash_phase(phase, window_seconds=window_seconds)
 
     def _countdown_text(self) -> str:
-        """Format the right-header countdown -- short and quiet on purpose."""
+        """Format the right-header countdown.
+
+        Prefers the loading / refreshing state so users have an
+        unmistakable "we're working on it" indicator during the 20-30
+        second first fetch.  Otherwise shows the time until the next
+        auto-refresh.
+        """
         state = self._state
+        if state.is_refreshing and state.last_refresh_at is None:
+            return "loading data..."
         if state.is_refreshing:
             return "refreshing..."
         if state.next_refresh_at is None:
@@ -294,8 +302,8 @@ class MainScreen(Screen[None]):
             return "next: now"
         if remaining >= 60:
             m, s = divmod(remaining, 60)
-            return f"next: {m}m{s:02d}s"
-        return f"next: {remaining}s"
+            return f"next refresh: {m}m{s:02d}s"
+        return f"next refresh: {remaining}s"
 
     def _rebuild_cards(self) -> None:
         theme_spec = get_theme(self._state.theme_name)
@@ -1250,11 +1258,19 @@ class DashboardApp(App[None]):
         self._refresh_usage()
 
         if self._repos and not self._skip_refresh:
-            # Seed the countdown before the first worker lands so the status
-            # bar shows "next refresh in ..." from the first paint.
+            # Seed the countdown before the first worker lands so the
+            # status bar shows "next refresh in ..." from paint zero.
+            # _trigger_refresh also sets next_refresh_at, but seeding
+            # here keeps the behaviour visible even when _trigger_refresh
+            # is mocked out in tests.
             self.state.next_refresh_at = datetime.now(UTC) + timedelta(
                 seconds=self._refresh_seconds
             )
+            # Trigger the first refresh immediately.  _trigger_refresh
+            # flips ``is_refreshing`` to True synchronously so the first
+            # StatusBar paint (driven by the tick 1s later) shows
+            # "loading data..." / "refreshing..." rather than going blank
+            # for the 20-30s the initial GitHub fetch takes.
             self.set_interval(self._refresh_seconds, self._trigger_refresh)
             self._trigger_refresh()
 
@@ -1601,8 +1617,10 @@ class DashboardApp(App[None]):
         def _on_dismiss(selected: set[str] | None) -> None:
             if selected is None:
                 return
+            # ``FilterChanged`` has already applied the selection live;
+            # final state equals ``selected`` here, so we just persist
+            # and announce it without doing another rerender pass.
             self.state.active_filters = selected
-            self._rerender()
             self._save_prefs()
             count = len(visible_healths(self.state))
             n = len(selected)
@@ -1610,6 +1628,16 @@ class DashboardApp(App[None]):
             self.notify(f"filter: {label} -- {count} repos", timeout=2)
 
         self.push_screen(FilterPanel(self.state), callback=_on_dismiss)
+
+    def on_filter_panel_filter_changed(self, message: FilterPanel.FilterChanged) -> None:
+        """Apply filter-panel selections live, without waiting for dismiss.
+
+        Without this handler the cards only re-filter when the panel
+        closes -- users watching the list behind the panel see nothing
+        happen and assume the app has hung.
+        """
+        self.state.active_filters = set(message.selected)
+        self._rerender()
 
     def action_toggle_workspace(self) -> None:
         mode = "no-workspace"

--- a/src/augint_tools/dashboard/screens/filter_panel.py
+++ b/src/augint_tools/dashboard/screens/filter_panel.py
@@ -1,4 +1,10 @@
-"""FilterPanel -- multi-select filter overlay."""
+"""FilterPanel -- multi-select filter overlay.
+
+Selections apply live -- each toggle posts :class:`FilterChanged` so the
+main screen can rebuild the grid immediately.  The panel is still
+dismissible with ``escape``/``f``; we return the final selection set
+from ``dismiss`` so callers that want the list have it.
+"""
 
 from __future__ import annotations
 
@@ -7,6 +13,7 @@ from typing import TYPE_CHECKING
 from textual import events
 from textual.binding import Binding
 from textual.containers import Container
+from textual.message import Message
 from textual.screen import ModalScreen
 from textual.widgets import SelectionList
 from textual.widgets.selection_list import Selection
@@ -43,6 +50,19 @@ class FilterPanel(ModalScreen[set[str]]):
         Binding("f", "dismiss_panel", "Close"),
     ]
 
+    class FilterChanged(Message):
+        """Emitted whenever the SelectionList selection changes.
+
+        Carries the current selected filter keys so the main screen can
+        apply them live without waiting for the panel to be dismissed.
+        This matches the mental model of checkboxes on a filter bar --
+        toggling one immediately filters the view underneath.
+        """
+
+        def __init__(self, selected: set[str]) -> None:
+            super().__init__()
+            self.selected = selected
+
     def __init__(self, state: AppState) -> None:
         super().__init__()
         self._state = state
@@ -66,6 +86,17 @@ class FilterPanel(ModalScreen[set[str]]):
     def on_click(self, event: events.Click) -> None:
         if event.button == 3:
             self.action_dismiss_panel()
+
+    def on_selection_list_selected_changed(self, event: SelectionList.SelectedChanged) -> None:
+        """Apply the user's selection as soon as they toggle a filter.
+
+        Without this handler the grid only re-filters when the user
+        dismisses the panel, which feels like the app has hung for
+        anyone expecting live feedback from the checkboxes.
+        """
+        event.stop()
+        selected = set(event.selection_list.selected)
+        self.post_message(self.FilterChanged(selected))
 
     def action_dismiss_panel(self) -> None:
         sel_list = self.query_one("#filter-list", SelectionList)

--- a/src/augint_tools/dashboard/state.py
+++ b/src/augint_tools/dashboard/state.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING
 from github.GithubException import GithubException
 from loguru import logger
 
-from ._data import RepoStatus, load_cache, load_health_cache
+from ._data import RepoStatus, load_cache, load_cache_timestamp, load_health_cache
 from .health import RepoHealth, Severity
 
 if TYPE_CHECKING:
@@ -427,7 +427,13 @@ def move_selection(state: AppState, delta: int) -> None:
 
 
 def bootstrap_from_cache(state: AppState, restrict_to: set[str] | None = None) -> bool:
-    """Populate state.healths from the on-disk cache. Returns True if loaded."""
+    """Populate state.healths from the on-disk cache. Returns True if loaded.
+
+    Also seeds ``last_refresh_at`` from the cache's ``health_ts`` so the
+    staleness indicator shows a real "updated Xm ago" value from the
+    first paint, instead of staying blank until the first live refresh
+    lands.
+    """
     try:
         cache = load_cache()
         if restrict_to is not None:
@@ -438,6 +444,12 @@ def bootstrap_from_cache(state: AppState, restrict_to: set[str] | None = None) -
         health_cache = load_health_cache(cache)
         state.healths = [health_cache.get(s.full_name) or RepoHealth(status=s) for s in statuses]
         state.health_by_name = {h.status.full_name: h for h in state.healths}
+        # Best-effort -- if the cache predates the health_ts field we just
+        # leave last_refresh_at as None and the staleness chip will show
+        # "loading..." until the first live refresh commits.
+        cache_ts = load_cache_timestamp()
+        if cache_ts is not None:
+            state.last_refresh_at = cache_ts
         return True
     except Exception as exc:
         state.log_error("cache", f"{exc.__class__.__name__}: {exc}")

--- a/src/augint_tools/dashboard/widgets/highlight_bar.py
+++ b/src/augint_tools/dashboard/widgets/highlight_bar.py
@@ -30,7 +30,10 @@ class HighlightBar(Static):
     def rerender(self) -> None:
         state = self._state
         if state is None or not state.healths:
-            self.update(Text("no data yet", style="dim"))
+            if state is not None and state.is_refreshing:
+                self.update(Text("loading repository data...", style="bold yellow"))
+            else:
+                self.update(Text("no data yet. press r to refresh.", style="dim"))
             return
 
         worst = min(state.healths, key=lambda h: h.score)

--- a/src/augint_tools/dashboard/widgets/repo_card.py
+++ b/src/augint_tools/dashboard/widgets/repo_card.py
@@ -360,5 +360,11 @@ class RepoCard(Widget):
                 self.post_message(self.ActionsRequested(self.repo_full_name))
             return
         if event.button == 1:
+            # Single click only selects -- a plain click must never
+            # trap the user in a modal drilldown screen.  Use a
+            # double-click (chord), the Enter key, or 'o' to open full
+            # detail; ``event.chain`` is 2 on the second click of a
+            # double-click.
             self.post_message(self.Selected(self.repo_full_name))
-            self.post_message(self.DrilldownRequested(self.repo_full_name))
+            if getattr(event, "chain", 1) >= 2:
+                self.post_message(self.DrilldownRequested(self.repo_full_name))

--- a/src/augint_tools/dashboard/widgets/status_bar.py
+++ b/src/augint_tools/dashboard/widgets/status_bar.py
@@ -1,7 +1,10 @@
-"""StatusBar -- org, sort/filter/layout/theme, error chip.
+"""StatusBar -- org, sort/filter/layout/theme, staleness + countdown + errors.
 
-The refresh countdown lives on the OrgDrawerHeader (subtle, grey, right-aligned)
-rather than here, so this bar stays focused on structural context.
+The staleness indicator ("loading" or "updated Xs ago") and the countdown
+to the next refresh live here so they are always visible, even when the
+org drawer is closed. The OrgDrawerHeader also renders a dim copy for
+users whose eye goes to the top of the screen, but this bar is the
+canonical source of truth.
 """
 
 from __future__ import annotations
@@ -41,6 +44,19 @@ def describe_filter(mode: str, team_labels: dict[str, str] | None = None) -> str
     if mode.startswith("org:"):
         return f"org: {mode.removeprefix('org:')}"
     return mode
+
+
+def _format_age(seconds: int) -> str:
+    """Format a timedelta in seconds as a compact 'Xs' / 'Xm' / 'Xh' string."""
+    if seconds < 60:
+        return f"{seconds}s"
+    if seconds < 3600:
+        return f"{seconds // 60}m"
+    if seconds < 86400:
+        h, m = divmod(seconds, 3600)
+        return f"{h}h{m // 60:02d}m" if m >= 60 else f"{h}h"
+    d, rem = divmod(seconds, 86400)
+    return f"{d}d{rem // 3600}h" if rem >= 3600 else f"{d}d"
 
 
 def _describe_active_filters(active: set[str], team_labels: dict[str, str] | None = None) -> str:
@@ -92,25 +108,59 @@ class StatusBar(Static):
             f"| layout: {state.layout_name} "
             f"| theme: {state.theme_name}"
         )
+        # Staleness first (brighter): users glance here to see whether data
+        # is current or still loading. Countdown is secondary.
+        stale_chip = self._staleness_chip(state)
+        if stale_chip:
+            t.append(" | ")
+            t.append(stale_chip[0], style=stale_chip[1])
         refresh_chip = self._refresh_chip(state)
         if refresh_chip:
-            t.append(f" | {refresh_chip[0]}", style=refresh_chip[1])
+            t.append(" | ")
+            t.append(refresh_chip[0], style=refresh_chip[1])
         error_chip = self._error_chip(state)
         if error_chip:
             t.append(f" | {error_chip}", style="bold red")
         self.update(t)
 
+    def _staleness_chip(self, state: AppState) -> tuple[str, str] | None:
+        """Return ("loading..." | "updated Xs ago", style) to show data freshness.
+
+        Shown at all times so users see a clear "yes we're working"
+        indicator during the 20-30s first-fetch window, and always know
+        roughly how fresh the on-screen data is between refreshes.
+        """
+        if state.is_refreshing and state.last_refresh_at is None:
+            return ("loading data...", "bold yellow")
+        if state.last_refresh_at is None:
+            # No cache and no refresh running -- offline / skipped refresh.
+            return ("no data yet", "bold red")
+        age = int((datetime.now(UTC) - state.last_refresh_at).total_seconds())
+        if age < 0:
+            age = 0
+        label = _format_age(age)
+        # Green while fresh (<=60s), yellow mid (<=10m), dim otherwise.
+        if age <= 60:
+            style = "green"
+        elif age <= 600:
+            style = "yellow"
+        else:
+            style = "dim"
+        return (f"updated {label} ago", style)
+
     def _refresh_chip(self, state: AppState) -> tuple[str, str] | None:
-        if state.is_refreshing:
+        if state.is_refreshing and state.last_refresh_at is not None:
+            # During a refresh that has prior data, staleness chip shows age;
+            # this chip announces that a refresh is in progress.
             return ("refreshing...", "bold yellow")
-        if state.next_refresh_at is not None:
+        if state.next_refresh_at is not None and not state.is_refreshing:
             remaining = int((state.next_refresh_at - datetime.now(UTC)).total_seconds())
             if remaining <= 0:
-                return ("next: now", "dim")
+                return ("next: now", "bold cyan")
             if remaining >= 60:
                 m, s = divmod(remaining, 60)
-                return (f"next: {m}m{s:02d}s", "dim")
-            return (f"next: {remaining}s", "dim")
+                return (f"next: {m}m{s:02d}s", "cyan")
+            return (f"next: {remaining}s", "cyan")
         return None
 
     def _error_chip(self, state: AppState) -> str:

--- a/tests/unit/test_dashboard.py
+++ b/tests/unit/test_dashboard.py
@@ -609,6 +609,24 @@ class TestDashboardActions:
 
         asyncio.run(run())
 
+    def test_filter_panel_applies_live(self):
+        """Toggling a checkbox in the FilterPanel updates the grid NOW.
+
+        Prior behaviour required dismissing the panel before anything
+        happened, which felt like the TUI had hung.  The
+        FilterChanged message flows straight into
+        on_filter_panel_filter_changed and mutates active_filters.
+        """
+        from augint_tools.dashboard.screens.filter_panel import FilterPanel
+
+        app = DashboardApp(repos=[], skip_refresh=True)
+        # Direct invocation of the message handler -- no TUI needed.
+        assert app.state.active_filters == set()
+        app.on_filter_panel_filter_changed(FilterPanel.FilterChanged({"broken-ci"}))
+        assert app.state.active_filters == {"broken-ci"}
+        app.on_filter_panel_filter_changed(FilterPanel.FilterChanged(set()))
+        assert app.state.active_filters == set()
+
     def test_toggle_workspace(self):
         async def run():
             app = DashboardApp(repos=[], skip_refresh=True)
@@ -1088,6 +1106,61 @@ class TestAppMisc:
 
         asyncio.run(run())
 
+    def test_card_single_click_only_selects(self):
+        """A single click must not post DrilldownRequested.
+
+        Previously every left click posted both Selected and
+        DrilldownRequested, so any click -- including unintentional
+        ones after dismissing the filter panel -- pushed a modal that
+        trapped the user and looked like a hang.
+        """
+        from augint_tools.dashboard.widgets.repo_card import RepoCard
+
+        posted: list = []
+
+        class _FakeEvent:
+            button = 1
+            meta = False
+            chain = 1
+
+            def stop(self):
+                pass
+
+            def prevent_default(self):
+                pass
+
+        theme = get_theme("default")
+        card = RepoCard(health=_health(full_name="org/r0"), theme_spec=theme)
+        card.post_message = posted.append  # type: ignore[assignment]
+        card.on_click(_FakeEvent())
+        kinds = [type(m).__name__ for m in posted]
+        assert "Selected" in kinds
+        assert "DrilldownRequested" not in kinds
+
+    def test_card_double_click_opens_drilldown(self):
+        """Double-click still opens the drilldown -- use chord=2."""
+        from augint_tools.dashboard.widgets.repo_card import RepoCard
+
+        posted: list = []
+
+        class _FakeEvent:
+            button = 1
+            meta = False
+            chain = 2
+
+            def stop(self):
+                pass
+
+            def prevent_default(self):
+                pass
+
+        theme = get_theme("default")
+        card = RepoCard(health=_health(full_name="org/r0"), theme_spec=theme)
+        card.post_message = posted.append  # type: ignore[assignment]
+        card.on_click(_FakeEvent())
+        kinds = [type(m).__name__ for m in posted]
+        assert "DrilldownRequested" in kinds
+
     def test_run_dashboard_invokes_app_run(self):
         from augint_tools.dashboard import app as _app_mod
 
@@ -1411,6 +1484,90 @@ class TestAppMisc:
         # method is deterministic: verify the refresh-phrase branch.
         assert app_state.next_refresh_at is None
         assert not app_state.is_refreshing
+
+    def test_status_bar_staleness_loading(self):
+        """With is_refreshing=True and no prior data, show "loading...".
+
+        This is the "first-launch, no cache" UX: the user pressed r /
+        ran the CLI and is waiting for the initial GitHub fetch. We
+        must show a visible "we're working on it" chip instead of
+        leaving the bar blank for 20-30 seconds.
+        """
+        from augint_tools.dashboard.widgets.status_bar import StatusBar
+
+        app_state = AppState()
+        app_state.is_refreshing = True
+        app_state.last_refresh_at = None
+        bar = StatusBar()
+        bar.bind_state(app_state, "testorg")
+        chip = bar._staleness_chip(app_state)
+        assert chip is not None
+        label, style = chip
+        assert "loading" in label.lower()
+        assert "bold" in style
+
+    def test_status_bar_staleness_updated_ago(self):
+        """With a prior refresh, the chip shows the age of that data."""
+        from datetime import UTC, datetime, timedelta
+
+        from augint_tools.dashboard.widgets.status_bar import StatusBar
+
+        app_state = AppState()
+        app_state.last_refresh_at = datetime.now(UTC) - timedelta(seconds=30)
+        bar = StatusBar()
+        bar.bind_state(app_state, "testorg")
+        chip = bar._staleness_chip(app_state)
+        assert chip is not None
+        label, _ = chip
+        assert "updated" in label and "ago" in label
+        # 30s-old data should be fresh-green, not dim.
+        assert chip[1] == "green"
+
+    def test_status_bar_format_age(self):
+        """The compact age formatter covers s/m/h/d units."""
+        from augint_tools.dashboard.widgets.status_bar import _format_age
+
+        assert _format_age(0) == "0s"
+        assert _format_age(5) == "5s"
+        assert _format_age(59) == "59s"
+        assert _format_age(60) == "1m"
+        assert _format_age(3599) == "59m"
+        assert _format_age(3600) == "1h"
+        assert _format_age(7200) == "2h"
+        assert _format_age(86400) == "1d"
+
+    def test_bootstrap_seeds_last_refresh_at(self, tmp_path):
+        """bootstrap_from_cache must set last_refresh_at from cache ts.
+
+        Without this the staleness indicator reads "loading..." even
+        when we painted the screen from a fresh on-disk cache -- the
+        user would have no idea the cards they see are already a few
+        minutes old.
+        """
+        import json
+        from datetime import UTC, datetime
+
+        from augint_tools.dashboard import _data
+        from augint_tools.dashboard.state import bootstrap_from_cache
+
+        cache_file = tmp_path / "tui_cache.json"
+        ts = datetime.now(UTC).isoformat()
+        status = _status(name="x", full_name="org/x")
+        from dataclasses import asdict
+
+        cache_file.write_text(
+            json.dumps(
+                {
+                    "repos": {"org/x": asdict(status)},
+                    "health": {},
+                    "health_ts": ts,
+                }
+            )
+        )
+        s = AppState()
+        with patch.object(_data, "CACHE_FILE", cache_file):
+            assert bootstrap_from_cache(s) is True
+        assert s.last_refresh_at is not None
 
     def test_sparkline_renders_block_heights(self):
         from augint_tools.dashboard.app import _sparkline


### PR DESCRIPTION
## Summary
- Add staleness chip (loading / updated Xs ago) to status bar -- always visible, color-coded by age
- Brighten and re-word the refresh countdown on OrgDrawerHeader so users actually see it
- Seed last_refresh_at from cache timestamp so "updated Xm ago" works from paint zero
- FilterPanel now applies selections live via a FilterChanged message instead of only on dismiss
- Single-click on a RepoCard only selects; drilldown modal requires a double-click (fixes the modal-trap that looked like a TUI hang)
- Highlight bar shows "loading repository data..." while a refresh is in flight

## Test plan
- [ ] Launch \`ai-tools dashboard\` with a warm cache -- header chip shows cached age immediately
- [ ] Launch with a cold cache -- status bar shows "loading data..." during the initial fetch instead of going blank
- [ ] Countdown ("next: Nm Ns") is legible on both the OrgDrawerHeader and StatusBar
- [ ] Open filter panel (f), toggle a checkbox -- grid re-filters before dismissing
- [ ] Single-click a repo card -- only selects, no modal
- [ ] Double-click a repo card -- opens drilldown modal