### PR TITLE
fix(dashboard): stop top-drawer flicker and harden toggle against races

### DIFF
--- a/src/augint_tools/dashboard/app.py
+++ b/src/augint_tools/dashboard/app.py
@@ -1545,7 +1545,11 @@ class DashboardApp(App[None]):
         """
         if self._main is None:
             return
-        if not self._main._top_drawer.is_open:
+        try:
+            if not self._main._top_drawer.is_open:
+                return
+        except Exception as exc:
+            logger.debug(f"_tick_sysmeter: drawer probe failed: {exc}")
             return
         self._refresh_sysmeter()
 
@@ -1694,12 +1698,22 @@ class DashboardApp(App[None]):
 
     def action_toggle_org(self) -> None:
         if self._main is None:
+            logger.debug("action_toggle_org: ignored, _main not yet mounted")
             return
-        self._main.toggle_org_drawer()
+        try:
+            self._main.toggle_org_drawer()
+        except Exception as exc:
+            # Don't let a render race in the drawer crash the whole app.
+            logger.exception(f"action_toggle_org: toggle failed: {exc}")
+            self.state.log_error("ui", f"toggle_org: {exc.__class__.__name__}: {exc}")
+            return
         # Kick a fresh probe on open so the sysmeter block isn't stale; the
         # periodic tick takes over from here.
-        if self._main._top_drawer.is_open:
-            self._refresh_sysmeter()
+        try:
+            if self._main._top_drawer.is_open:
+                self._refresh_sysmeter()
+        except Exception as exc:
+            logger.debug(f"action_toggle_org: post-toggle probe skipped: {exc}")
 
     def action_widen_card(self) -> None:
         self._resize_card(+PANEL_WIDTH_STEP)
@@ -1855,12 +1869,15 @@ class DashboardApp(App[None]):
 
     def on_repo_card_go_back(self, _message: RepoCard.GoBack) -> None:
         if self._main is not None:
-            if self._main._top_drawer.is_open:
-                self._main._top_drawer.close()
-                return
-            if self._main._drawer.is_open:
-                self._main._drawer.close()
-                return
+            try:
+                if self._main._top_drawer.is_open:
+                    self._main._top_drawer.close()
+                    return
+                if self._main._drawer.is_open:
+                    self._main._drawer.close()
+                    return
+            except Exception as exc:
+                logger.debug(f"on_repo_card_go_back: drawer probe failed: {exc}")
         if len(self.screen_stack) > 1:
             self.pop_screen()
 

--- a/src/augint_tools/dashboard/app.py
+++ b/src/augint_tools/dashboard/app.py
@@ -254,11 +254,18 @@ class MainScreen(Screen[None]):
         self._status_bar.tick()
         self._header.set_countdown(self._countdown_text())
         if self._top_drawer.is_open:
-            self._top_drawer.set_content(
-                self._org_drawer_left_sections(),
-                self._org_drawer_middle_sections(),
-                self._org_drawer_right_sections(),
-            )
+            logger.info("MainScreen.rerender: drawer open, refreshing top_drawer")
+            try:
+                self._top_drawer.set_content(
+                    self._org_drawer_left_sections(),
+                    self._org_drawer_middle_sections(),
+                    self._org_drawer_right_sections(),
+                )
+            except Exception as exc:
+                logger.exception(
+                    f"MainScreen.rerender: top_drawer.set_content failed: "
+                    f"{exc.__class__.__name__}: {exc}"
+                )
 
     def rerender_usage_only(self) -> None:
         """Update only the usage-derived UI (HighlightBar + open usage/org drawer)."""
@@ -267,11 +274,18 @@ class MainScreen(Screen[None]):
             self._drawer.set_content(self._usage_drawer_content())
         if self._top_drawer.is_open:
             # Org drawer embeds a usage block; refresh it in place.
-            self._top_drawer.set_content(
-                self._org_drawer_left_sections(),
-                self._org_drawer_middle_sections(),
-                self._org_drawer_right_sections(),
-            )
+            logger.info("MainScreen.rerender_usage_only: drawer open, refreshing top_drawer")
+            try:
+                self._top_drawer.set_content(
+                    self._org_drawer_left_sections(),
+                    self._org_drawer_middle_sections(),
+                    self._org_drawer_right_sections(),
+                )
+            except Exception as exc:
+                logger.exception(
+                    f"MainScreen.rerender_usage_only: top_drawer.set_content failed: "
+                    f"{exc.__class__.__name__}: {exc}"
+                )
 
     def tick_status(self) -> None:
         self._status_bar.tick()
@@ -1549,7 +1563,7 @@ class DashboardApp(App[None]):
             if not self._main._top_drawer.is_open:
                 return
         except Exception as exc:
-            logger.debug(f"_tick_sysmeter: drawer probe failed: {exc}")
+            logger.exception(f"_tick_sysmeter: drawer probe failed: {exc}")
             return
         self._refresh_sysmeter()
 
@@ -1698,8 +1712,9 @@ class DashboardApp(App[None]):
 
     def action_toggle_org(self) -> None:
         if self._main is None:
-            logger.debug("action_toggle_org: ignored, _main not yet mounted")
+            logger.info("action_toggle_org: ignored, _main not yet mounted")
             return
+        logger.info("action_toggle_org: dispatching to MainScreen.toggle_org_drawer")
         try:
             self._main.toggle_org_drawer()
         except Exception as exc:
@@ -1711,9 +1726,10 @@ class DashboardApp(App[None]):
         # periodic tick takes over from here.
         try:
             if self._main._top_drawer.is_open:
+                logger.info("action_toggle_org: drawer now open, kicking sysmeter")
                 self._refresh_sysmeter()
         except Exception as exc:
-            logger.debug(f"action_toggle_org: post-toggle probe skipped: {exc}")
+            logger.exception(f"action_toggle_org: post-toggle probe failed: {exc}")
 
     def action_widen_card(self) -> None:
         self._resize_card(+PANEL_WIDTH_STEP)

--- a/src/augint_tools/dashboard/widgets/top_drawer.py
+++ b/src/augint_tools/dashboard/widgets/top_drawer.py
@@ -15,6 +15,7 @@ section id, which the app uses to open an explanatory modal.
 
 from __future__ import annotations
 
+from loguru import logger
 from rich.text import Text
 from textual import events
 from textual.containers import Container
@@ -110,22 +111,88 @@ class TopDrawer(Container):
         or a single :class:`~rich.text.Text` for backward compatibility. A
         raw ``Text`` is treated as a one-section column with a stub id.
         """
