### PR TITLE
chore(renovate): add canonical library Renovate config

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1,0 +1,116 @@
+// Renovate Bot Configuration -- Library (main-only, publishes to PyPI)
+// Docs: https://docs.renovatebot.com/configuration-options/
+//
+// Based on the canonical library-template.json5 maintained in ai-cc-tools
+// (plugins/ai-standardize/templates/library-template.json5).
+// augint-tools is a Python library managed with uv + pyproject.toml and
+// released via python-semantic-release.
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+
+  "extends": [
+    "config:recommended"
+  ],
+
+  "rebaseWhen": "behind-base-branch",
+
+  "schedule": ["before 11:59pm on Sunday"],
+  "timezone": "America/Los_Angeles",
+  "platformAutomerge": true,
+  // "auto" defers to repo merge method settings
+  "automergeStrategy": "auto",
+  "rangeStrategy": "auto",
+
+  "enabledManagers": [
+    "pep621",
+    "pre-commit",
+    "github-actions"
+  ],
+
+  "labels": ["dependencies", "renovate"],
+
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": ["before 11:59pm on the first day of the month"],
+    "commitMessageAction": "refresh",
+    "automerge": true
+  },
+
+  "vulnerabilityAlerts": {
+    "enabled": true,
+    "schedule": ["at any time"],
+    "labels": ["dependencies", "security"],
+    "commitMessagePrefix": "fix(deps):",
+    "automerge": true
+  },
+
+  "packageRules": [
+    // --- Production dependencies: chore(deps): -- no release ---
+
+    {
+      "matchDepTypes": ["project.dependencies"],
+      "matchManagers": ["pep621"],
+      "matchUpdateTypes": ["patch"],
+      "commitMessagePrefix": "chore(deps):",
+      "automerge": true
+    },
+    {
+      "matchDepTypes": ["project.dependencies"],
+      "matchManagers": ["pep621"],
+      "matchUpdateTypes": ["minor"],
+      "commitMessagePrefix": "chore(deps):",
+      "automerge": false
+    },
+    {
+      "matchDepTypes": ["project.dependencies"],
+      "matchManagers": ["pep621"],
+      "matchUpdateTypes": ["major"],
+      "commitMessagePrefix": "chore(deps):",
+      "automerge": false,
+      "dependencyDashboardApproval": true
+    },
+
+    // --- Dev dependencies: chore(deps-dev): -- grouped, no release ---
+
+    {
+      "matchDepTypes": ["project.optional-dependencies", "dependency-groups"],
+      "matchManagers": ["pep621"],
+      "matchUpdateTypes": ["patch", "minor"],
+      "commitMessagePrefix": "chore(deps-dev):",
+      "automerge": true,
+      "groupName": "dev dependency updates",
+      "groupSlug": "dev-deps"
+    },
+    {
+      "matchDepTypes": ["project.optional-dependencies", "dependency-groups"],
+      "matchManagers": ["pep621"],
+      "matchUpdateTypes": ["major"],
+      "commitMessagePrefix": "chore(deps-dev):",
+      "automerge": false
+    },
+
+    // --- python-semantic-release: never automerge ---
+    {
+      "matchPackageNames": ["python-semantic-release"],
+      "automerge": false,
+      "commitMessagePrefix": "chore(deps-dev):"
+    },
+
+    // --- GitHub Actions ---
+
+    {
+      "matchManagers": ["github-actions"],
+      "commitMessagePrefix": "ci(deps):",
+      "automerge": true,
+      "groupName": "GitHub Actions",
+      "groupSlug": "gh-actions"
+    },
+
+    // --- Pre-commit hooks ---
+    {
+      "matchManagers": ["pre-commit"],
+      "commitMessagePrefix": "ci(deps):",
+      "automerge": true
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds `renovate.json5` based on the canonical Augint library template (`ai-standardize` plugin)
- Weekly schedule, monthly `lockFileMaintenance` for `uv.lock`
- Patch automerges for prod deps; minor/major require human approval
- Dev dep patch+minor grouped and automerged; major separate, no automerge
- GitHub Actions and pre-commit hooks grouped and automerged with `ci(deps):` prefix
- `python-semantic-release` itself: never automerge

## Test plan
- [ ] Confirm Renovate GitHub App is installed on the org with access to `augint-tools`
- [ ] Wait for first Renovate run (or trigger manually) and confirm dependency dashboard issue is created