### PR TITLE
feat(dashboard): add Open Source honorary group for personal public repos

### DIFF
--- a/src/augint_tools/dashboard/app.py
+++ b/src/augint_tools/dashboard/app.py
@@ -43,6 +43,7 @@ from .state import (
     SORT_MODES,
     AppState,
     CollectedTeamData,
+    apply_open_source_team,
     bootstrap_from_cache,
     collect_repo_teams,
     ensure_selection,
@@ -1342,6 +1343,7 @@ class DashboardApp(App[None]):
         # Cache-first: load before mounting so the first paint shows data.
         restrict = {r.full_name for r in self._repos} if self._repos else None
         bootstrap_from_cache(self.state, restrict_to=restrict)
+        apply_open_source_team(self.state)
 
         self._main = MainScreen(self.state, self._org_name, owners=self._owners)
         self.push_screen(self._main)
@@ -1576,6 +1578,7 @@ class DashboardApp(App[None]):
                 f"commit: merged team data for {len(team_data)} repos, "
                 f"{len(self.state.team_labels)} known teams"
             )
+        apply_open_source_team(self.state)
         # Carry forward / stamp warning-transition timestamps *before* we swap
         # the healths list, so the card-flash logic can tell whether yellow is
         # new (ok -> warning) or established. Timestamps on the RepoStatus side

--- a/src/augint_tools/dashboard/layouts/grouped.py
+++ b/src/augint_tools/dashboard/layouts/grouped.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from ..state import (
     PANEL_WIDTH_DEFAULT,
-    UNASSIGNED_TEAM,
     RepoTeamInfo,
     display_team_label,
 )
@@ -31,18 +30,13 @@ class GroupedLayout:
             pass
 
         # Bucket cards by their repo's primary team.
-        # Public repos without a team are grouped under a synthetic
-        # "open-source" key so the grouped view labels them clearly.
-        _OPEN_SOURCE_KEY = "__open_source__"
+        # Public repos without an org team are already promoted to the
+        # OPEN_SOURCE_TEAM key by apply_open_source_team() in state.py.
         buckets: dict[str, list] = {}
         order: list[str] = []
         for card in cards:
             info = ctx.state.repo_teams.get(card.repo_full_name, RepoTeamInfo())
             team_key = info.primary
-            # Promote public + unassigned repos into an "Open source" group.
-            health = ctx.state.health_by_name.get(card.repo_full_name)
-            if team_key == UNASSIGNED_TEAM and health and not health.status.private:
-                team_key = _OPEN_SOURCE_KEY
             if team_key not in buckets:
                 buckets[team_key] = []
                 order.append(team_key)
@@ -50,10 +44,7 @@ class GroupedLayout:
 
         headers: dict[str, str] = {}
         for team_key in order:
-            if team_key == _OPEN_SOURCE_KEY:
-                headers[team_key] = "Open source"
-            else:
-                headers[team_key] = display_team_label(team_key, ctx.state.team_labels)
+            headers[team_key] = display_team_label(team_key, ctx.state.team_labels)
         container.set_group_headers(order, headers, buckets)
 
         for card in cards:

--- a/src/augint_tools/dashboard/state.py
+++ b/src/augint_tools/dashboard/state.py
@@ -28,6 +28,7 @@ PANEL_WIDTH_MAX = 60
 PANEL_WIDTH_STEP = 2
 
 UNASSIGNED_TEAM = "unassigned"
+OPEN_SOURCE_TEAM = "__open_source__"
 
 SORT_MODES: tuple[str, ...] = ("health", "alpha", "problem")
 
@@ -165,6 +166,8 @@ def owner_of(full_name: str) -> str:
 def display_team_label(team_key: str, team_labels: dict[str, str]) -> str:
     if team_key == UNASSIGNED_TEAM:
         return "Unassigned"
+    if team_key == OPEN_SOURCE_TEAM:
+        return "Open Source"
     return team_labels.get(team_key, team_key.replace("-", " ").title())
 
 
@@ -289,6 +292,18 @@ def merge_team_data(state: AppState, collected: list[CollectedTeamData]) -> None
             continue
         state.repo_teams[td.full_name] = td.info
         state.team_labels.update(td.labels)
+
+
+def apply_open_source_team(state: AppState) -> None:
+    """Promote personal public repos with no team to the Open Source group."""
+    state.team_labels[OPEN_SOURCE_TEAM] = "Open Source"
+    for full_name, health in state.health_by_name.items():
+        info = state.repo_teams.get(full_name, RepoTeamInfo())
+        if info.primary == UNASSIGNED_TEAM and not health.status.private:
+            state.repo_teams[full_name] = RepoTeamInfo(
+                primary=OPEN_SOURCE_TEAM,
+                all=(OPEN_SOURCE_TEAM,),
+            )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_dashboard.py
+++ b/tests/unit/test_dashboard.py
@@ -1441,10 +1441,11 @@ class TestAppMisc:
                 known = list(app.state.team_labels)
                 platform_accent = team_accent("platform", known)
                 growth_accent = team_accent("growth", known)
+                os_accent = team_accent(state.OPEN_SOURCE_TEAM, known)
                 assert platform_accent in name_spans["repo-a"]
                 assert growth_accent in name_spans["repo-b"]
-                # repo-c has no team entry -> default grey.
-                assert "#808080" in name_spans["repo-c"]
+                # repo-c is public with no org team -> Open Source group.
+                assert os_accent in name_spans["repo-c"]
                 # Different teams should produce different accents.
                 assert platform_accent != growth_accent
 


### PR DESCRIPTION
## Summary
- Promotes personal public repos with no GitHub team to a first-class "Open Source" honorary team in the state system
- The group now shows as a team label badge on cards, appears in the team filter panel, gets a team accent color, and works across all layouts (not just grouped)
- Simplifies the grouped layout by removing its local open-source bucketing logic in favor of the centralized state assignment

## Test plan
- [x] Existing test updated to reflect new Open Source team accent on public unassigned repos
- [x] `uv run ruff check` passes on all modified files
- [x] `uv run ruff format` passes on all modified files
- [x] `uv run pytest tests/ -x -q` all tests pass
- [x] `uv run pre-commit run --all-files` all hooks pass