### PR TITLE
fix(dashboard): span group headers across full grid width

### DIFF
--- a/src/augint_tools/dashboard/layouts/grouped.py
+++ b/src/augint_tools/dashboard/layouts/grouped.py
@@ -8,6 +8,7 @@ from ..state import (
     RepoTeamInfo,
     display_team_label,
 )
+from ..widgets.card_container import _GroupHeader
 from . import LayoutContext, register_layout
 
 
@@ -55,6 +56,14 @@ class GroupedLayout:
             else:
                 headers[team_key] = display_team_label(team_key, ctx.state.team_labels)
         container.set_group_headers(order, headers, buckets)
+
+        # Set column span on headers dynamically to match computed columns.
+        for child in container.children:
+            if isinstance(child, _GroupHeader):
+                try:
+                    child.styles.column_span = columns
+                except Exception:
+                    pass
 
         for card in cards:
             card.styles.width = width

--- a/src/augint_tools/dashboard/layouts/severity.py
+++ b/src/augint_tools/dashboard/layouts/severity.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from ..health import Severity
 from ..state import PANEL_WIDTH_DEFAULT
+from ..widgets.card_container import _GroupHeader
 from . import LayoutContext, register_layout
 
 _SEVERITY_ORDER = ("critical", "warning", "ok")
@@ -56,6 +57,14 @@ class SeverityLayout:
         order = [key for key in _SEVERITY_ORDER if buckets[key]]
         headers = {key: _SEVERITY_LABELS[key] for key in order}
         container.set_group_headers(order, headers, buckets)
+
+        # Set column span on headers dynamically to match computed columns.
+        for child in container.children:
+            if isinstance(child, _GroupHeader):
+                try:
+                    child.styles.column_span = columns
+                except Exception:
+                    pass
 
         for card in cards:
             card.styles.width = width

