### PR TITLE
fix(env): use set() over redundant set comprehension (ruff C416)

### DIFF
--- a/src/augint_tools/env/classify.py
+++ b/src/augint_tools/env/classify.py
@@ -44,7 +44,7 @@ _INFRA_BASE_NAMES = (
 )
 
 KEY_ALWAYS_VAR = frozenset(
-    {name for name in _INFRA_BASE_NAMES}
+    set(_INFRA_BASE_NAMES)
     | {f"STAGING_{name}" for name in _INFRA_BASE_NAMES}
     | {f"PROD_{name}" for name in _INFRA_BASE_NAMES}
 )


### PR DESCRIPTION
CI ruff flagged `{name for name in _INFRA_BASE_NAMES}` as C416 -- rewritten using `set(_INFRA_BASE_NAMES)`. No behavior change. Local ruff version did not flag this (version drift), confirmed CI now passes locally.