### PR TITLE
fix(cli): quiet default output for sync and gh push

### DIFF
--- a/src/augint_tools/cli/commands/env.py
+++ b/src/augint_tools/cli/commands/env.py
@@ -13,6 +13,50 @@ def _get_output_opts(ctx: click.Context) -> dict:
     return {"json_mode": obj.get("json_mode", False)}
 
 
+def _make_quiet_writer(*, verbose: bool, json_mode: bool):
+    """Return a clean stderr writer for human mode, or None when output should be silent.
+
+    Suppressed under ``--json`` (machine-readable) and under ``--verbose`` (the
+    detailed loguru stream already covers user-visible activity).
+    """
+    if verbose or json_mode:
+        return None
+
+    def _write(msg: str) -> None:
+        click.echo(msg, err=True)
+
+    return _write
+
+
+def _configure_env_logging(verbose: bool) -> None:
+    """Quiet loguru by default; preserve detailed loguru output with --verbose.
+
+    Loguru's default sink is DEBUG-to-stderr with timestamps, levels, and
+    module paths, which produces a wall of text for user-facing CLIs. We
+    remove the default sink and only re-add it when ``-v`` is passed, in
+    which case the original loguru format is preserved exactly.
+    """
+    import sys
+
+    from loguru import logger
+
+    logger.remove()
+    if verbose:
+        # Loguru's documented default format. Re-adding explicitly keeps
+        # the verbose stream identical to what users saw before this
+        # quieting change.
+        logger.add(
+            sys.stderr,
+            level="DEBUG",
+            format=(
+                "<green>{time:HH:mm:ss.SSS}</green> | "
+                "<level>{level: <8}</level> | "
+                "<cyan>{name}</cyan>:<cyan>{function}</cyan>:<cyan>{line}</cyan> "
+                "- <level>{message}</level>"
+            ),
+        )
+
+
 @click.group()
 @click.pass_context
 def gh(ctx):
@@ -90,6 +134,8 @@ def push(ctx, dry_run, verbose, force_var, force_secret, filename):
     from augint_tools.env.sync import perform_sync
 
     opts = _get_output_opts(ctx)
+    _configure_env_logging(verbose)
+    quiet_writer = _make_quiet_writer(verbose=verbose, json_mode=opts["json_mode"])
 
     fv = frozenset(k.strip() for k in force_var.split(",") if k.strip()) if force_var else None
     fs = (
@@ -97,7 +143,15 @@ def push(ctx, dry_run, verbose, force_var, force_secret, filename):
     )
 
     try:
-        results = asyncio.run(perform_sync(filename, dry_run, force_var=fv, force_secret=fs))
+        results = asyncio.run(
+            perform_sync(
+                filename,
+                dry_run,
+                force_var=fv,
+                force_secret=fs,
+                quiet_writer=quiet_writer,
+            )
+        )
     except Exception as e:
         emit_response(CommandResponse.error("gh push", "repo", str(e)), **opts)
         sys.exit(1)
@@ -136,6 +190,8 @@ def sync(ctx, no_sync, verbose, dry_run, filename):
     from augint_tools.env.chezmoi import chezmoi_backup
 
     opts = _get_output_opts(ctx)
+    _configure_env_logging(verbose)
+    quiet_writer = _make_quiet_writer(verbose=verbose, json_mode=opts["json_mode"])
 
     try:
         result = chezmoi_backup(
@@ -143,6 +199,7 @@ def sync(ctx, no_sync, verbose, dry_run, filename):
             sync_github=not no_sync,
             verbose=verbose,
             dry_run=dry_run,
+            quiet_writer=quiet_writer,
         )
     except click.ClickException as e:
         emit_response(CommandResponse.error("sync", "repo", e.format_message()), **opts)

--- a/src/augint_tools/env/chezmoi.py
+++ b/src/augint_tools/env/chezmoi.py
@@ -6,11 +6,14 @@ import asyncio
 import shutil
 import subprocess
 from pathlib import Path
+from typing import Callable
 
 import click
 from loguru import logger
 
 from augint_tools.env.sync import perform_sync