-        self._set_column(self._left, _normalise(left))
-        self._set_column(self._middle, _normalise(middle))
-        self._set_column(self._right, _normalise(right))
+        # Skip while not mounted -- mount() on an unmounted Container raises
+        # MountError in Textual. The first paint of an open drawer is driven
+        # by toggle()/open_with() which run after compose() has mounted the
+        # column containers, so this only protects against races where a
+        # background tick fires before/after that window.
+        if not self._columns_ready():
+            logger.debug("top_drawer.set_content: columns not mounted yet, skipping")
+            return
+        self._reconcile_column(self._left, _normalise(left))
+        self._reconcile_column(self._middle, _normalise(middle))
+        self._reconcile_column(self._right, _normalise(right))
 
-    def _set_column(self, column: Container, sections: list[Section]) -> None:
-        """Rebuild a column to host exactly ``sections`` in order."""
-        # Remove any existing child widgets before re-mounting.
+    def _columns_ready(self) -> bool:
+        """True when all three column containers are mounted and usable."""
+        for column in (self._left, self._middle, self._right):
+            if not getattr(column, "is_mounted", False):
+                return False
+        return True
+
+    def _reconcile_column(self, column: Container, sections: list[Section]) -> None:
+        """Update ``column`` to host exactly ``sections`` in order.
+
+        Reconciles in place rather than tearing down and rebuilding: existing
+        Static widgets with matching section ids have their content updated
+        via ``Static.update()``; only added/removed sections trigger
+        ``mount()`` / ``remove()``. This avoids the flicker where rapid
+        ``set_content`` calls (from refresh ticks while the drawer is open)
+        leave the column momentarily empty between async remove and mount.
+        """
+        # Build a map of currently-mounted Static widgets keyed by section id.
+        existing: dict[str, Static] = {}
         for child in list(column.children):
