### PR TITLE
perf(env): run chezmoi backup and GitHub sync in parallel

### DIFF
--- a/src/augint_tools/env/chezmoi.py
+++ b/src/augint_tools/env/chezmoi.py
@@ -54,6 +54,96 @@ def ensure_chezmoi() -> None:
         )
 
 
+def _run_chezmoi_pipeline(
+    filename: str,
+    env_path: Path,
+    project_name: str,
+    *,
+    verbose: bool,
+    dry_run: bool,
+) -> bool:
+    """Execute the synchronous chezmoi backup pipeline.
+
+    Returns True if a commit was produced (or would be in dry-run).
+    """
+    click.echo(f"Adding {filename} to chezmoi...")
+    run_chezmoi(["add", str(env_path)], dry_run=dry_run, verbose=verbose)
+
+    run_chezmoi(["git", "add", "--", "."], dry_run=dry_run, verbose=verbose)
+
+    status_result = run_chezmoi(
+        ["git", "status", "--", "--porcelain"], dry_run=dry_run, verbose=verbose
+    )
+    status_output = status_result.stdout.strip()
+
+    if not (status_output or dry_run):
+        return False
+
+    message = build_commit_message(project_name, status_output)
+    click.echo("Committing to chezmoi...")
+    run_chezmoi(["git", "commit", "--", "-m", message], dry_run=dry_run, verbose=verbose)
+
+    click.echo("Syncing with chezmoi remote...")
+    run_chezmoi(["git", "pull", "--", "--rebase"], dry_run=dry_run, verbose=verbose)
+    run_chezmoi(["git", "push"], dry_run=dry_run, verbose=verbose)
+    return True
+
+
+async def _run_github_sync(
+    filename: str, sync_github: bool, dry_run: bool
+) -> dict[str, list[str]] | None:
+    """Run the GitHub secrets sync if enabled."""
+    if not sync_github:
+        return None
+    click.echo("Syncing secrets to GitHub...")
+    return await perform_sync(filename, dry_run)
+
+
+async def _run_pipelines_concurrently(
+    filename: str,
+    env_path: Path,
+    project_name: str,
+    *,
+    sync_github: bool,
+    verbose: bool,
+    dry_run: bool,
+) -> tuple[bool, dict[str, list[str]] | None]:
+    """Run chezmoi and GitHub sync pipelines concurrently.
+
+    Both pipelines run to completion even if one fails, so users see all
+    errors in a single invocation. If either fails, raises a
+    click.ClickException aggregating the messages.
+    """
+    chezmoi_task = asyncio.create_task(
+        asyncio.to_thread(
+            _run_chezmoi_pipeline,
+            filename,
+            env_path,
+            project_name,
+            verbose=verbose,
+            dry_run=dry_run,
+        )
+    )
+    github_task = asyncio.create_task(_run_github_sync(filename, sync_github, dry_run))
+
+    results = await asyncio.gather(chezmoi_task, github_task, return_exceptions=True)
+    chezmoi_result, github_result = results
+
+    errors: list[str] = []
+    if isinstance(chezmoi_result, BaseException):
+        errors.append(f"chezmoi backup failed: {chezmoi_result}")
+    if isinstance(github_result, BaseException):
+        errors.append(f"GitHub sync failed: {github_result}")
+
+    if errors:
+        raise click.ClickException("; ".join(errors))
+
+    # mypy: both are not exceptions here
+    assert not isinstance(chezmoi_result, BaseException)
+    assert not isinstance(github_result, BaseException)
+    return chezmoi_result, github_result
+
+
 def chezmoi_backup(
     filename: str = ".env",
     *,
@@ -62,6 +152,9 @@ def chezmoi_backup(
     dry_run: bool = False,
 ) -> dict[str, object]:
     """Back up an env file to chezmoi and optionally sync secrets to GitHub.
+
+    The chezmoi backup (local subprocess calls) and the GitHub secrets sync
+    (remote API calls) run concurrently because they are independent.
 
     Returns a result dict suitable for CommandResponse.
     """
@@ -73,32 +166,20 @@ def chezmoi_backup(
 
     project_name = Path.cwd().name
 
-    click.echo(f"Adding {filename} to chezmoi...")
-    run_chezmoi(["add", str(env_path)], dry_run=dry_run, verbose=verbose)
-
-    run_chezmoi(["git", "add", "--", "."], dry_run=dry_run, verbose=verbose)
-
-    status_result = run_chezmoi(
-        ["git", "status", "--", "--porcelain"], dry_run=dry_run, verbose=verbose
+    chezmoi_committed, sync_result = asyncio.run(
+        _run_pipelines_concurrently(
+            filename,
+            env_path,
+            project_name,
+            sync_github=sync_github,
+            verbose=verbose,
+            dry_run=dry_run,
+        )
     )
-    status_output = status_result.stdout.strip()
-
-    chezmoi_committed = False
-    if status_output or dry_run:
-        message = build_commit_message(project_name, status_output)
-        click.echo("Committing to chezmoi...")
-        run_chezmoi(["git", "commit", "--", "-m", message], dry_run=dry_run, verbose=verbose)
-
-        click.echo("Syncing with chezmoi remote...")
-        run_chezmoi(["git", "pull", "--", "--rebase"], dry_run=dry_run, verbose=verbose)
-        run_chezmoi(["git", "push"], dry_run=dry_run, verbose=verbose)
-        chezmoi_committed = True
 
     result: dict[str, object] = {"chezmoi_committed": chezmoi_committed}
 
-    if sync_github:
-        click.echo("Syncing secrets to GitHub...")
-        sync_result = asyncio.run(perform_sync(filename, dry_run))
+    if sync_result is not None:
         result["secrets_synced"] = len(sync_result["secrets"])
         result["variables_synced"] = len(sync_result["variables"])
     else:

--- a/tests/unit/test_env_chezmoi.py
+++ b/tests/unit/test_env_chezmoi.py
@@ -1,13 +1,16 @@
 """Tests for chezmoi backup functionality."""
 
+import asyncio
 import subprocess
+import threading
+import time
 from pathlib import Path
 from unittest.mock import patch
 
 from click.testing import CliRunner
 
 from augint_tools.cli.__main__ import cli
-from augint_tools.env.chezmoi import build_commit_message
+from augint_tools.env.chezmoi import build_commit_message, chezmoi_backup
 
 
 class TestBuildCommitMessage:
@@ -149,3 +152,130 @@ class TestChezmoiCommand:
             result = runner.invoke(cli, ["sync", "--no-sync"])
 
         assert result.exit_code != 0
+
+
+class TestConcurrency:
+    """Verify that chezmoi and GitHub sync pipelines run in parallel."""
+
+    @patch("augint_tools.env.chezmoi.perform_sync")
+    @patch("augint_tools.env.chezmoi.subprocess.run")
+    @patch("augint_tools.env.chezmoi.shutil.which", return_value="/usr/bin/chezmoi")
+    def test_pipelines_run_concurrently(self, mock_which, mock_run, mock_sync):
+        """Both pipelines should execute in parallel, not serially.
+
+        The blocking chezmoi pipeline sleeps 0.2s; the async GitHub sync
+        sleeps 0.2s. Sequential execution would take ~0.4s; concurrent
+        execution takes ~0.2s. We also assert both pipelines were active
+        at the same moment via an Event.
+        """
+        chezmoi_started = threading.Event()
+        github_started = threading.Event()
+        overlap_observed = threading.Event()
+
+        def chezmoi_side_effect(cmd, **kwargs):
+            # Mark chezmoi entered, then wait briefly for github to start
+            # to confirm they overlap.
+            chezmoi_started.set()
+            if github_started.wait(timeout=1.0):
+                overlap_observed.set()
+            time.sleep(0.05)
+            if cmd == ["chezmoi", "git", "status", "--", "--porcelain"]:
+                return subprocess.CompletedProcess(cmd, 0, stdout=" M dot_env\n", stderr="")
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+        async def github_side_effect(filename, dry_run):
+            github_started.set()
+            # Wait for chezmoi pipeline to also be running.
+            await asyncio.sleep(0.2)
+            assert chezmoi_started.is_set(), "chezmoi pipeline should have started by now"
+            return {"secrets": ["A"], "variables": ["B"]}
+
+        mock_run.side_effect = chezmoi_side_effect
+        mock_sync.side_effect = github_side_effect
+
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            Path(".env").write_text("GH_REPO=r\nGH_ACCOUNT=a\nFOO=bar\n")
+            start = time.monotonic()
+            result = runner.invoke(cli, ["sync"])
+            elapsed = time.monotonic() - start
+
+        assert result.exit_code == 0, result.output
+        assert overlap_observed.is_set(), "chezmoi and github pipelines did not overlap"
+        # Concurrent runs must be faster than purely sequential. The chezmoi
+        # pipeline issues ~6 subprocess calls (~0.3s of sleeps) plus 0.2s for
+        # GitHub; serial would be >0.5s. Allow generous slack for CI.
+        assert elapsed < 0.45, f"pipelines appear sequential (took {elapsed:.2f}s)"
+        mock_sync.assert_called_once()
+
+    @patch("augint_tools.env.chezmoi.perform_sync")
+    @patch("augint_tools.env.chezmoi.subprocess.run")
+    @patch("augint_tools.env.chezmoi.shutil.which", return_value="/usr/bin/chezmoi")
+    def test_both_pipelines_run_even_if_one_fails(self, mock_which, mock_run, mock_sync):
+        """If chezmoi fails, GitHub sync still runs (and vice versa)."""
+        mock_run.return_value = subprocess.CompletedProcess([], 1, stdout="", stderr="chezmoi boom")
+
+        sync_called = threading.Event()
+
+        async def github_side_effect(filename, dry_run):
+            sync_called.set()
+            return {"secrets": [], "variables": []}
+
+        mock_sync.side_effect = github_side_effect
+
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            Path(".env").write_text("GH_REPO=r\nGH_ACCOUNT=a\nFOO=bar\n")
+            result = runner.invoke(cli, ["sync"])
+
+        assert result.exit_code != 0
+        assert sync_called.is_set(), "GitHub sync should run even when chezmoi fails"
+        assert "chezmoi" in result.output.lower()
+
+    @patch("augint_tools.env.chezmoi.perform_sync")
+    @patch("augint_tools.env.chezmoi.subprocess.run")
+    @patch("augint_tools.env.chezmoi.shutil.which", return_value="/usr/bin/chezmoi")
+    def test_aggregates_failures_from_both_pipelines(self, mock_which, mock_run, mock_sync):
+        """Both failures are surfaced in the error message."""
+        mock_run.return_value = subprocess.CompletedProcess([], 1, stdout="", stderr="chezmoi boom")
+
+        async def github_side_effect(filename, dry_run):
+            raise RuntimeError("github boom")
+
+        mock_sync.side_effect = github_side_effect
+
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            Path(".env").write_text("GH_REPO=r\nGH_ACCOUNT=a\nFOO=bar\n")
+            result = runner.invoke(cli, ["sync"])
+
+        assert result.exit_code != 0
+        # Both error messages should appear in the surfaced error
+        lowered = result.output.lower()
+        assert "chezmoi" in lowered
+        assert "github" in lowered
+
+    @patch("augint_tools.env.chezmoi.perform_sync")
+    @patch("augint_tools.env.chezmoi.subprocess.run")
+    @patch("augint_tools.env.chezmoi.shutil.which", return_value="/usr/bin/chezmoi")
+    def test_chezmoi_backup_returns_expected_shape_on_success(
+        self, mock_which, mock_run, mock_sync
+    ):
+        """Direct call to chezmoi_backup still returns the expected result dict."""
+        mock_sync.return_value = {"secrets": ["S1"], "variables": ["V1", "V2"]}
+
+        def side_effect(cmd, **kwargs):
+            if cmd == ["chezmoi", "git", "status", "--", "--porcelain"]:
+                return subprocess.CompletedProcess(cmd, 0, stdout=" M dot_env\n", stderr="")
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+        mock_run.side_effect = side_effect
+
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            Path(".env").write_text("FOO=bar\n")
+            result = chezmoi_backup(".env")
+
+        assert result["chezmoi_committed"] is True
+        assert result["secrets_synced"] == 1
+        assert result["variables_synced"] == 2


### PR DESCRIPTION
## Summary
- \`chezmoi_backup()\` now runs the chezmoi pipeline (add/commit/pull/push) and the GitHub secrets sync concurrently via \`asyncio.gather(return_exceptions=True)\`
- Public signature of \`chezmoi_backup\` unchanged; CLI \`sync\` command is untouched
- Failures from either pipeline are aggregated into a single \`click.ClickException\` so one failing side does not hide the other's result

## Test plan
- [ ] \`uv run pytest tests/unit/test_env_chezmoi.py\` -- 4 new concurrency tests pass
- [ ] \`ai-tools sync --dry-run\` -- both pipelines run, output interleaves
- [ ] Force a chezmoi failure (e.g., no chezmoi remote) -- GitHub sync still runs; combined error message surfaces both