### PR TITLE
fix(dashboard): prefix item counts with parentheses for dense layouts

### DIFF
--- a/src/augint_tools/dashboard/health/checks/open_issues.py
+++ b/src/augint_tools/dashboard/health/checks/open_issues.py
@@ -35,7 +35,7 @@ class OpenIssuesCheck:
             return HealthCheckResult(
                 check_name=self.name,
                 severity=Severity.OK,
-                summary=f"{status.open_issues} open issues",
+                summary=f"({status.open_issues}) open issues",
             )
 
         # Fetch issues to filter out bot-created noise.
@@ -56,14 +56,14 @@ class OpenIssuesCheck:
             return HealthCheckResult(
                 check_name=self.name,
                 severity=Severity.LOW,
-                summary=f"{human_count} open issues (excl. bots)",
+                summary=f"({human_count}) open issues (excl. bots)",
                 link=f"https://github.com/{status.full_name}/issues",
             )
 
         return HealthCheckResult(
             check_name=self.name,
             severity=Severity.OK,
-            summary=f"{human_count} open issues",
+            summary=f"({human_count}) open issues",
         )
 
 

--- a/src/augint_tools/dashboard/health/checks/renovate_prs.py
+++ b/src/augint_tools/dashboard/health/checks/renovate_prs.py
@@ -39,7 +39,7 @@ class RenovatePRsPilingCheck:
             return HealthCheckResult(
                 check_name=self.name,
                 severity=Severity.HIGH,
-                summary=f"{len(renovate_prs)} Renovate PRs piling up",
+                summary=f"({len(renovate_prs)}) Renovate PRs piling up",
                 link=oldest.html_url,
             )
 

--- a/src/augint_tools/dashboard/health/checks/stale_prs.py
+++ b/src/augint_tools/dashboard/health/checks/stale_prs.py
@@ -49,7 +49,7 @@ class StalePRsCheck:
             return HealthCheckResult(
                 check_name=self.name,
                 severity=Severity.MEDIUM,
-                summary=f"{len(stale)} stale PR(s), oldest {oldest_age}d",
+                summary=f"({len(stale)}) stale PR(s), oldest {oldest_age}d",
                 link=oldest_pr.html_url,
             )
 

--- a/tests/unit/test_health.py
+++ b/tests/unit/test_health.py
@@ -321,7 +321,7 @@ class TestRenovatePRsPiling:
             _mock_repo(), _status(), config={}, pulls=pulls
         )
         assert result.severity == Severity.HIGH
-        assert "5 Renovate PRs" in result.summary
+        assert "(5) Renovate PRs" in result.summary
         assert result.link is not None
 
     def test_custom_threshold(self):
@@ -342,7 +342,7 @@ class TestRenovatePRsPiling:
             _mock_repo(), _status(), config={}, pulls=pulls
         )
         assert result.severity == Severity.HIGH
-        assert "3 Renovate PRs" in result.summary
+        assert "(3) Renovate PRs" in result.summary
 
 
 class TestStalePRs:
@@ -361,7 +361,7 @@ class TestStalePRs:
         ]
         result = get_check("stale_prs").evaluate(_mock_repo(), _status(), config={}, pulls=pulls)
         assert result.severity == Severity.MEDIUM
-        assert "1 stale PR" in result.summary
+        assert "(1) stale PR" in result.summary
         assert "10d" in result.summary
         assert result.link == "https://github.com/org/repo/pull/1"
 
@@ -419,7 +419,7 @@ class TestOpenIssues:
         repo.get_issues.return_value = [_mock_issue() for _ in range(15)]
         result = get_check("open_issues").evaluate(repo, _status(open_issues=15), config={})
         assert result.severity == Severity.LOW
-        assert "15 open issues" in result.summary
+        assert "(15) open issues" in result.summary
         assert result.link is not None
 
     def test_bot_issues_excluded(self):
@@ -435,7 +435,7 @@ class TestOpenIssues:
         repo.get_issues.return_value = issues
         result = get_check("open_issues").evaluate(repo, _status(open_issues=12), config={})
         assert result.severity == Severity.OK
-        assert "5 open issues" in result.summary
+        assert "(5) open issues" in result.summary
 
     def test_custom_threshold(self):
         repo = _mock_repo()


### PR DESCRIPTION
## Summary
- Wrap numeric counts in parentheses `(N)` at the start of health check summaries so the count stays visible when messages are truncated in compressed/dense TUI layouts.
- Applied to `renovate_prs.py`, `stale_prs.py`, and `open_issues.py` health checks.
- Updated corresponding test assertions in `test_health.py`.

## Test plan
- [x] `uv run ruff check src/augint_tools/dashboard/health/checks/` -- passes
- [x] `uv run pytest tests/ -x -q -k "health or check"` -- all 53 tests pass
- [x] `uv run pre-commit run --all-files` -- all hooks pass