-            child.remove()
+            wid = getattr(child, "id", None) or ""
+            if wid.startswith(_SECTION_ID_PREFIX) and isinstance(child, Static):
+                existing[wid[len(_SECTION_ID_PREFIX) :]] = child
+            else:
+                # Unknown child (legacy or stale) -- drop it.
+                child.remove()
+
+        desired_ids = {section_id for section_id, _ in sections}
+
+        # Remove sections that no longer appear in the desired list.
+        stale_ids = [sid for sid in existing if sid not in desired_ids]
+        for stale_id in stale_ids:
+            existing[stale_id].remove()
+            del existing[stale_id]
+
+        # Update or mount each desired section in order.
         for section_id, text in sections:
-            static = Static(
-                text,
-                id=f"{_SECTION_ID_PREFIX}{section_id}",
-                classes="top-drawer-section",
-            )
-            column.mount(static)
+            widget = existing.get(section_id)
+            if widget is None:
+                static = Static(
+                    text,
+                    id=f"{_SECTION_ID_PREFIX}{section_id}",
+                    classes="top-drawer-section",
+                )
+                try:
+                    column.mount(static)
+                except Exception as exc:
+                    # Defensive: a mount race (column not yet mounted, or
+                    # mid-removal) shouldn't crash the toggle handler.
+                    logger.debug(
+                        f"top_drawer.mount failed for section {section_id!r}: "
+                        f"{exc.__class__.__name__}: {exc}"
+                    )
+            else:
+                # In-place update -- no remount, no flicker.
+                widget.update(text)
+
+        # Reorder to match the desired sequence. move_child is a no-op when
+        # the widget is already at the correct index.
+        for idx, (section_id, _) in enumerate(sections):
+            widget = existing.get(section_id)
+            if widget is None:
+                # Newly mounted above; Textual appended it at the end.
+                widget = column.query_one(f"#{_SECTION_ID_PREFIX}{section_id}", Static)  # type: ignore[arg-type]
+            try:
+                column.move_child(widget, before=idx)
+            except Exception:
+                # move_child raises if the widget isn't yet a child (mount
+                # is still pending). Order will settle on the next refresh.
+                pass
 
     def toggle(
         self,
@@ -135,8 +202,10 @@ class TopDrawer(Container):
     ) -> None:
         """Open the drawer with the column contents, or close if already open."""
         if self.is_open:
+            logger.debug("top_drawer.toggle: closing")
             self.close()
             return
+        logger.debug("top_drawer.toggle: opening")
         self.set_content(left, middle, right)
         self.add_class("open")
 

--- a/src/augint_tools/dashboard/widgets/top_drawer.py
+++ b/src/augint_tools/dashboard/widgets/top_drawer.py
@@ -33,6 +33,23 @@ _COLUMN_IDS = ("top-drawer-left", "top-drawer-middle", "top-drawer-right")
 Section = tuple[str, Text]
 
 
+def _column_children_ids(column: Container) -> list[str]:
+    """Snapshot the ids of ``column``'s current children.
+
+    Used in log lines so we can see exactly which siblings were already
+    present when a DuplicateIds-style collision occurred.
+    """
+    out: list[str] = []
+    try:
+        for child in column.children:
+            wid = getattr(child, "id", None)
+            out.append(wid if wid is not None else "<no-id>")
+    except Exception:
+        # Never let logging crash the render path.
+        pass
+    return out
+
+
 class TopDrawer(Container):
     """Top-docked drawer that displaces the card grid when open."""
 
@@ -117,11 +134,23 @@ class TopDrawer(Container):
         # column containers, so this only protects against races where a
         # background tick fires before/after that window.
         if not self._columns_ready():
-            logger.debug("top_drawer.set_content: columns not mounted yet, skipping")
+            logger.info(
+                "top_drawer.set_content: columns not mounted yet, skipping "
+                f"(is_open={self.is_open})"
+            )
             return
