### PR TITLE
fix(env): allowlist known infra keys so they never classify as secrets

### DIFF
--- a/src/augint_tools/env/classify.py
+++ b/src/augint_tools/env/classify.py
@@ -34,6 +34,21 @@ class Classification(Enum):
 
 KEY_SKIP_PREFIXES = frozenset({"AWS_PROFILE", "AWS_DEFAULT_REGION", "AWS_REGION"})
 
+_INFRA_BASE_NAMES = (
+    "AWS_DEPLOY_ROLE",
+    "PIPELINE_EXECUTION_ROLE",
+    "CLOUDFORMATION_EXECUTION_ROLE",
+    "ARTIFACTS_BUCKET",
+    "HOSTED_ZONE_ID",
+    "WILDCARD_CERT_ARN",
+)
+
+KEY_ALWAYS_VAR = frozenset(
+    {name for name in _INFRA_BASE_NAMES}
+    | {f"STAGING_{name}" for name in _INFRA_BASE_NAMES}
+    | {f"PROD_{name}" for name in _INFRA_BASE_NAMES}
+)
+
 KEY_SECRET_KEYWORDS = frozenset(
     {
         "secret",
@@ -273,6 +288,13 @@ def classify_variable(
         return ClassificationResult(
             key, value, Classification.VARIABLE, ["inline comment hint @var"]
         )
+
+    # --- Always-var allowlist: known infrastructure identifier keys ---
+    # Wins over every heuristic. Still loses to --force-secret and @secret so the
+    # user can override from the call site or the .env itself.
+    if key in KEY_ALWAYS_VAR:
+        logger.info(f"[classify] {key} -> VARIABLE (always-var list)")
+        return ClassificationResult(key, value, Classification.VARIABLE, ["always-var list"])
 
     # --- Heuristic classification ---
     reasons: list[str] = []

--- a/tests/unit/test_env_classify.py
+++ b/tests/unit/test_env_classify.py
@@ -544,3 +544,46 @@ class TestRegressionMiscategorizedKeys:
         assert r.classification == Classification.VARIABLE, (
             f"{key}={value!r} classified as {r.classification.value}; reasons={r.reasons}"
         )
+
+
+class TestAlwaysVarAllowlist:
+    """Keys in ``KEY_ALWAYS_VAR`` are variables even against strong secret signals."""
+
+    @pytest.mark.parametrize(
+        "key",
+        [
+            "HOSTED_ZONE_ID",
+            "STAGING_HOSTED_ZONE_ID",
+            "PROD_HOSTED_ZONE_ID",
+            "AWS_DEPLOY_ROLE",
+            "STAGING_AWS_DEPLOY_ROLE",
+            "PROD_AWS_DEPLOY_ROLE",
+            "PIPELINE_EXECUTION_ROLE",
+            "STAGING_PIPELINE_EXECUTION_ROLE",
+            "PROD_PIPELINE_EXECUTION_ROLE",
+            "CLOUDFORMATION_EXECUTION_ROLE",
+            "STAGING_CLOUDFORMATION_EXECUTION_ROLE",
+            "PROD_CLOUDFORMATION_EXECUTION_ROLE",
+            "ARTIFACTS_BUCKET",
+            "STAGING_ARTIFACTS_BUCKET",
+            "PROD_ARTIFACTS_BUCKET",
+            "WILDCARD_CERT_ARN",
+            "STAGING_WILDCARD_CERT_ARN",
+            "PROD_WILDCARD_CERT_ARN",
+        ],
+    )
+    def test_allowlist_key_is_variable(self, key):
+        # A long, high-entropy, base64-ish value that would otherwise flag SECRET.
+        r = classify_variable(key, "Z0123456789AbCdEfGhIjKlMnOpQrStUvWxYz+/abcd==")
+        assert r.classification == Classification.VARIABLE
+        assert "always-var list" in r.reasons
+
+    def test_allowlist_loses_to_force_secret(self):
+        r = classify_variable("HOSTED_ZONE_ID", "Z0ABC", force_secret=frozenset({"HOSTED_ZONE_ID"}))
+        assert r.classification == Classification.SECRET
+
+    def test_allowlist_loses_to_inline_secret_comment(self, tmp_path):
+        env_file = tmp_path / ".env"
+        env_file.write_text("# @secret\nHOSTED_ZONE_ID=Z0ABC\n")
+        results = classify_env(str(env_file))
+        assert results[0].classification == Classification.SECRET


### PR DESCRIPTION
## Summary
- Adds KEY_ALWAYS_VAR -- explicit allowlist of deploy-role, pipeline/cfn-execution-role, artifacts-bucket, hosted-zone-id, wildcard-cert-arn keys (bare, STAGING_, PROD_ prefixes)
- Wins over every heuristic; still loses to \`--force-secret\` and inline \`# @secret\` so users can override
- Root cause of the bug: HOSTED_ZONE_ID ends in \`_id\`, not \`_zone\`, so the existing _INFRA_KEY_SUFFIXES rule missed it and the value fell through to entropy heuristics
- 20 new tests: 18 parametrized over the allowlist plus two precedence tests

## Test plan
- [ ] \`uv run pytest tests/unit/test_env_classify.py\` -- all pass including new TestAlwaysVarAllowlist
- [ ] \`ai-tools gh classify .env\` on a repo with HOSTED_ZONE_ID -- now shows as variable