### PR TITLE
ci: align pipeline job names with canonical gate vocabulary

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -21,8 +21,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  pre-commit:
-    name: Pre-commit checks
+  code-quality:
+    name: Code quality
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -48,10 +48,10 @@ jobs:
       - name: Run pre-commit hooks
         run: uv run pre-commit run --all-files
 
-  security-scan:
-    name: Security scanning
+  security:
+    name: Security
     runs-on: ubuntu-latest
-    needs: [pre-commit]
+    needs: [code-quality]
     permissions:
       contents: read
 
@@ -107,10 +107,10 @@ jobs:
             pip-audit-report.json
             semgrep-results.sarif
 
-  compliance-reports:
-    name: License compliance
+  compliance:
+    name: Compliance
     runs-on: ubuntu-latest
-    needs: [pre-commit]
+    needs: [code-quality]
     permissions:
       contents: read
 
@@ -150,7 +150,7 @@ jobs:
 
   unit-tests:
     name: Unit tests
-    needs: [pre-commit]
+    needs: [code-quality]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -197,9 +197,41 @@ jobs:
           name: unit-test-reports
           path: test-report.html
 
+  build-validation:
+    name: Build validation
+    needs: [code-quality]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install UV
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: uv build
+        run: uv build
+
+      - name: Upload dist artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
   release:
     name: Semantic release
-    needs: [unit-tests, security-scan, compliance-reports]
+    needs: [unit-tests, security, compliance, build-validation]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     concurrency:


### PR DESCRIPTION
## Summary
- Renames pipeline jobs to the canonical five-gate vocabulary (Code quality, Security, Unit tests, Compliance, Build validation)
- Adds the missing **Build validation** job (runs `uv build`, uploads `dist/` artifact)
- Updates the `release` job's `needs` to depend on all four pre-merge gates plus `unit-tests`

## Context
The repository ruleset's required status check contexts have already been updated on `main` to the new names, so this PR's CI run will produce the contexts the ruleset now requires.

## Test plan
- [ ] Pipeline runs on this PR and all five pre-merge gates report under the new names
- [ ] Build validation job produces a `dist/` artifact
- [ ] PR merges cleanly once CI is green