### PR TITLE
feat(config): add IDE GitHub Tasks servers for workspace child repos

### DIFF
--- a/src/augint_tools/cli/commands/config.py
+++ b/src/augint_tools/cli/commands/config.py
@@ -42,6 +42,7 @@ from augint_tools.ide.detect import (
     resolve_windows_paths,
     upsert_dotenv,
 )
+from augint_tools.ide.steps import _apply_github_tasks
 
 # ---------------------------------------------------------------------------
 # Context: everything the steps might need, detected up front.
@@ -264,6 +265,58 @@ def _run_bookmarks(c: ConfigContext) -> StepResult:
     return step_bookmarks(c.project_dir, c.project_name, c.workspace_path, c.product_ws)
 
 
+def _parse_repo_url(url: str) -> tuple[str, str] | None:
+    """Parse owner/repo from git SSH or HTTPS URL."""
+    import re
+
+    # SSH: git@github.com:owner/repo.git
+    m = re.match(r"git@github\.com:([^/]+)/([^/.]+?)(?:\.git)?$", url)
+    if m:
+        return m.group(1), m.group(2)
+    # HTTPS: https://github.com/owner/repo.git
+    m = re.match(r"https?://github\.com/([^/]+)/([^/.]+?)(?:\.git)?$", url)
+    if m:
+        return m.group(1), m.group(2)
+    return None
+
+
+def _run_workspace_github_tasks(c: ConfigContext) -> StepResult:
+    """Set up GitHub Tasks servers for all repos in workspace.yaml."""
+    import yaml
+
+    ws_path = os.path.join(c.project_dir, "workspace.yaml")
+    with open(ws_path) as f:
+        ws_data = yaml.safe_load(f)
+
+    repos = ws_data.get("repos", [])
+    if not repos:
+        return _skip("workspace_tasks", "No repos found in workspace.yaml")
+
+    added = []
+    skipped = []
+    for repo_entry in repos:
+        url = repo_entry.get("url", "")
+        parsed = _parse_repo_url(url)
+        if parsed is None:
+            continue
+        owner, repo_name = parsed
+        # Apply to both product workspace and project workspace
+        if c.product_ws:
+            _apply_github_tasks(c.product_ws, owner, repo_name, None, False)
+        status = _apply_github_tasks(c.workspace_path, owner, repo_name, c.gh_token, False)
+        if status == "ok":
+            added.append(f"{owner}/{repo_name}")
+        else:
+            skipped.append(f"{owner}/{repo_name}")
+
+    if not added:
+        return _skip(
+            "workspace_tasks",
+            f"All {len(skipped)} workspace repo servers already configured",
+        )
+    return _ok("workspace_tasks", f"Added GitHub Tasks servers for: {', '.join(added)}")
+
+
 def _run_reset_prompt(c: ConfigContext) -> StepResult:
     """Offer to delete the product workspace file so changes take effect."""
     if c.product_ws is None or not os.path.exists(c.product_ws):
@@ -351,6 +404,17 @@ CONFIG_STEPS: list[ConfigStep] = [
             (False, "no GitHub remote in .git/config") if c.git_remote is None else (True, "")
         ),
         run=_run_github_tasks,