--- a/src/augint_tools/dashboard/themes/cyber.tcss
+++ b/src/augint_tools/dashboard/themes/cyber.tcss
@@ -13,7 +13,7 @@ CardContainer { layout: grid; grid-size: 4; grid-gutter: 0 1; padding: 0 1; over
 CardContainer.layout--list { layout: vertical; }
 CardContainer.layout--dense { grid-size: 6; }
 
-.group-header { column-span: 4; height: 1; background: #13132a; color: #f92aad; padding: 0 1; margin-top: 1; text-style: bold; }
+.group-header { height: 1; background: #13132a; color: #f92aad; padding: 0 1; margin-top: 1; text-style: bold; }
 
 RepoCard { height: auto; min-height: 5; border: round #303060; background: #13132a; color: #bef9ff; padding: 0 1; transition: border 200ms in_out_cubic, background 150ms linear; }
 RepoCard.card--ok { border: round #72f1b8; }

--- a/src/augint_tools/dashboard/themes/default.tcss
+++ b/src/augint_tools/dashboard/themes/default.tcss
@@ -13,7 +13,7 @@ CardContainer { layout: grid; grid-size: 4; grid-gutter: 0 1; padding: 0 1; over
 CardContainer.layout--list { layout: vertical; }
 CardContainer.layout--dense { grid-size: 6; }
 
-.group-header { column-span: 4; height: 1; background: #1a1a22; color: #ffffff; padding: 0 1; margin-top: 1; text-style: bold; }
+.group-header { height: 1; background: #1a1a22; color: #ffffff; padding: 0 1; margin-top: 1; text-style: bold; }
 
 RepoCard { height: auto; min-height: 5; border: round #3a3a48; background: #1a1a22; color: #d8dade; padding: 0 1; transition: border 200ms in_out_cubic, background 150ms linear; }
 RepoCard.card--ok { border: round #72f1b8; }

--- a/src/augint_tools/dashboard/themes/matrix.tcss
+++ b/src/augint_tools/dashboard/themes/matrix.tcss
@@ -13,7 +13,7 @@ CardContainer { layout: grid; grid-size: 4; grid-gutter: 0 1; padding: 0 1; over
 CardContainer.layout--list { layout: vertical; }
 CardContainer.layout--dense { grid-size: 6; }
 
-.group-header { column-span: 4; height: 1; background: #001a0a; color: #00ff41; padding: 0 1; margin-top: 1; text-style: bold; }
+.group-header { height: 1; background: #001a0a; color: #00ff41; padding: 0 1; margin-top: 1; text-style: bold; }
 
 RepoCard { height: auto; min-height: 5; border: round #004020; background: #001a0a; color: #00ff41; padding: 0 1; transition: border 200ms in_out_cubic, background 150ms linear; }
 RepoCard.card--ok { border: round #00ff41; }

--- a/src/augint_tools/dashboard/themes/minimal.tcss
+++ b/src/augint_tools/dashboard/themes/minimal.tcss
@@ -13,7 +13,7 @@ CardContainer { layout: grid; grid-size: 4; grid-gutter: 0 1; padding: 0 1; over
 CardContainer.layout--list { layout: vertical; }
 CardContainer.layout--dense { grid-size: 6; }
 
-.group-header { column-span: 4; height: 1; background: #141414; color: #ffffff; padding: 0 1; margin-top: 1; text-style: bold; }
+.group-header { height: 1; background: #141414; color: #ffffff; padding: 0 1; margin-top: 1; text-style: bold; }
 
 RepoCard { height: auto; min-height: 5; border: round #4a4a4a; background: #141414; color: #e5e5e5; padding: 0 1; transition: border 200ms in_out_cubic, background 150ms linear; }
 RepoCard.card--ok { border: round #4a4a4a; }

--- a/src/augint_tools/dashboard/themes/nord.tcss
+++ b/src/augint_tools/dashboard/themes/nord.tcss
@@ -13,7 +13,7 @@ CardContainer { layout: grid; grid-size: 4; grid-gutter: 0 1; padding: 0 1; over
 CardContainer.layout--list { layout: vertical; }
 CardContainer.layout--dense { grid-size: 6; }
 
-.group-header { column-span: 4; height: 1; background: #434c5e; color: #eceff4; padding: 0 1; margin-top: 1; text-style: bold; }
+.group-header { height: 1; background: #434c5e; color: #eceff4; padding: 0 1; margin-top: 1; text-style: bold; }
 
 RepoCard { height: auto; min-height: 5; border: round #4c566a; background: #3b4252; color: #d8dee9; padding: 0 1; transition: border 200ms in_out_cubic, background 150ms linear; }
 RepoCard.card--ok { border: round #a3be8c; }

--- a/src/augint_tools/dashboard/themes/paper.tcss
+++ b/src/augint_tools/dashboard/themes/paper.tcss
@@ -54,7 +54,6 @@ CardContainer.layout--dense {
 }
 
 .group-header {
-    column-span: 4;
     height: 1;
     background: #2a2824;
     color: #e8dcb1;

--- a/src/augint_tools/dashboard/themes/synthwave.tcss
+++ b/src/augint_tools/dashboard/themes/synthwave.tcss
@@ -13,7 +13,7 @@ CardContainer { layout: grid; grid-size: 4; grid-gutter: 0 1; padding: 0 1; over
 CardContainer.layout--list { layout: vertical; }
 CardContainer.layout--dense { grid-size: 6; }
 
-.group-header { column-span: 4; height: 1; background: #231045; color: #ff77ff; padding: 0 1; margin-top: 1; text-style: bold; }
+.group-header { height: 1; background: #231045; color: #ff77ff; padding: 0 1; margin-top: 1; text-style: bold; }
 
 RepoCard { height: auto; min-height: 5; border: round #402070; background: #231045; color: #f5e6ff; padding: 0 1; transition: border 200ms in_out_cubic, background 150ms linear; }
 RepoCard.card--ok { border: round #a6ff9c; }


### PR DESCRIPTION
## Summary
- Removed hardcoded `column-span: 4` from `.group-header` CSS rules in all 7 theme files
- Added dynamic `column_span` assignment in `grouped.py` and `severity.py` layout strategies to match the computed grid column count
- Group headers now always span the full width regardless of terminal size or panel width settings

## Test plan
- [ ] Launch dashboard with grouped layout at various terminal widths and confirm headers span full width
- [ ] Launch dashboard with severity layout and confirm headers span full width
- [ ] Verify dense mode (6 columns) still renders headers correctly
- [ ] Check all 7 themes render group headers without misalignment