### PR TITLE
feat(dashboard): make footer bar items clickable

### DIFF
--- a/src/augint_tools/dashboard/widgets/dashboard_footer.py
+++ b/src/augint_tools/dashboard/widgets/dashboard_footer.py
@@ -1,50 +1,107 @@
-"""Custom two-zone footer: numbered functional keys left, visual keys right."""
+"""Custom two-zone footer: numbered functional keys left, visual keys right.
+
+Each key entry is a separate clickable widget that triggers the corresponding
+app action on click, in addition to the existing keyboard shortcuts.
+"""
 
 from __future__ import annotations
 
 from rich.text import Text
-from textual.containers import Container
+from textual.containers import Horizontal
+from textual.events import Click
 from textual.widgets import Static
 
 # Functional keys shown on the left with [N] numbering.
-_LEFT_KEYS: list[tuple[str, str]] = [
-    ("q", "Quit"),
-    ("r", "Refresh"),
-    ("s", "Sort"),
-    ("f", "Filter"),
-    ("d", "Detail"),
-    ("u", "Usage"),
-    ("i", "Org"),
-    ("e", "Errors"),
-    ("?", "Help"),
+# (key_char, label, action_name)
+_LEFT_KEYS: list[tuple[str, str, str]] = [
+    ("q", "Quit", "quit"),
+    ("r", "Refresh", "refresh_now"),
+    ("s", "Sort", "cycle_sort"),
+    ("f", "Filter", "open_filter_panel"),
+    ("d", "Detail", "toggle_drawer"),
+    ("u", "Usage", "toggle_usage"),
+    ("i", "Org", "toggle_org"),
+    ("e", "Errors", "toggle_errors"),
+    ("?", "Help", "show_help"),
 ]
 
 # Visual/presentation keys shown on the right without numbering.
-_RIGHT_KEYS: list[tuple[str, str]] = [
-    ("g", "Layout"),
-    ("t", "Theme"),
-    ("b", "Blink"),
+# (key_char, label, action_name)
+_RIGHT_KEYS: list[tuple[str, str, str]] = [
+    ("g", "Layout", "cycle_layout"),
+    ("t", "Theme", "cycle_theme"),
+    ("b", "Blink", "toggle_flash"),
 ]
 
 
-class DashboardFooter(Container):
+class _FooterItem(Static):
+    """A single clickable footer key entry."""
+
+    DEFAULT_CSS = """
+    _FooterItem {
+        width: auto;
+        height: 1;
+        padding: 0 0;
+    }
+    _FooterItem:hover {
+        background: #333344;
+    }
+    """
+
+    def __init__(self, label: Text, action_name: str) -> None:
+        super().__init__(label)
+        self._action_name = action_name
+
+    async def _on_click(self, event: Click) -> None:
+        event.stop()
+        await self.app.run_action(self._action_name)
+
+
+def _build_left_items() -> list[_FooterItem]:
+    """Create clickable items for the left (numbered) section."""
+    items: list[_FooterItem] = []
+    for i, (key, label, action) in enumerate(_LEFT_KEYS, 1):
+        txt = Text()
+        if i > 1:
+            txt.append(" ")
+        txt.append(f"[{i}]", style="dim")
+        txt.append(" ")
+        txt.append(key, style="bold")
+        txt.append(f" {label}")
+        items.append(_FooterItem(txt, action))
+    return items
+
+
+def _build_right_items() -> list[_FooterItem]:
+    """Create clickable items for the right (visual) section."""
+    items: list[_FooterItem] = []
+    for key, label, action in _RIGHT_KEYS:
+        txt = Text()
+        txt.append(key, style="bold")
+        txt.append(f" {label} ")
+        items.append(_FooterItem(txt, action))
+    return items
+
+
+class DashboardFooter(Horizontal):
     """Split footer: numbered functional controls left, visual controls right."""
 
     DEFAULT_CSS = """
     DashboardFooter {
         dock: bottom;
         height: 1;
-        layout: horizontal;
         overflow: hidden;
         background: #1a1a22;
         color: #8791b0;
     }
     DashboardFooter > #footer-left {
         width: 1fr;
+        height: 1;
         overflow: hidden;
     }
     DashboardFooter > #footer-right {
         width: auto;
+        height: 1;
         content-align: right middle;
         overflow: hidden;
     }
@@ -52,29 +109,7 @@ class DashboardFooter(Container):
 
     def __init__(self, id: str = "dashboard-footer") -> None:
         super().__init__(id=id)
-        self._left = Static("", id="footer-left")
-        self._right = Static("", id="footer-right")
 
-    def compose(self):
-        yield self._left
-        yield self._right
-
-    def on_mount(self) -> None:
-        self._render_footer()
-
-    def _render_footer(self) -> None:
-        left = Text()
-        for i, (key, label) in enumerate(_LEFT_KEYS, 1):
-            if i > 1:
-                left.append(" ")
-            left.append(f"[{i}]", style="dim")
-            left.append(" ")
-            left.append(key, style="bold")
-            left.append(f" {label}")
-        self._left.update(left)
-
-        right = Text()
-        for key, label in _RIGHT_KEYS:
-            right.append(key, style="bold")
-            right.append(f" {label} ")
-        self._right.update(right)
+    def compose(self):  # type: ignore[override]
+        yield Horizontal(*_build_left_items(), id="footer-left")
+        yield Horizontal(*_build_right_items(), id="footer-right")


### PR DESCRIPTION
## Summary
- Replace the two monolithic `Static` widgets in the dashboard footer with individual `_FooterItem` clickable widgets
- Each footer item triggers its corresponding app action on click via `run_action()`, matching existing keyboard shortcuts (q/1 Quit, r/2 Refresh, s/3 Sort, etc.)
- Adds hover highlight (`#333344`) for visual feedback on mouseover

## Test plan
- [ ] Launch dashboard TUI and verify footer renders identically to before
- [ ] Click each left-side item (Quit, Refresh, Sort, Filter, Detail, Usage, Org, Errors, Help) and verify the corresponding action fires
- [ ] Click each right-side item (Layout, Theme, Blink) and verify the corresponding action fires
- [ ] Verify keyboard shortcuts still work as before
- [ ] Hover over footer items and confirm highlight appears
- [ ] `uv run pre-commit run --all-files` passes (ruff, mypy, format)
- [ ] `uv run pytest tests/ -x -q` passes