### PR TITLE
feat(dashboard): show last and next refresh times in top header

### DIFF
--- a/src/augint_tools/dashboard/app.py
+++ b/src/augint_tools/dashboard/app.py
@@ -61,7 +61,7 @@ from .widgets.drawer import Drawer
 from .widgets.error_drawer import ErrorDrawer
 from .widgets.highlight_bar import HighlightBar
 from .widgets.repo_card import RepoCard
-from .widgets.status_bar import StatusBar
+from .widgets.status_bar import StatusBar, format_header_refresh_text
 from .widgets.top_drawer import TopDrawer
 
 if TYPE_CHECKING:
@@ -176,7 +176,7 @@ class OrgDrawerHeader(Container):
     }
     OrgDrawerHeader > #hdr-countdown {
         width: auto;
-        max-width: 24;
+        max-width: 44;
         padding: 0 1;
         color: #d0d0d8;
         overflow: hidden;
@@ -283,27 +283,37 @@ class MainScreen(Screen[None]):
             card.apply_flash_phase(phase, window_seconds=window_seconds)
 
     def _countdown_text(self) -> str:
-        """Format the right-header countdown.
+        """Format the right-header refresh indicator.
 
-        Prefers the loading / refreshing state so users have an
-        unmistakable "we're working on it" indicator during the 20-30
-        second first fetch.  Otherwise shows the time until the next
-        auto-refresh.
+        Shows both "last: Xs ago" and "next: in Ys" so users see at a
+        glance both how fresh the on-screen data is and when the next
+        auto-refresh will fire.  Prefers loading / refreshing state so
+        users have an unmistakable "we're working on it" indicator
+        during the 20-30 second first fetch.
+
+        Drift note: ``next_refresh_at`` is set when ``_trigger_refresh``
+        starts a refresh, so during a long-running refresh the displayed
+        countdown briefly reflects the cycle that's already in flight.
+        We mask this by showing "refreshing..." while ``is_refreshing``
+        is true rather than a misleading countdown.
         """
         state = self._state
-        if state.is_refreshing and state.last_refresh_at is None:
-            return "loading data..."
-        if state.is_refreshing:
-            return "refreshing..."
-        if state.next_refresh_at is None:
-            return "auto-refresh off"
-        remaining = int((state.next_refresh_at - datetime.now(UTC)).total_seconds())
-        if remaining <= 0:
-            return "next: now"
-        if remaining >= 60:
-            m, s = divmod(remaining, 60)
-            return f"next refresh: {m}m{s:02d}s"
-        return f"next refresh: {remaining}s"
+        now = datetime.now(UTC)
+        last_age = (
+            int((now - state.last_refresh_at).total_seconds())
+            if state.last_refresh_at is not None
+            else None
+        )
+        remaining = (
+            int((state.next_refresh_at - now).total_seconds())
+            if state.next_refresh_at is not None
+            else None
+        )
+        return format_header_refresh_text(
+            is_refreshing=state.is_refreshing,
+            last_refresh_age_seconds=last_age,
+            next_refresh_remaining_seconds=remaining,
+        )
 
     def _rebuild_cards(self) -> None:
         theme_spec = get_theme(self._state.theme_name)

--- a/src/augint_tools/dashboard/widgets/status_bar.py
+++ b/src/augint_tools/dashboard/widgets/status_bar.py
@@ -59,6 +59,57 @@ def _format_age(seconds: int) -> str:
     return f"{d}d{rem // 3600}h" if rem >= 3600 else f"{d}d"
 
 
+def _format_countdown(seconds: int) -> str:
+    """Format a remaining-time countdown as 'Xs' or 'MmSSs'."""
+    if seconds < 0:
+        seconds = 0
+    if seconds >= 60:
+        m, s = divmod(seconds, 60)
+        return f"{m}m{s:02d}s"
+    return f"{seconds}s"
+
+
+def format_header_refresh_text(
+    *,
+    is_refreshing: bool,
+    last_refresh_age_seconds: int | None,
+    next_refresh_remaining_seconds: int | None,
+) -> str:
+    """Build the right-aligned header refresh indicator.
+
+    Shows both halves -- "last: Xs ago" and "next: in Ys" -- so users can
+    see at a glance both how fresh the on-screen data is and when the
+    next auto-refresh will fire.
+
+    Special states (first-launch loading, mid-refresh, auto-refresh
+    disabled) collapse to a single phrase rather than padding the line
+    with stale or meaningless values.
+
+    Inputs are pre-computed integers so this function can be unit-tested
+    without freezing time.
+    """
+    if is_refreshing and last_refresh_age_seconds is None:
+        return "loading data..."
+    if is_refreshing:
+        # Mid-refresh with prior data: keep showing how stale the visible
+        # data is; suppress the "next" half because it's about to reset.
+        if last_refresh_age_seconds is not None:
+            return f"last: {_format_age(max(0, last_refresh_age_seconds))} ago · refreshing..."
+        return "refreshing..."
+    if next_refresh_remaining_seconds is None:
+        if last_refresh_age_seconds is not None:
+            return f"last: {_format_age(max(0, last_refresh_age_seconds))} ago · auto-refresh off"
+        return "auto-refresh off"
+    last_part = (
+        f"last: {_format_age(max(0, last_refresh_age_seconds))} ago"
+        if last_refresh_age_seconds is not None
+        else "last: --"
+    )
+    remaining = max(0, next_refresh_remaining_seconds)
+    next_part = "next: now" if remaining == 0 else f"next: in {_format_countdown(remaining)}"
+    return f"{last_part} · {next_part}"
+
+
 def _describe_active_filters(active: set[str], team_labels: dict[str, str] | None = None) -> str:
     """Summarise the active filter set for the status bar."""
     if not active:

--- a/tests/unit/test_dashboard.py
+++ b/tests/unit/test_dashboard.py
@@ -1536,6 +1536,95 @@ class TestAppMisc:
         assert _format_age(7200) == "2h"
         assert _format_age(86400) == "1d"
 
+    def test_header_refresh_text_loading(self):
+        """First-launch with no prior data shows a loading phrase."""
+        from augint_tools.dashboard.widgets.status_bar import format_header_refresh_text
+
+        assert (
+            format_header_refresh_text(
+                is_refreshing=True,
+                last_refresh_age_seconds=None,
+                next_refresh_remaining_seconds=None,
+            )
+            == "loading data..."
+        )
+
+    def test_header_refresh_text_mid_refresh_with_prior_data(self):
+        """Mid-refresh with prior data shows last-age plus a 'refreshing' tag.
+
+        The next-refresh half is suppressed because ``next_refresh_at``
+        was just rolled forward by ``_trigger_refresh`` and would otherwise
+        show a misleading countdown to the cycle that's already in flight.
+        """
+        from augint_tools.dashboard.widgets.status_bar import format_header_refresh_text
+
+        text = format_header_refresh_text(
+            is_refreshing=True,
+            last_refresh_age_seconds=12,
+            next_refresh_remaining_seconds=600,
+        )
+        assert "last: 12s ago" in text
+        assert "refreshing" in text
+        assert "next:" not in text
+
+    def test_header_refresh_text_idle_shows_both_halves(self):
+        """Steady state: both 'last: ... ago' and 'next: in ...' are shown."""
+        from augint_tools.dashboard.widgets.status_bar import format_header_refresh_text
+
+        text = format_header_refresh_text(
+            is_refreshing=False,
+            last_refresh_age_seconds=12,
+            next_refresh_remaining_seconds=18,
+        )
+        assert "last: 12s ago" in text
+        assert "next: in 18s" in text
+
+    def test_header_refresh_text_idle_minutes(self):
+        """Countdown rolls over to MmSSs once it's at least a minute out."""
+        from augint_tools.dashboard.widgets.status_bar import format_header_refresh_text
+
+        text = format_header_refresh_text(
+            is_refreshing=False,
+            last_refresh_age_seconds=45,
+            next_refresh_remaining_seconds=125,
+        )
+        assert "last: 45s ago" in text
+        assert "next: in 2m05s" in text
+
+    def test_header_refresh_text_due_now(self):
+        """Zero remaining seconds renders as 'next: now', not 'in 0s'."""
+        from augint_tools.dashboard.widgets.status_bar import format_header_refresh_text
+
+        text = format_header_refresh_text(
+            is_refreshing=False,
+            last_refresh_age_seconds=30,
+            next_refresh_remaining_seconds=0,
+        )
+        assert "next: now" in text
+
+    def test_header_refresh_text_negative_remaining_clamped(self):
+        """A late tick (clock drift, scheduler hiccup) clamps to 'next: now'."""
+        from augint_tools.dashboard.widgets.status_bar import format_header_refresh_text
+
+        text = format_header_refresh_text(
+            is_refreshing=False,
+            last_refresh_age_seconds=30,
+            next_refresh_remaining_seconds=-3,
+        )
+        assert "next: now" in text
+
+    def test_header_refresh_text_auto_refresh_off(self):
+        """No scheduled next-refresh collapses the second half."""
+        from augint_tools.dashboard.widgets.status_bar import format_header_refresh_text
+
+        text = format_header_refresh_text(
+            is_refreshing=False,
+            last_refresh_age_seconds=120,
+            next_refresh_remaining_seconds=None,
+        )
+        assert "last: 2m ago" in text
+        assert "auto-refresh off" in text
+
     def test_bootstrap_seeds_last_refresh_at(self, tmp_path):
         """bootstrap_from_cache must set last_refresh_at from cache ts.
 


### PR DESCRIPTION
## Summary
- Top header now shows `last: Xs ago - next: in Ys`, right-aligned in the existing top row
- Reuses the existing 1s `_tick_status` interval (no new timer overhead)
- During an in-flight refresh, displays `last: Xs ago - refreshing...` to avoid drift confusion

## Test plan
- [ ] Launch `ai-tools dashboard -a`, confirm timer is visible in top-right of header
- [ ] Watch the countdown tick down each second
- [ ] Confirm display switches to `refreshing...` during a refresh cycle
- [ ] Confirm the Claude usage block is not displaced