+    ),
+    ConfigStep(
+        id="workspace_tasks",
+        label="IDE: workspace GitHub Tasks servers",
+        description="Add GitHub Tasks server entries for all repos found in workspace.yaml.",
+        applicable=lambda c: (
+            (True, "")
+            if os.path.exists(os.path.join(c.project_dir, "workspace.yaml")) and c.has_idea
+            else (False, "no workspace.yaml or no .idea/")
+        ),
+        run=_run_workspace_github_tasks,
     ),
     ConfigStep(
         id="jdk_table",

--- a/tests/unit/test_ide.py
+++ b/tests/unit/test_ide.py
@@ -807,6 +807,185 @@ class TestBookmarks:
 
 
 # ---------------------------------------------------------------------------
+# config.py workspace tasks
+# ---------------------------------------------------------------------------
+
+
+class TestParseRepoUrl:
+    def test_ssh_url(self) -> None:
+        from augint_tools.cli.commands.config import _parse_repo_url
+
+        assert _parse_repo_url("git@github.com:owner1/repo-one.git") == ("owner1", "repo-one")
+
+    def test_ssh_url_no_git_suffix(self) -> None:
+        from augint_tools.cli.commands.config import _parse_repo_url
+
+        assert _parse_repo_url("git@github.com:owner1/repo-one") == ("owner1", "repo-one")
+
+    def test_https_url(self) -> None:
+        from augint_tools.cli.commands.config import _parse_repo_url
+
+        assert _parse_repo_url("https://github.com/owner2/repo-two.git") == ("owner2", "repo-two")
+
+    def test_https_url_no_git_suffix(self) -> None:
+        from augint_tools.cli.commands.config import _parse_repo_url
+
+        assert _parse_repo_url("https://github.com/owner2/repo-two") == ("owner2", "repo-two")
+
+    def test_non_github_url_returns_none(self) -> None:
+        from augint_tools.cli.commands.config import _parse_repo_url
+
+        assert _parse_repo_url("https://gitlab.com/owner/repo.git") is None
+
+    def test_empty_string_returns_none(self) -> None:
+        from augint_tools.cli.commands.config import _parse_repo_url
+
+        assert _parse_repo_url("") is None
+
+
+class TestWorkspaceGithubTasks:
+    def test_adds_servers_for_workspace_repos(self, tmp_path: Path) -> None:
+        from augint_tools.cli.commands.config import ConfigContext, _run_workspace_github_tasks
+
+        # Create workspace.yaml
+        (tmp_path / "workspace.yaml").write_text(
+            "repos:\n"
+            "  - name: repo-one\n"
+            "    url: git@github.com:owner1/repo-one.git\n"
+            "  - name: repo-two\n"
+            "    url: https://github.com/owner2/repo-two.git\n"
+        )
+        # Create workspace.xml
+        idea = tmp_path / ".idea"
+        idea.mkdir()
+        ws_xml = idea / "workspace.xml"
+        ws_xml.write_text(
+            '<?xml version="1.0" encoding="UTF-8"?>\n<project version="4"></project>\n'
+        )
+
+        c = ConfigContext(
+            project_dir=str(tmp_path),
+            project_name="test",
+            venv_path=str(tmp_path / ".venv"),
+            sdk_name="Python 3.12 (test)",
+            full_ver="3.12.0",
+            major_minor="3.12",
+            iml_path=None,
+            workspace_path=str(ws_xml),
+            misc_path=str(idea / "misc.xml"),
+            has_idea=True,
+            has_git=True,
+            has_venv=False,
+            has_pyproject=False,
+            git_remote=None,
+            win_proj=None,
+            win_venv=None,
+            win_python=None,
+            jb_options=None,
+            product_ws=None,
+            gh_token="ghp_test123",
+            external_project_storage=False,
+        )
+
+        result = _run_workspace_github_tasks(c)
+        assert result.status == "ok"
+        assert "owner1/repo-one" in result.message
+        assert "owner2/repo-two" in result.message
+
+        # Verify XML was written
+        content = ws_xml.read_text()
+        assert "owner1" in content
+        assert "repo-one" in content
+        assert "owner2" in content
+        assert "repo-two" in content
+
+    def test_idempotent_skips_existing(self, tmp_path: Path) -> None:
+        from augint_tools.cli.commands.config import ConfigContext, _run_workspace_github_tasks
+
+        (tmp_path / "workspace.yaml").write_text(
+            "repos:\n  - name: repo-one\n    url: git@github.com:owner1/repo-one.git\n"
+        )
+        idea = tmp_path / ".idea"
+        idea.mkdir()
+        ws_xml = idea / "workspace.xml"
+        ws_xml.write_text(
+            '<?xml version="1.0" encoding="UTF-8"?>\n<project version="4"></project>\n'
+        )
+
+        c = ConfigContext(
+            project_dir=str(tmp_path),
+            project_name="test",
+            venv_path=str(tmp_path / ".venv"),
+            sdk_name="Python 3.12 (test)",
+            full_ver="3.12.0",
+            major_minor="3.12",
+            iml_path=None,
+            workspace_path=str(ws_xml),
+            misc_path=str(idea / "misc.xml"),
+            has_idea=True,
+            has_git=True,
+            has_venv=False,
+            has_pyproject=False,
+            git_remote=None,
+            win_proj=None,
+            win_venv=None,
+            win_python=None,
+            jb_options=None,
+            product_ws=None,
+            gh_token="",
+            external_project_storage=False,
+        )
+
+        # Run once
+        result1 = _run_workspace_github_tasks(c)
+        assert result1.status == "ok"
+
+        # Run again -- should skip
+        result2 = _run_workspace_github_tasks(c)
+        assert result2.status == "skipped"
+        assert "already configured" in result2.message
+
+    def test_empty_repos_list(self, tmp_path: Path) -> None:
+        from augint_tools.cli.commands.config import ConfigContext, _run_workspace_github_tasks
+
+        (tmp_path / "workspace.yaml").write_text("repos: []\n")
+        idea = tmp_path / ".idea"
+        idea.mkdir()
+        ws_xml = idea / "workspace.xml"
+        ws_xml.write_text(
+            '<?xml version="1.0" encoding="UTF-8"?>\n<project version="4"></project>\n'
+        )
+
+        c = ConfigContext(
+            project_dir=str(tmp_path),
+            project_name="test",
+            venv_path=str(tmp_path / ".venv"),
+            sdk_name="Python 3.12 (test)",
+            full_ver="3.12.0",
+            major_minor="3.12",
+            iml_path=None,
+            workspace_path=str(ws_xml),
+            misc_path=str(idea / "misc.xml"),
+            has_idea=True,
+            has_git=True,
+            has_venv=False,
+            has_pyproject=False,
+            git_remote=None,
+            win_proj=None,
+            win_venv=None,
+            win_python=None,
+            jb_options=None,
+            product_ws=None,
+            gh_token="",
+            external_project_storage=False,
+        )
+
+        result = _run_workspace_github_tasks(c)
+        assert result.status == "skipped"
+        assert "No repos" in result.message
+
+
+# ---------------------------------------------------------------------------
 # CLI integration
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Adds a new `workspace_tasks` config step that detects `workspace.yaml`, parses child repo URLs (SSH and HTTPS), and registers GitHub Tasks server entries in the IDE for each unique owner/repo pair
- Includes `_parse_repo_url` helper supporting both `git@github.com:owner/repo.git` and `https://github.com/owner/repo.git` formats
- Step is idempotent -- skips repos already configured

## Test plan
- [x] Unit tests for `_parse_repo_url` (SSH, HTTPS, no suffix, non-GitHub, empty)
- [x] Unit tests for `_run_workspace_github_tasks` (adds servers, idempotent skip, empty repos list)
- [x] All existing tests pass
- [x] Pre-commit hooks pass (ruff check, ruff format, mypy, uv.lock)