### PR TITLE
fix(dashboard): drop open-PR count from severity classification

### DIFF
--- a/src/augint_tools/dashboard/layouts/severity.py
+++ b/src/augint_tools/dashboard/layouts/severity.py
@@ -24,7 +24,7 @@ def _card_severity_bucket(health) -> str:
     worst = health.worst_severity
     if worst == Severity.CRITICAL:
         return "critical"
-    if worst in (Severity.HIGH, Severity.MEDIUM) or status.open_prs > 0:
+    if worst in (Severity.HIGH, Severity.MEDIUM):
         return "warning"
     return "ok"
 

--- a/src/augint_tools/dashboard/widgets/repo_card.py
+++ b/src/augint_tools/dashboard/widgets/repo_card.py
@@ -206,7 +206,7 @@ class RepoCard(Widget):
         worst = health.worst_severity
         if worst == Severity.CRITICAL:
             self.add_class("card--critical")
-        elif worst in (Severity.HIGH, Severity.MEDIUM) or status.open_prs > 0:
+        elif worst in (Severity.HIGH, Severity.MEDIUM):
             self.add_class("card--warning")
         else:
             self.add_class("card--ok")


### PR DESCRIPTION
## Summary
- Open PRs no longer push a card into the warning bucket.
- Only actual findings (high/medium severity) determine the warning classification, so healthy repos with active PR queues stay green.
- Two-line change in two files (severity.py layout grouping + repo_card.py CSS class assignment), kept in sync so the layout bucket and the card class agree.

## Test plan
- [ ] Open the dashboard with a repo that has open PRs but no severity findings -> card classifies as ok / green.
- [ ] Open the dashboard with a repo that has high/medium findings -> card still classifies as warning / yellow.
- [ ] Open the dashboard with a repo that has critical findings or main/dev failing -> card still classifies as critical / red.