### PR TITLE
feat(dashboard): sectioned filter panel with per-section select all/none

### DIFF
--- a/src/augint_tools/dashboard/app.py
+++ b/src/augint_tools/dashboard/app.py
@@ -1767,13 +1767,21 @@ class DashboardApp(App[None]):
         self._rerender()
 
     def action_toggle_workspace(self) -> None:
-        mode = "no-workspace"
-        if mode in self.state.active_filters:
-            self.state.active_filters.discard(mode)
-            self.notify("showing workspaces", timeout=2)
-        else:
-            self.state.active_filters.add(mode)
+        has_ws = "workspace" in self.state.active_filters
+        has_nws = "non-workspace" in self.state.active_filters
+        self.state.active_filters.discard("workspace")
+        self.state.active_filters.discard("non-workspace")
+        if not has_ws and not has_nws:
+            # show all -> hide workspaces
+            self.state.active_filters.add("non-workspace")
             self.notify("hiding workspaces", timeout=2)
+        elif has_nws:
+            # hide workspaces -> workspace only
+            self.state.active_filters.add("workspace")
+            self.notify("workspace repos only", timeout=2)
+        else:
+            # workspace only -> show all
+            self.notify("showing all repos", timeout=2)
         self._rerender()
         self._save_prefs()
 

--- a/src/augint_tools/dashboard/prefs.py
+++ b/src/augint_tools/dashboard/prefs.py
@@ -37,6 +37,12 @@ class DashboardPrefs:
     def from_dict(cls, data: dict) -> DashboardPrefs:
         allowed = {f.name for f in __import__("dataclasses").fields(cls)}
         filtered = {k: v for k, v in data.items() if k in allowed}
+        # Migrate legacy "no-workspace" -> "non-workspace".
+        filters = filtered.get("active_filters")
+        if isinstance(filters, list) and "no-workspace" in filters:
+            filtered["active_filters"] = [
+                "non-workspace" if f == "no-workspace" else f for f in filters
+            ]
         return cls(**filtered)
 
 

--- a/src/augint_tools/dashboard/screens/filter_panel.py
+++ b/src/augint_tools/dashboard/screens/filter_panel.py
@@ -1,9 +1,12 @@
-"""FilterPanel -- multi-select filter overlay.
+"""FilterPanel -- sectioned multi-select filter overlay.
 
 Selections apply live -- each toggle posts :class:`FilterChanged` so the
 main screen can rebuild the grid immediately.  The panel is still
 dismissible with ``escape``/``f``; we return the final selection set
 from ``dismiss`` so callers that want the list have it.
+
+The panel is organised into sections (Orgs, Teams, Visibility, Workspace,
+Status) each with their own SelectionList and All/None toggle buttons.
 """
 
 from __future__ import annotations
@@ -12,17 +15,82 @@ from typing import TYPE_CHECKING
 
 from textual import events
 from textual.binding import Binding
-from textual.containers import Container
+from textual.containers import Container, Horizontal, VerticalScroll
 from textual.message import Message
 from textual.screen import ModalScreen
-from textual.widgets import SelectionList
+from textual.widgets import Button, Rule, SelectionList, Static
 from textual.widgets.selection_list import Selection
 
-from ..state import available_filter_modes
+from ..state import available_filter_sections
 from ..widgets.status_bar import describe_filter
 
 if TYPE_CHECKING:
     from ..state import AppState
+
+
+class FilterSection(Container):
+    """A labelled group of filter checkboxes with All/None toggle buttons."""
+
+    DEFAULT_CSS = """
+    FilterSection {
+        height: auto;
+        padding: 0 0 1 0;
+    }
+    FilterSection .section-header {
+        height: 1;
+        width: 100%;
+        padding: 0;
+    }
+    FilterSection .section-title {
+        width: 1fr;
+        text-style: bold;
+    }
+    FilterSection .section-btn {
+        min-width: 6;
+        height: 1;
+        border: none;
+        padding: 0 1;
+        margin: 0;
+        background: $surface;
+        color: $text-muted;
+    }
+    FilterSection .section-btn:hover {
+        background: $boost;
+        color: $text;
+    }
+    FilterSection SelectionList {
+        height: auto;
+        max-height: 100%;
+        padding: 0;
+        margin: 0;
+    }
+    """
+
+    def __init__(
+        self,
+        title: str,
+        section_id: str,
+        selections: list[Selection[str]],
+    ) -> None:
+        super().__init__(id=f"section-{section_id}")
+        self._title = title
+        self._section_id = section_id
+        self._selections = selections
+
+    def compose(self):
+        with Horizontal(classes="section-header"):
+            yield Static(self._title, classes="section-title")
+            yield Button("All", id=f"{self._section_id}-all", classes="section-btn")
+            yield Button("None", id=f"{self._section_id}-none", classes="section-btn")
+        yield SelectionList[str](*self._selections, id=f"{self._section_id}-list")
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        event.stop()
+        sel_list = self.query_one(SelectionList)
+        if event.button.id and event.button.id.endswith("-all"):
+            sel_list.select_all()
+        elif event.button.id and event.button.id.endswith("-none"):
+            sel_list.deselect_all()
 
 
 class FilterPanel(ModalScreen[set[str]]):
@@ -33,15 +101,19 @@ class FilterPanel(ModalScreen[set[str]]):
         align: center middle;
     }
     FilterPanel > Container {
-        width: 50;
+        width: 58;
         max-height: 80%;
         border: thick $accent;
         background: $surface;
         padding: 1 2;
     }
-    FilterPanel SelectionList {
+    FilterPanel VerticalScroll {
         height: auto;
         max-height: 100%;
+    }
+    FilterPanel Rule {
+        margin: 0 0 1 0;
+        color: $accent;
     }
     """
 