-        self._reconcile_column(self._left, _normalise(left))
-        self._reconcile_column(self._middle, _normalise(middle))
-        self._reconcile_column(self._right, _normalise(right))
+        left_sections = _normalise(left)
+        middle_sections = _normalise(middle)
+        right_sections = _normalise(right)
+        logger.info(
+            "top_drawer.set_content: reconciling columns "
+            f"left={[sid for sid, _ in left_sections]} "
+            f"middle={[sid for sid, _ in middle_sections]} "
+            f"right={[sid for sid, _ in right_sections]}"
+        )
+        self._reconcile_column(self._left, left_sections, column_name="left")
+        self._reconcile_column(self._middle, middle_sections, column_name="middle")
+        self._reconcile_column(self._right, right_sections, column_name="right")
 
     def _columns_ready(self) -> bool:
         """True when all three column containers are mounted and usable."""
@@ -130,7 +159,13 @@ class TopDrawer(Container):
                 return False
         return True
 
-    def _reconcile_column(self, column: Container, sections: list[Section]) -> None:
+    def _reconcile_column(
+        self,
+        column: Container,
+        sections: list[Section],
+        *,
+        column_name: str = "?",
+    ) -> None:
         """Update ``column`` to host exactly ``sections`` in order.
 
         Reconciles in place rather than tearing down and rebuilding: existing
@@ -139,46 +174,127 @@ class TopDrawer(Container):
         ``mount()`` / ``remove()``. This avoids the flicker where rapid
         ``set_content`` calls (from refresh ticks while the drawer is open)
         leave the column momentarily empty between async remove and mount.
+
+        Hardened against re-entrant calls: collecting ``existing`` reads
+        ``column.children`` directly (which reflects pending mounts), and
+        every ``mount()`` is wrapped in a guarded helper that swallows
+        ``DuplicateIds`` so a render race cannot crash the toggle handler.
         """
+        before_ids = _column_children_ids(column)
         # Build a map of currently-mounted Static widgets keyed by section id.
+        # Walk ``column.children`` once -- this includes widgets whose mount
+        # is still in flight, which is critical for survival of re-entrant
+        # set_content calls fired by background ticks.
         existing: dict[str, Static] = {}
         for child in list(column.children):
             wid = getattr(child, "id", None) or ""
             if wid.startswith(_SECTION_ID_PREFIX) and isinstance(child, Static):
-                existing[wid[len(_SECTION_ID_PREFIX) :]] = child
+                section_key = wid[len(_SECTION_ID_PREFIX) :]
+                if section_key in existing:
+                    # A duplicate already snuck in (prior race). Drop the
+                    # extra so we don't hand the same id back to mount().
+                    logger.warning(
+                        f"top_drawer.reconcile.duplicate_in_column[{column_name}]: "
+                        f"removing extra widget for section {section_key!r}"
+                    )
+                    try:
+                        child.remove()
+                    except Exception as exc:
+                        logger.exception(
+                            f"top_drawer.reconcile.duplicate_remove_failed[{column_name}]: "
+                            f"{exc.__class__.__name__}: {exc}"
+                        )
+                    continue
+                existing[section_key] = child
             else:
                 # Unknown child (legacy or stale) -- drop it.
-                child.remove()
+                try:
+                    child.remove()
+                except Exception as exc:
+                    logger.exception(
+                        f"top_drawer.reconcile.unknown_remove_failed[{column_name}]: "
+                        f"{exc.__class__.__name__}: {exc}"
+                    )
 
         desired_ids = {section_id for section_id, _ in sections}
 
         # Remove sections that no longer appear in the desired list.
         stale_ids = [sid for sid in existing if sid not in desired_ids]
         for stale_id in stale_ids:
-            existing[stale_id].remove()
+            logger.info(
+                f"top_drawer.remove_section[{column_name}]: section={stale_id!r} "
+                f"id={_SECTION_ID_PREFIX}{stale_id}"
+            )
+            try:
+                existing[stale_id].remove()
+            except Exception as exc:
+                logger.exception(
+                    f"top_drawer.remove_section_failed[{column_name}]: "
+                    f"section={stale_id!r}: {exc.__class__.__name__}: {exc}"
+                )
             del existing[stale_id]
 
         # Update or mount each desired section in order.