+
+QuietWriter = Callable[[str], None]
 
 
 def run_chezmoi(
@@ -61,12 +64,15 @@ def _run_chezmoi_pipeline(
     *,
     verbose: bool,
     dry_run: bool,
+    quiet_writer: QuietWriter | None = None,
 ) -> bool:
     """Execute the synchronous chezmoi backup pipeline.
 
     Returns True if a commit was produced (or would be in dry-run).
     """
-    click.echo(f"Adding {filename} to chezmoi...")
+    if quiet_writer is not None:
+        quiet_writer(f"chezmoi: add {filename}")
+    logger.info(f"Adding {filename} to chezmoi...")
     run_chezmoi(["add", str(env_path)], dry_run=dry_run, verbose=verbose)
 
     run_chezmoi(["git", "add", "--", "."], dry_run=dry_run, verbose=verbose)
@@ -77,26 +83,38 @@ def _run_chezmoi_pipeline(
     status_output = status_result.stdout.strip()
 
     if not (status_output or dry_run):
+        if quiet_writer is not None:
+            quiet_writer("chezmoi: no changes")
         return False
 
     message = build_commit_message(project_name, status_output)
-    click.echo("Committing to chezmoi...")
+    if quiet_writer is not None:
+        quiet_writer("chezmoi: commit")
+    logger.info("Committing to chezmoi...")
     run_chezmoi(["git", "commit", "--", "-m", message], dry_run=dry_run, verbose=verbose)
 
-    click.echo("Syncing with chezmoi remote...")
+    if quiet_writer is not None:
+        quiet_writer("chezmoi: push")
+    logger.info("Syncing with chezmoi remote...")
     run_chezmoi(["git", "pull", "--", "--rebase"], dry_run=dry_run, verbose=verbose)
     run_chezmoi(["git", "push"], dry_run=dry_run, verbose=verbose)
     return True
 
 
 async def _run_github_sync(
-    filename: str, sync_github: bool, dry_run: bool
+    filename: str,
+    sync_github: bool,
+    dry_run: bool,
+    *,
+    quiet_writer: QuietWriter | None = None,
 ) -> dict[str, list[str]] | None:
     """Run the GitHub secrets sync if enabled."""
     if not sync_github:
         return None
-    click.echo("Syncing secrets to GitHub...")
-    return await perform_sync(filename, dry_run)
+    if quiet_writer is not None:
+        quiet_writer("github: sync")
+    logger.info("Syncing secrets to GitHub...")
+    return await perform_sync(filename, dry_run, quiet_writer=quiet_writer)
 
 
 async def _run_pipelines_concurrently(
@@ -107,6 +125,7 @@ async def _run_pipelines_concurrently(
     sync_github: bool,
     verbose: bool,
     dry_run: bool,
+    quiet_writer: QuietWriter | None = None,
 ) -> tuple[bool, dict[str, list[str]] | None]:
     """Run chezmoi and GitHub sync pipelines concurrently.
 
@@ -122,9 +141,12 @@ async def _run_pipelines_concurrently(
             project_name,
             verbose=verbose,
             dry_run=dry_run,
+            quiet_writer=quiet_writer,
         )
     )
-    github_task = asyncio.create_task(_run_github_sync(filename, sync_github, dry_run))
+    github_task = asyncio.create_task(
+        _run_github_sync(filename, sync_github, dry_run, quiet_writer=quiet_writer)
+    )
 
     results = await asyncio.gather(chezmoi_task, github_task, return_exceptions=True)
     chezmoi_result, github_result = results
@@ -150,6 +172,7 @@ def chezmoi_backup(
     sync_github: bool = True,
     verbose: bool = False,
     dry_run: bool = False,
+    quiet_writer: QuietWriter | None = None,
 ) -> dict[str, object]:
     """Back up an env file to chezmoi and optionally sync secrets to GitHub.
 
@@ -174,6 +197,7 @@ def chezmoi_backup(
             sync_github=sync_github,
             verbose=verbose,
             dry_run=dry_run,
+            quiet_writer=quiet_writer,
         )
     )
 

--- a/src/augint_tools/env/sync.py
+++ b/src/augint_tools/env/sync.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import asyncio
 import os
-from typing import Any
+from typing import Any, Callable
 
 from dotenv import load_dotenv
 from loguru import logger
@@ -16,8 +16,20 @@ from loguru import logger
 from augint_tools.env.auth import get_github_repo
 from augint_tools.env.classify import partition_env
 
+# Type alias for an optional quiet-mode writer. When provided, it is invoked
+# once per per-item action with a clean, human-readable message (no
+# timestamps, levels, or module paths). The verbose loguru output is
+# emitted independently and is unchanged.
+QuietWriter = Callable[[str], None]
 
-async def _sync_secrets(repo: Any, env_data: dict[str, str], dry_run: bool) -> list[str]:
+
+async def _sync_secrets(
+    repo: Any,
+    env_data: dict[str, str],
+    dry_run: bool,
+    *,
+    quiet_writer: QuietWriter | None = None,
+) -> list[str]:
     """Create/update/delete GitHub secrets to match env_data."""
     existing = await asyncio.to_thread(repo.get_secrets)
     existing_names = [s.name for s in existing]
@@ -27,13 +39,18 @@ async def _sync_secrets(repo: Any, env_data: dict[str, str], dry_run: bool) -> l
 
     for name, value in env_data.items():
         action = "Updating" if name in existing_names else "Creating"
+        verb = "update" if name in existing_names else "set"
         logger.info(f"{prefix}{action} secret {name}...")
+        if quiet_writer is not None:
+            quiet_writer(f"{prefix}{verb} {name} (secret)")
         tasks.append(asyncio.to_thread(repo.create_secret, name, value))
         synced.append(name)
 
     for name in existing_names:
         if name not in env_data:
             logger.info(f"{prefix}Deleting secret {name}...")
+            if quiet_writer is not None:
+                quiet_writer(f"{prefix}delete {name} (secret)")
             tasks.append(asyncio.to_thread(repo.delete_secret, name))
 
     if not dry_run:
@@ -41,7 +58,13 @@ async def _sync_secrets(repo: Any, env_data: dict[str, str], dry_run: bool) -> l
     return synced
 
 
-async def _sync_variables(repo: Any, env_data: dict[str, str], dry_run: bool) -> list[str]:
+async def _sync_variables(
+    repo: Any,
+    env_data: dict[str, str],
+    dry_run: bool,
+    *,
+    quiet_writer: QuietWriter | None = None,
+) -> list[str]:
     """Create/update/delete GitHub variables to match env_data."""
     existing = await asyncio.to_thread(repo.get_variables)
     existing_names = [v.name for v in existing]
@@ -52,6 +75,8 @@ async def _sync_variables(repo: Any, env_data: dict[str, str], dry_run: bool) ->
     for name, value in env_data.items():
         if name in existing_names:
             logger.info(f"{prefix}Updating variable {name}...")
+            if quiet_writer is not None:
+                quiet_writer(f"{prefix}update {name} (var)")
 
             def _delete_then_create(r: Any, n: str, v: str) -> None:
                 r.delete_variable(n)
@@ -60,12 +85,16 @@ async def _sync_variables(repo: Any, env_data: dict[str, str], dry_run: bool) ->
             tasks.append(asyncio.to_thread(_delete_then_create, repo, name, value))
         else:
             logger.info(f"{prefix}Creating variable {name}...")
+            if quiet_writer is not None:
+                quiet_writer(f"{prefix}set {name} (var)")
             tasks.append(asyncio.to_thread(repo.create_variable, name, value))
         synced.append(name)
 
     for name in existing_names:
         if name not in env_data:
             logger.info(f"{prefix}Deleting variable {name}...")
+            if quiet_writer is not None:
+                quiet_writer(f"{prefix}delete {name} (var)")
             tasks.append(asyncio.to_thread(repo.delete_variable, name))
 
     if not dry_run:
@@ -79,6 +108,7 @@ async def perform_sync(
     *,
     force_var: frozenset[str] | set[str] | None = None,
     force_secret: frozenset[str] | set[str] | None = None,
+    quiet_writer: QuietWriter | None = None,
 ) -> dict[str, list[str]]:
     """Sync .env file to GitHub secrets and variables.
 
@@ -98,7 +128,9 @@ async def perform_sync(
 
     repo = get_github_repo(gh_account, gh_repo)
 
-    synced_secrets = await _sync_secrets(repo, secrets, dry_run)
-    synced_variables = await _sync_variables(repo, variables, dry_run)
+    synced_secrets = await _sync_secrets(repo, secrets, dry_run, quiet_writer=quiet_writer)
+    synced_variables = await _sync_variables(
+        repo, variables, dry_run, quiet_writer=quiet_writer
+    )
 
     return {"secrets": synced_secrets, "variables": synced_variables}

--- a/tests/unit/test_env_chezmoi.py
+++ b/tests/unit/test_env_chezmoi.py
@@ -183,7 +183,7 @@ class TestConcurrency:
                 return subprocess.CompletedProcess(cmd, 0, stdout=" M dot_env\n", stderr="")
             return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
 
-        async def github_side_effect(filename, dry_run):
+        async def github_side_effect(filename, dry_run, **kwargs):
             github_started.set()
             # Wait for chezmoi pipeline to also be running.
             await asyncio.sleep(0.2)
@@ -217,7 +217,7 @@ class TestConcurrency:
 
         sync_called = threading.Event()
 
-        async def github_side_effect(filename, dry_run):
+        async def github_side_effect(filename, dry_run, **kwargs):
             sync_called.set()
             return {"secrets": [], "variables": []}
 
@@ -239,7 +239,7 @@ class TestConcurrency:
         """Both failures are surfaced in the error message."""
         mock_run.return_value = subprocess.CompletedProcess([], 1, stdout="", stderr="chezmoi boom")
 
-        async def github_side_effect(filename, dry_run):
+        async def github_side_effect(filename, dry_run, **kwargs):
             raise RuntimeError("github boom")
 
         mock_sync.side_effect = github_side_effect

--- a/tests/unit/test_env_cli.py
+++ b/tests/unit/test_env_cli.py
@@ -117,3 +117,73 @@ class TestPushCommand:
         with runner.isolated_filesystem():
             result = runner.invoke(cli, ["gh", "push", "nonexistent.env"])
         assert result.exit_code != 0
+
+
+class TestOutputQuieting:
+    """Default mode emits clean lines; --verbose preserves loguru detail; --json stays parseable."""
+
+    def _make_perform_sync_stub(self):
+        async def _stub(filename, dry_run, *, force_var=None, force_secret=None, quiet_writer=None):
+            if quiet_writer is not None:
+                quiet_writer("set FOO_KEY (secret)")
+                quiet_writer("set BAR_NAME (var)")
+            return {"secrets": ["FOO_KEY"], "variables": ["BAR_NAME"]}
+
+        return _stub
+
+    def test_push_default_output_is_clean(self):
+        from unittest.mock import patch
+
+        runner = CliRunner()
+        stub = self._make_perform_sync_stub()
+        with runner.isolated_filesystem():
+            Path(".env").write_text("FOO_KEY=ghp_abc\nBAR_NAME=hello\n")
+            with patch("augint_tools.cli.commands.env.perform_sync", new=stub, create=True):
+                # patching the module-level import is brittle; patch the source:
+                with patch("augint_tools.env.sync.perform_sync", new=stub):
+                    result = runner.invoke(cli, ["gh", "push"])
+
+        assert result.exit_code == 0, result.output
+        # Clean per-key lines, no timestamps or loguru-style level prefixes
+        assert "set FOO_KEY (secret)" in result.output
+        assert "set BAR_NAME (var)" in result.output
+        assert "DEBUG" not in result.output
+        assert "| INFO" not in result.output
+
+    def test_push_json_mode_suppresses_quiet_writer(self):
+        from unittest.mock import patch
+
+        runner = CliRunner()
+        stub = self._make_perform_sync_stub()
+        with runner.isolated_filesystem():
+            Path(".env").write_text("FOO_KEY=ghp_abc\n")
+            with patch("augint_tools.env.sync.perform_sync", new=stub):
+                result = runner.invoke(cli, ["--json", "gh", "push"])
+
+        assert result.exit_code == 0, result.output
+        # JSON mode must remain parseable: no quiet_writer narration
+        assert "set FOO_KEY (secret)" not in result.output
+        data = json.loads(result.output)
+        assert data["status"] == "ok"
+
+    def test_push_verbose_preserves_loguru_format(self):
+        """With --verbose, loguru emits to stderr in the documented format."""
+        from unittest.mock import patch
+
+        from loguru import logger
+
+        async def _stub(filename, dry_run, *, force_var=None, force_secret=None, quiet_writer=None):
+            logger.info("Creating secret VERBOSE_KEY...")
+            return {"secrets": ["VERBOSE_KEY"], "variables": []}
+
+        runner = CliRunner(mix_stderr=False)
+        with runner.isolated_filesystem():
+            Path(".env").write_text("VERBOSE_KEY=ghp_abc\n")
+            with patch("augint_tools.env.sync.perform_sync", new=_stub):
+                result = runner.invoke(cli, ["gh", "push", "--verbose"])
+
+        assert result.exit_code == 0, result.output
+        # Verbose loguru format includes a level token (DEBUG/INFO) and the message
+        assert "Creating secret VERBOSE_KEY" in (result.stderr or "")
+        # Restore loguru to a quiet state for following tests
+        logger.remove()


### PR DESCRIPTION
## Summary
- `ai-tools sync` and `ai-tools gh push` no longer dump timestamped, leveled loguru lines by default
- Clean per-key output (`set FOO_KEY (secret)`, `update BAR (var)`) plus a one-line summary
- `-v/--verbose` preserves the existing detailed loguru-style output verbatim
- `--json` keeps machine-parseable output (no narration)

## Test plan
- [ ] Run `ai-tools gh push --dry-run` and confirm clean output
- [ ] Run `ai-tools gh push -v --dry-run` and confirm full loguru output preserved
- [ ] Run `ai-tools sync --dry-run` and confirm same quieting behavior
- [ ] Confirm `--json` mode still emits structured response only