@@ -55,8 +127,6 @@ class FilterPanel(ModalScreen[set[str]]):
 
         Carries the current selected filter keys so the main screen can
         apply them live without waiting for the panel to be dismissed.
-        This matches the mental model of checkboxes on a filter bar --
-        toggling one immediately filters the view underneath.
         """
 
         def __init__(self, selected: set[str]) -> None:
@@ -67,37 +137,57 @@ class FilterPanel(ModalScreen[set[str]]):
         super().__init__()
         self._state = state
 
-    def compose(self):
-        modes = available_filter_modes(
-            self._state.team_labels, self._state.repo_teams, self._state.healths
-        )
-        # Skip "all" -- empty selection already means all repos.
-        selections = [
+    def _make_selections(
+        self, modes: list[str], team_labels: dict[str, str]
+    ) -> list[Selection[str]]:
+        return [
             Selection(
-                describe_filter(mode, self._state.team_labels),
+                describe_filter(mode, team_labels),
                 mode,
                 initial_state=mode in self._state.active_filters,
             )
             for mode in modes
-            if mode != "all"
         ]
-        yield Container(SelectionList[str](*selections, id="filter-list"))
+
+    def compose(self):
+        sections = available_filter_sections(
+            self._state.team_labels, self._state.repo_teams, self._state.healths
+        )
+        tl = self._state.team_labels
+        has_identity = bool(sections.orgs) or bool(sections.teams)
+
+        with Container():
+            with VerticalScroll():
+                if sections.orgs:
+                    yield FilterSection(
+                        "Organizations", "orgs", self._make_selections(sections.orgs, tl)
+                    )
+                if sections.teams:
+                    yield FilterSection("Teams", "teams", self._make_selections(sections.teams, tl))
+                if has_identity:
+                    yield Rule()
+                yield FilterSection(
+                    "Visibility", "visibility", self._make_selections(sections.visibility, tl)
+                )
+                yield FilterSection(
+                    "Workspace", "workspace", self._make_selections(sections.workspace, tl)
+                )
+                yield FilterSection("Status", "health", self._make_selections(sections.health, tl))
+
+    def _collect_selected(self) -> set[str]:
+        merged: set[str] = set()
+        for sl in self.query(SelectionList):
+            merged.update(sl.selected)
+        return merged
 
     def on_click(self, event: events.Click) -> None:
         if event.button == 3:
             self.action_dismiss_panel()
 
     def on_selection_list_selected_changed(self, event: SelectionList.SelectedChanged) -> None:
-        """Apply the user's selection as soon as they toggle a filter.
-
-        Without this handler the grid only re-filters when the user
-        dismisses the panel, which feels like the app has hung for
-        anyone expecting live feedback from the checkboxes.
-        """
+        """Apply the user's selection as soon as they toggle a filter."""
         event.stop()
-        selected = set(event.selection_list.selected)
-        self.post_message(self.FilterChanged(selected))
+        self.post_message(self.FilterChanged(self._collect_selected()))
 
     def action_dismiss_panel(self) -> None:
-        sel_list = self.query_one("#filter-list", SelectionList)
-        self.dismiss(set(sel_list.selected))
+        self.dismiss(self._collect_selected())