+        mounted_count = 0
+        updated_count = 0
         for section_id, text in sections:
             widget = existing.get(section_id)
+            full_id = f"{_SECTION_ID_PREFIX}{section_id}"
             if widget is None:
+                # Last-chance dedupe: query the column directly. mount()
+                # raises DuplicateIds if any child (including a widget we
+                # missed because remove() is still pending) has the same id.
+                try:
+                    pre_existing = column.query(f"#{full_id}")
+                    if len(pre_existing) > 0:
+                        # Reuse the in-DOM widget; update its content rather
+                        # than mount a duplicate.
+                        candidate = pre_existing.first()
+                        if isinstance(candidate, Static):
+                            logger.info(
+                                f"top_drawer.adopt_pending[{column_name}]: "
+                                f"section={section_id!r} adopted existing widget "
+                                f"id={full_id} (mount/remove race)"
+                            )
+                            candidate.update(text)
+                            existing[section_id] = candidate
+                            updated_count += 1
+                            continue
+                except Exception as exc:
+                    # query() can raise during teardown; fall through to mount.
+                    logger.debug(
+                        f"top_drawer.predupe_query_failed[{column_name}]: "
+                        f"section={section_id!r}: {exc.__class__.__name__}: {exc}"
+                    )
                 static = Static(
                     text,
-                    id=f"{_SECTION_ID_PREFIX}{section_id}",
+                    id=full_id,
                     classes="top-drawer-section",
+                )
+                sibling_ids = _column_children_ids(column)
+                logger.info(
+                    f"top_drawer.mount_section[{column_name}]: section={section_id!r} "
+                    f"id={full_id} siblings={sibling_ids}"
                 )
                 try:
                     column.mount(static)
+                    mounted_count += 1
                 except Exception as exc:
-                    # Defensive: a mount race (column not yet mounted, or
-                    # mid-removal) shouldn't crash the toggle handler.
-                    logger.debug(
-                        f"top_drawer.mount failed for section {section_id!r}: "
-                        f"{exc.__class__.__name__}: {exc}"
+                    # Defensive: a mount race (column not yet mounted, or a
+                    # DuplicateIds collision because remove() is still in
+                    # flight) shouldn't crash the toggle handler. Log the
+                    # full traceback so we can diagnose without re-running.
+                    sibling_ids_now = _column_children_ids(column)
+                    logger.exception(
+                        f"top_drawer.mount_section_failed[{column_name}]: "
+                        f"section={section_id!r} id={full_id} "
+                        f"err={exc.__class__.__name__}: {exc} "
+                        f"siblings_at_failure={sibling_ids_now}"
                     )
             else:
                 # In-place update -- no remount, no flicker.
                 widget.update(text)
+                updated_count += 1
 
         # Reorder to match the desired sequence. move_child is a no-op when
         # the widget is already at the correct index.
@@ -186,13 +302,25 @@ class TopDrawer(Container):
             widget = existing.get(section_id)
             if widget is None:
                 # Newly mounted above; Textual appended it at the end.
-                widget = column.query_one(f"#{_SECTION_ID_PREFIX}{section_id}", Static)  # type: ignore[arg-type]
+                try:
+                    widget = column.query_one(f"#{_SECTION_ID_PREFIX}{section_id}", Static)
+                except Exception:
+                    # Mount is still pending; order will settle next tick.
+                    continue
             try:
                 column.move_child(widget, before=idx)
             except Exception:
                 # move_child raises if the widget isn't yet a child (mount
                 # is still pending). Order will settle on the next refresh.
                 pass
+
+        after_ids = _column_children_ids(column)
+        logger.info(
+            f"top_drawer.reconcile.done[{column_name}]: "
+            f"before={before_ids} after={after_ids} "
+            f"mounted={mounted_count} updated={updated_count} "
+            f"removed={len(stale_ids)}"
+        )
 
     def toggle(
         self,
@@ -201,12 +329,29 @@ class TopDrawer(Container):
         right: list[Section] | Text | None = None,
     ) -> None:
         """Open the drawer with the column contents, or close if already open."""
-        if self.is_open:
-            logger.debug("top_drawer.toggle: closing")
+        currently_open = self.is_open
+        try:
+            child_count = sum(
+                len(list(c.children)) for c in (self._left, self._middle, self._right)
+            )
+        except Exception:
+            child_count = -1
+        logger.info(
+            f"top_drawer.toggle: is_open={currently_open} "
+            f"action={'close' if currently_open else 'open'} "
+            f"total_section_children={child_count}"
+        )
+        if currently_open:
             self.close()
             return
-        logger.debug("top_drawer.toggle: opening")
-        self.set_content(left, middle, right)
+        try:
+            self.set_content(left, middle, right)
+        except Exception as exc:
+            logger.exception(
+                f"top_drawer.toggle.set_content_failed: {exc.__class__.__name__}: {exc}"
+            )
+            # Still flip the open class -- a partial render is better than a
+            # hung toggle key.
         self.add_class("open")
 
     def open_with(
@@ -215,10 +360,17 @@ class TopDrawer(Container):
         middle: list[Section] | Text | None = None,
         right: list[Section] | Text | None = None,
     ) -> None:
-        self.set_content(left, middle, right)
+        logger.info("top_drawer.open_with: forcing open")
+        try:
+            self.set_content(left, middle, right)
+        except Exception as exc:
+            logger.exception(
+                f"top_drawer.open_with.set_content_failed: {exc.__class__.__name__}: {exc}"
+            )
         self.add_class("open")
 
     def close(self) -> None:
+        logger.info("top_drawer.close: removing 'open' class")
         self.remove_class("open")
 
     # ------------------------------------------------------------------

--- a/tests/unit/test_dashboard.py
+++ b/tests/unit/test_dashboard.py
@@ -2416,3 +2416,112 @@ class TestWidgetHelpScreen:
                 assert top.widget_id == "activity"
 
         asyncio.run(run())
+
+
+class TestTopDrawerReconcile:
+    """Regression tests for the drawer's set_content reconcile path.
+
+    The drawer used to remove every Static and remount fresh ones on each
+    set_content call, which caused (a) flicker between the async remove and
+    mount and (b) intermittent crashes when set_content fired during a
+    refresh tick. The reconcile path keeps Static widgets across redraws
+    and updates their content in place; tests below pin that contract.
+    """
+
+    @tui
+    def test_set_content_before_mount_is_safe(self):
+        """Calling set_content on an unmounted TopDrawer must not raise.
+
+        Background ticks (sysmeter, refresh) can fire before MainScreen has
+        finished composing. The pre-mount call must be a no-op rather than a
+        MountError.
+        """
+        from rich.text import Text as _Text
+
+        from augint_tools.dashboard.widgets.top_drawer import TopDrawer
+
+        drawer = TopDrawer()
+        # Not mounted -- should be a quiet no-op, not a crash.
+        drawer.set_content([("system", _Text("anything"))])
+
+    @tui
+    def test_set_content_reuses_static_widgets_across_calls(self):
+        """Repeated set_content with the same section ids must update Static
+        widgets in place (no remount). Identity preservation is what kills
+        the open->close->reopen flicker."""
+        from rich.text import Text as _Text
+
+        async def run():
+            app = DashboardApp(repos=[], skip_refresh=True, org_name="acme")
+            app.state.healths = [_health(full_name="org/a")]
+            app.state.health_by_name = {"org/a": app.state.healths[0]}
+            async with app.run_test() as pilot:
+                await pilot.pause()
+                assert app._main is not None
+                drawer = app._main._top_drawer
+                # Open the drawer first so columns are mounted and populated.
+                app.action_toggle_org()
+                await pilot.pause()
+                first_ids = {
+                    child.id: id(child)
+                    for column in (drawer._left, drawer._middle, drawer._right)
+                    for child in column.children
+                    if child.id
+                }
+                assert first_ids, "expected at least one section after open"
+                # Re-call set_content with fresh Text objects but the same
+                # section structure -- widget identity should be preserved.
+                drawer.set_content(
+                    [("system", _Text("updated"))],
+                    [("usage", _Text("updated middle"))],
+                    [("leaderboard", _Text("updated right"))],
+                )
+                await pilot.pause()
+                second_ids = {
+                    child.id: id(child)
+                    for column in (drawer._left, drawer._middle, drawer._right)
+                    for child in column.children
+                    if child.id
+                }
+                shared = set(first_ids) & set(second_ids)
+                assert shared, "no shared section ids after second set_content"
+                for sid in shared:
+                    assert first_ids[sid] == second_ids[sid], (
+                        f"section {sid!r} was remounted instead of updated in place"
+                    )
+
+        asyncio.run(run())
+
+    @tui
+    def test_action_toggle_org_does_not_crash_when_main_unset(self):
+        """Pressing the org-toggle key before the main screen is mounted
+        must be a no-op, not an AttributeError. Defensive check for the
+        race the user hit when --log was wired up to capture the crash."""
+
+        async def run():
+            app = DashboardApp(repos=[], skip_refresh=True, org_name="acme")
+            # Deliberately do not enter run_test -- _main stays None.
+            app.action_toggle_org()  # must not raise
+
+        asyncio.run(run())
+
+    @tui
+    def test_repeated_toggle_keeps_drawer_consistent(self):
+        """Toggling open->close->open->close in quick succession must not
+        crash and must leave is_open in a sane state. Mirrors the reported
+        bug where pressing the toggle key several times eventually crashed."""
+
+        async def run():
+            app = DashboardApp(repos=[], skip_refresh=True, org_name="acme")
+            app.state.healths = [_health(full_name="org/a")]
+            app.state.health_by_name = {"org/a": app.state.healths[0]}
+            async with app.run_test() as pilot:
+                await pilot.pause()
+                assert app._main is not None
+                drawer = app._main._top_drawer
+                for expected_open in (True, False, True, False, True):
+                    app.action_toggle_org()
+                    await pilot.pause()
+                    assert drawer.is_open is expected_open
+
+        asyncio.run(run())

--- a/tests/unit/test_dashboard.py
+++ b/tests/unit/test_dashboard.py
@@ -2525,3 +2525,127 @@ class TestTopDrawerReconcile:
                     assert drawer.is_open is expected_open
 
         asyncio.run(run())
+
+    @tui
+    def test_open_close_open_does_not_raise_duplicate_ids(self):
+        """The reported bug: opening the drawer, closing it, then opening
+        again raises ``DuplicateIds`` because Static widgets from the first
+        open are still in the column when the second open's mount fires.
+
+        Even with the reconcile-in-place fix, a refresh tick (sysmeter,
+        usage, periodic rerender) firing between the close and the next
+        open can interleave a remove with a remount of the same id. This
+        test pins that the open->close->open sequence stays crash-free.
+        """
+
+        async def run():
+            app = DashboardApp(repos=[], skip_refresh=True, org_name="acme")
+            app.state.healths = [_health(full_name="org/a")]
+            app.state.health_by_name = {"org/a": app.state.healths[0]}
+            async with app.run_test() as pilot:
+                await pilot.pause()
+                assert app._main is not None
+                drawer = app._main._top_drawer
+                # Open
+                app.action_toggle_org()
+                await pilot.pause()
+                assert drawer.is_open
+                # Close
+                app.action_toggle_org()
+                await pilot.pause()
+                assert not drawer.is_open
+                # Reopen -- this is the path that used to raise DuplicateIds.
+                app.action_toggle_org()
+                await pilot.pause()
+                assert drawer.is_open
+
+        asyncio.run(run())
+
+    @tui
+    def test_set_content_called_twice_in_a_row_survives(self):
+        """Two back-to-back set_content calls (mimicking a refresh tick
+        firing on top of a toggle) must not raise DuplicateIds even when
+        the second call lands while the first call's mount is still pending.
+        """
+        from rich.text import Text as _Text
+
+        async def run():
+            app = DashboardApp(repos=[], skip_refresh=True, org_name="acme")
+            app.state.healths = [_health(full_name="org/a")]
+            app.state.health_by_name = {"org/a": app.state.healths[0]}
+            async with app.run_test() as pilot:
+                await pilot.pause()
+                assert app._main is not None
+                drawer = app._main._top_drawer
+                app.action_toggle_org()
+                await pilot.pause()
+                # Fire two set_content calls without a pause between them.
+                # On the buggy code path the second mount of the same id
+                # would raise DuplicateIds.
+                drawer.set_content(
+                    [("system", _Text("a"))],
+                    [("usage", _Text("b"))],
+                    [("leaderboard", _Text("c"))],
+                )
+                drawer.set_content(
+                    [("system", _Text("a2"))],
+                    [("usage", _Text("b2"))],
+                    [("leaderboard", _Text("c2"))],
+                )
+                await pilot.pause()
+                # No crash == pass. Sanity-check the ids are unique.
+                seen_ids: list[str] = []
+                for column in (drawer._left, drawer._middle, drawer._right):
+                    for child in column.children:
+                        if child.id:
+                            seen_ids.append(child.id)
+                assert len(seen_ids) == len(set(seen_ids)), f"duplicate ids in drawer: {seen_ids}"
+
+        asyncio.run(run())
+
+    def test_reconcile_dedupes_when_same_id_already_present(self):
+        """Pure-state-machine guard: if the column somehow already contains
+        two widgets with the same section id (e.g. from a prior race), the
+        reconcile path must drop the extra rather than mount a third.
+
+        Runs without a Pilot so it's safe in CI without textual headless.
+        """
+        from rich.text import Text as _Text
+        from textual.widgets import Static
+
+        from augint_tools.dashboard.widgets.top_drawer import (
+            _SECTION_ID_PREFIX,
+            TopDrawer,
+        )
+
+        drawer = TopDrawer()
+        # Simulate a column with a duplicate already present. We can't
+        # really mount widgets without an app, so we monkey-patch the
+        # column's children with stubs that quack like Static.
+        sid = "system"
+        full_id = f"{_SECTION_ID_PREFIX}{sid}"
+
+        class _StubStatic(Static):
+            removed = False
+
+            def remove(self):  # type: ignore[override]
+                self.removed = True
+
+            def update(self, *args, **kwargs):  # type: ignore[override]
+                pass
+
+        first = _StubStatic("", id=full_id)
+        second = _StubStatic("", id=full_id)
+        column = drawer._left
+        # Bypass mount -- inject the children directly for the test.
+        column._nodes._nodes.extend([first, second])  # type: ignore[attr-defined]
+
+        # Force the columns_ready check to pass.
+        object.__setattr__(column, "_is_mounted", True)
+        object.__setattr__(drawer._middle, "_is_mounted", True)
+        object.__setattr__(drawer._right, "_is_mounted", True)
+
+        # Reconcile a single section -- the duplicate should be dropped.
+        drawer._reconcile_column(column, [(sid, _Text("hi"))], column_name="left")
+        # At least one of the two stubs got remove()'d.
+        assert first.removed or second.removed


### PR DESCRIPTION
## Summary
- Root cause: `TopDrawer._set_column` tore down and remounted every Static on every `set_content()` call; async `remove()` vs sync `mount()` caused flicker and DuplicateIds crashes
- Now reconciles in place via `Static.update(text)`, only mounts/removes on actual section adds/removals
- Pre-mount guard prevents `MountError` from background ticks firing before columns are mounted
- `action_toggle_org`, `rerender`, `_tick_sysmeter` wrapped in try/except with `logger.exception`
- INFO-level logging at every drawer transition for future debugging

## Test plan
- [ ] Run `ai-tools dashboard -a --log ./tui.log`
- [ ] Press `i` to open org drawer -- should render cleanly, stay open
- [ ] Wait for auto-refresh while drawer is open -- columns should not flicker
- [ ] Press `i` again to close, then reopen -- no crash, no DuplicateIds
- [ ] Check tui.log for `top_drawer.toggle:` and `top_drawer.set_content:` entries