--- a/src/augint_tools/dashboard/state.py
+++ b/src/augint_tools/dashboard/state.py
@@ -30,15 +30,22 @@ PANEL_WIDTH_STEP = 2
 UNASSIGNED_TEAM = "unassigned"
 
 SORT_MODES: tuple[str, ...] = ("health", "alpha", "problem")
-FILTER_MODES: tuple[str, ...] = (
-    "all",
-    "private",
-    "public",
-    "no-workspace",
+
+# --- Filter categories ---------------------------------------------------
+VISIBILITY_FILTERS: tuple[str, ...] = ("private", "public")
+WORKSPACE_FILTERS: tuple[str, ...] = ("workspace", "non-workspace")
+HEALTH_FILTERS: tuple[str, ...] = (
     "broken-ci",
     "no-renovate",
+    "renovate-prs-piling",
     "stale-prs",
     "issues",
+)
+FILTER_MODES: tuple[str, ...] = (
+    "all",
+    *VISIBILITY_FILTERS,
+    *WORKSPACE_FILTERS,
+    *HEALTH_FILTERS,
 )
 
 _TEAM_FILTER_PREFIX = "team:"
@@ -61,6 +68,21 @@ class ErrorEntry:
     timestamp: datetime
     source: str  # "refresh" | "usage" | "cache" | "ui"
     message: str
+
+
+@dataclass(frozen=True)
+class FilterSections:
+    """Grouped filter modes for the sectioned filter panel."""
+
+    orgs: list[str]
+    teams: list[str]
+    visibility: list[str]
+    workspace: list[str]
+    health: list[str]
+
+    def all_modes(self) -> list[str]:
+        """Flat list of every filter mode across all sections."""
+        return [*self.orgs, *self.teams, *self.visibility, *self.workspace, *self.health]
 
 
 @dataclass
@@ -288,13 +310,19 @@ def _matches_filter(h: RepoHealth, mode: str, repo_teams: dict[str, RepoTeamInfo
         return h.status.private
     if mode == "public":
         return not h.status.private
-    if mode == "no-workspace":
+    if mode == "workspace":
+        return h.status.is_workspace
+    if mode == "non-workspace":
         return not h.status.is_workspace
     if mode == "broken-ci":
         return any(c.check_name == "broken_ci" and c.severity != Severity.OK for c in h.checks)
     if mode == "no-renovate":
         return any(
             c.check_name == "renovate_enabled" and c.severity != Severity.OK for c in h.checks
+        )
+    if mode == "renovate-prs-piling":
+        return any(
+            c.check_name == "renovate_prs_piling" and c.severity != Severity.OK for c in h.checks
         )
     if mode == "stale-prs":
         return any(c.check_name == "stale_prs" and c.severity != Severity.OK for c in h.checks)
@@ -332,12 +360,9 @@ def apply_active_filters(
     active: set[str],
     repo_teams: dict[str, RepoTeamInfo] | None = None,
 ) -> list[RepoHealth]:
-    """Apply multiple filters.
+    """Apply multiple filters with OR semantics.
 
-    ``no-workspace`` is the only hard AND constraint -- it always
-    excludes workspace repos when checked (persistent toggle via ``w``).
-
-    Every other filter is an OR **selection**: each checked item adds
+    Every checked filter is an OR **selection**: each checked item adds
     matching repos to the visible set.  This matches the mental model
     of a multi-select checklist where checking ``broken-ci`` +
     ``team:woxom`` means "show broken-CI repos PLUS woxom repos."
@@ -345,25 +370,16 @@ def apply_active_filters(
     if not active:
         return list(healths)
     teams = repo_teams or {}
-    # no-workspace is a hard exclusion (the 'w' toggle).
-    has_no_workspace = "no-workspace" in active
-    # Everything else ORs together as additive selections.
-    selections = sorted(m for m in active if m != "no-workspace")
-    result: list[RepoHealth] = []
-    for h in healths:
-        if has_no_workspace and not _matches_filter(h, "no-workspace", teams):
-            continue
-        if selections and not any(_matches_filter(h, mode, teams) for mode in selections):
-            continue
-        result.append(h)
-    return result
+    selections = sorted(active)
+    return [h for h in healths if any(_matches_filter(h, mode, teams) for mode in selections)]
 
 
-def available_filter_modes(
+def available_filter_sections(
     team_labels: dict[str, str],
     repo_teams: dict[str, RepoTeamInfo],
     healths: list[RepoHealth] | None = None,
-) -> list[str]:
+) -> FilterSections:
+    """Return filter modes grouped into UI sections."""
     team_keys = {team for info in repo_teams.values() for team in (info.all or (info.primary,))}
     team_dynamic = [
         team_filter_mode(team_key)
@@ -371,12 +387,27 @@ def available_filter_modes(
             team_keys, key=lambda key: display_team_label(key, team_labels).lower()
         )
     ]
-    # Org filters derived from the owners present in the current health data.
     org_keys: set[str] = set()
     if healths:
         org_keys = {owner_of(h.status.full_name) for h in healths}
     org_dynamic = [org_filter_mode(key) for key in sorted(org_keys)]
-    return [*FILTER_MODES, *org_dynamic, *team_dynamic]
+    return FilterSections(
+        orgs=org_dynamic,
+        teams=team_dynamic,
+        visibility=list(VISIBILITY_FILTERS),
+        workspace=list(WORKSPACE_FILTERS),
+        health=list(HEALTH_FILTERS),
+    )
+
+
+def available_filter_modes(
+    team_labels: dict[str, str],
+    repo_teams: dict[str, RepoTeamInfo],
+    healths: list[RepoHealth] | None = None,
+) -> list[str]:
+    """Flat list of all available filter modes (compat wrapper)."""
+    sections = available_filter_sections(team_labels, repo_teams, healths)
+    return [*FILTER_MODES, *sections.orgs, *sections.teams]
 
 
 def visible_healths(state: AppState) -> list[RepoHealth]:

--- a/src/augint_tools/dashboard/widgets/status_bar.py
+++ b/src/augint_tools/dashboard/widgets/status_bar.py
@@ -23,11 +23,13 @@ _FILTER_LABELS: dict[str, str] = {
     "all": "all repos",
     "private": "Private",
     "public": "Public (Open source)",
-    "broken-ci": "broken CI",
-    "no-renovate": "no renovate",
-    "no-workspace": "no workspace",
-    "stale-prs": "stale PRs",
-    "issues": "has issues",
+    "workspace": "Workspace repos",
+    "non-workspace": "Non-workspace repos",
+    "broken-ci": "Broken CI",
+    "no-renovate": "No Renovate config",
+    "renovate-prs-piling": "Renovate PRs piling up",
+    "stale-prs": "Stale PRs",
+    "issues": "Open issues",
 }
 
 

--- a/tests/unit/test_dashboard.py
+++ b/tests/unit/test_dashboard.py
@@ -25,11 +25,13 @@ from augint_tools.dashboard.state import (
     FILTER_MODES,
     SORT_MODES,
     AppState,
+    FilterSections,
     RepoTeamInfo,
     apply_active_filters,
     apply_filter,
     apply_sort,
     available_filter_modes,
+    available_filter_sections,
     ensure_selection,
     move_selection,
     team_accent,
@@ -318,8 +320,8 @@ class TestApplyActiveFilters:
         out = apply_active_filters([broken, fine], {"broken-ci"})
         assert [h.status.name for h in out] == ["broken"]
 
-    def test_no_workspace_and_with_selection(self):
-        """no-workspace is a hard AND; broken-ci is an OR selection."""
+    def test_non_workspace_and_broken_ci_or_together(self):
+        """non-workspace + broken-ci OR together: non-ws repos PLUS broken repos."""
         ci_check = HealthCheckResult(
             check_name="broken_ci", severity=Severity.CRITICAL, summary="x"
         )
@@ -330,9 +332,11 @@ class TestApplyActiveFilters:
             name="repo-broken", full_name="org/repo-broken", checks=[ci_check], is_workspace=False
         )
         repo_ok = _health(name="repo-ok", full_name="org/repo-ok", is_workspace=False)
-        out = apply_active_filters([ws_broken, repo_broken, repo_ok], {"broken-ci", "no-workspace"})
-        # ws-broken excluded by no-workspace AND, repo-ok doesn't match broken-ci OR
-        assert [h.status.name for h in out] == ["repo-broken"]
+        out = apply_active_filters(
+            [ws_broken, repo_broken, repo_ok], {"broken-ci", "non-workspace"}
+        )
+        # ws-broken matches broken-ci, repo-broken matches both, repo-ok matches non-workspace
+        assert {h.status.name for h in out} == {"ws-broken", "repo-broken", "repo-ok"}
 
     def test_team_filters_or_logic(self):
         """Multiple team filters combine with OR: repo in ANY selected team passes."""
@@ -409,6 +413,24 @@ class TestTeamHelpers:
         assert "team:alpha" in modes
         # Standard filter modes still present.
         assert set(FILTER_MODES).issubset(set(modes))
+
+    def test_available_filter_sections(self):
+        repo_teams = {"org/a": RepoTeamInfo(primary="alpha", all=("alpha",))}
+        labels = {"alpha": "Alpha Team"}
+        healths = [_health(name="a", full_name="org-x/a")]
+        sections = available_filter_sections(labels, repo_teams, healths)
+        assert isinstance(sections, FilterSections)
+        assert "team:alpha" in sections.teams
+        assert "org:org-x" in sections.orgs
+        assert sections.visibility == ["private", "public"]
+        assert sections.workspace == ["workspace", "non-workspace"]
+        assert "broken-ci" in sections.health
+        assert "renovate-prs-piling" in sections.health
+        # all_modes returns a flat list covering everything.
+        flat = sections.all_modes()
+        assert "team:alpha" in flat
+        assert "org:org-x" in flat
+        assert "broken-ci" in flat
 
 
 # ---------------------------------------------------------------------------
@@ -633,13 +655,23 @@ class TestDashboardActions:
             _seed_state(app)
             async with app.run_test() as pilot:
                 await pilot.pause()
-                assert "no-workspace" not in app.state.active_filters
+                # Start: neither workspace filter active
+                assert "non-workspace" not in app.state.active_filters
+                assert "workspace" not in app.state.active_filters
+                # First press: hide workspaces
                 await pilot.press("w")
                 await pilot.pause()
-                assert "no-workspace" in app.state.active_filters
+                assert "non-workspace" in app.state.active_filters
+                # Second press: workspace only
                 await pilot.press("w")
                 await pilot.pause()
-                assert "no-workspace" not in app.state.active_filters
+                assert "workspace" in app.state.active_filters
+                assert "non-workspace" not in app.state.active_filters
+                # Third press: show all
+                await pilot.press("w")
+                await pilot.pause()
+                assert "workspace" not in app.state.active_filters
+                assert "non-workspace" not in app.state.active_filters
 
         asyncio.run(run())
 
@@ -937,17 +969,31 @@ class TestStateHelpers:
         out = apply_filter([iss, _health(name="ok", full_name="org/ok")], "issues")
         assert [h.status.name for h in out] == ["i"]
 
-    def test_apply_filter_no_workspace(self):
+    def test_apply_filter_non_workspace(self):
         ws = _health(name="ws", full_name="org/ws", is_workspace=True)
         repo = _health(name="repo", full_name="org/repo", is_workspace=False)
-        out = apply_filter([ws, repo], "no-workspace")
+        out = apply_filter([ws, repo], "non-workspace")
         assert [h.status.name for h in out] == ["repo"]
 
-    def test_apply_filter_no_workspace_all_regular(self):
+    def test_apply_filter_workspace(self):
+        ws = _health(name="ws", full_name="org/ws", is_workspace=True)
+        repo = _health(name="repo", full_name="org/repo", is_workspace=False)
+        out = apply_filter([ws, repo], "workspace")
+        assert [h.status.name for h in out] == ["ws"]
+
+    def test_apply_filter_non_workspace_all_regular(self):
         a = _health(name="a", full_name="org/a")
         b = _health(name="b", full_name="org/b")
-        out = apply_filter([a, b], "no-workspace")
+        out = apply_filter([a, b], "non-workspace")
         assert len(out) == 2
+
+    def test_apply_filter_renovate_prs_piling(self):
+        check = HealthCheckResult(
+            check_name="renovate_prs_piling", severity=Severity.HIGH, summary="piling"
+        )
+        piling = _health(name="p", full_name="org/p", checks=[check])
+        out = apply_filter([piling, _health(name="ok", full_name="org/ok")], "renovate-prs-piling")
+        assert [h.status.name for h in out] == ["p"]
 
     def test_apply_sort_problem(self):
         critical = HealthCheckResult(
@@ -1917,7 +1963,7 @@ class TestPrefs:
             theme_name="nord",
             layout_name="dense",
             sort_mode="alpha",
-            active_filters=["broken-ci", "no-workspace"],
+            active_filters=["broken-ci", "non-workspace"],
             panel_width=42,
             flash_enabled=False,
         )
@@ -1926,7 +1972,7 @@ class TestPrefs:
         assert loaded.theme_name == "nord"
         assert loaded.layout_name == "dense"
         assert loaded.sort_mode == "alpha"
-        assert loaded.active_filters == ["broken-ci", "no-workspace"]
+        assert loaded.active_filters == ["broken-ci", "non-workspace"]
         assert loaded.panel_width == 42
         assert loaded.flash_enabled is False
 
@@ -1947,6 +1993,18 @@ class TestPrefs:
         monkeypatch.setattr("augint_tools.dashboard.prefs.PREFS_FILE", prefs_file)
         loaded = load_prefs()
         assert loaded == DashboardPrefs()
+
+    def test_prefs_migration_no_workspace(self, tmp_path, monkeypatch):
+        """Loading prefs with legacy 'no-workspace' migrates to 'non-workspace'."""
+        import json
+
+        from augint_tools.dashboard.prefs import load_prefs
+
+        prefs_file = tmp_path / "prefs.json"
+        prefs_file.write_text(json.dumps({"active_filters": ["broken-ci", "no-workspace"]}))
+        monkeypatch.setattr("augint_tools.dashboard.prefs.PREFS_FILE", prefs_file)
+        loaded = load_prefs()
+        assert loaded.active_filters == ["broken-ci", "non-workspace"]
 
     def test_unknown_fields_ignored(self, tmp_path, monkeypatch):
         import json
@@ -2031,6 +2089,8 @@ class TestVisibilityFilters:
     def test_private_and_public_in_filter_modes(self):
         assert "private" in FILTER_MODES
         assert "public" in FILTER_MODES
+        assert "workspace" in FILTER_MODES
+        assert "non-workspace" in FILTER_MODES
 
     def test_active_filters_public_hides_private(self):
         priv = _health(name="secret", full_name="org/secret", private=True)
@@ -2079,8 +2139,8 @@ class TestVisibilityFilters:
         # All pass: pub-team matches both, priv-team matches team:alpha, pub-no-team matches public
         assert {h.status.name for h in out} == {"pub-team", "priv-team", "pub-no-team"}
 
-    def test_no_workspace_constrains_or_selections(self):
-        """no-workspace AND excludes workspaces even when other selections match."""
+    def test_non_workspace_ors_with_other_selections(self):
+        """non-workspace ORs with other filters like any other selection."""
         priv_team = _health(
             name="priv-team", full_name="org/priv-team", private=True, is_workspace=False
         )
@@ -2095,11 +2155,12 @@ class TestVisibilityFilters:
         }
         out = apply_active_filters(
             [priv_team, pub_ws, pub_other],
-            {"no-workspace", "public", team_filter_mode("alpha")},
+            {"non-workspace", "public", team_filter_mode("alpha")},
             repo_teams,
         )
-        # pub-ws excluded by no-workspace even though it matches public + team:alpha
-        assert {h.status.name for h in out} == {"priv-team", "pub-other"}
+        # All three match: priv-team matches non-workspace + team:alpha,
+        # pub-ws matches public + team:alpha, pub-other matches non-workspace + public
+        assert {h.status.name for h in out} == {"priv-team", "pub-ws", "pub-other"}
 
 
 class TestRepoStatusPrivateField:


### PR DESCRIPTION
## Summary

Reorganize the filter modal into labelled sections -- Orgs, Teams, a separator, then Visibility, Workspace, Status -- each with their own "All"/"None" toggle buttons so switching between custom filters and state-based filters no longer requires unchecking items one by one.

- Replace the inverted \`no-workspace\` filter with symmetric \`workspace\` and \`non-workspace\` filters that behave like every other category. The \`w\` keybinding now cycles: show all -> hide workspaces -> workspace only -> show all.
- Add \`renovate-prs-piling\` filter to surface the existing health check, which previously had no filter entry.
- Remove the \`no-workspace\` AND special case from \`apply_active_filters\`; all filters now OR uniformly.
- Migrate legacy \`no-workspace\` values in persisted preferences to \`non-workspace\` on load.

## Test plan

- [x] \`uv run pytest tests/unit/test_dashboard.py\` -- 180/180 pass
- [x] \`uv run pre-commit run --all-files\` -- all hooks pass
- [ ] Manual: launch dashboard, press \`f\`, verify sections with headers and All/None buttons render correctly
- [ ] Manual: verify All/None buttons toggle their section's checkboxes
- [ ] Manual: verify \`w\` cycles through show all -> hide workspace -> workspace only -> show all
- [ ] Manual: verify live filtering works as checkboxes are toggled