### PR TITLE
fix(dashboard): fix group headers, finding visibility, and refresh timer

### DIFF
--- a/src/augint_tools/dashboard/layouts/grouped.py
+++ b/src/augint_tools/dashboard/layouts/grouped.py
@@ -7,7 +7,6 @@ from ..state import (
     RepoTeamInfo,
     display_team_label,
 )
-from ..widgets.card_container import _GroupHeader
 from . import LayoutContext, register_layout
 
 
@@ -46,15 +45,7 @@ class GroupedLayout:
         headers: dict[str, str] = {}
         for team_key in order:
             headers[team_key] = display_team_label(team_key, ctx.state.team_labels)
-        container.set_group_headers(order, headers, buckets)
-
-        # Set column span on headers dynamically to match computed columns.
-        for child in container.children:
-            if isinstance(child, _GroupHeader):
-                try:
-                    child.styles.column_span = columns
-                except Exception:
-                    pass
+        container.set_group_headers(order, headers, buckets, columns=columns)
 
         for card in cards:
             card.styles.width = width

--- a/src/augint_tools/dashboard/layouts/severity.py
+++ b/src/augint_tools/dashboard/layouts/severity.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from ..health import Severity
 from ..state import PANEL_WIDTH_DEFAULT
-from ..widgets.card_container import _GroupHeader
 from . import LayoutContext, register_layout
 
 _SEVERITY_ORDER = ("critical", "warning", "ok")
@@ -56,15 +55,7 @@ class SeverityLayout:
         # Only show sections that have cards.
         order = [key for key in _SEVERITY_ORDER if buckets[key]]
         headers = {key: _SEVERITY_LABELS[key] for key in order}
-        container.set_group_headers(order, headers, buckets)
-
-        # Set column span on headers dynamically to match computed columns.
-        for child in container.children:
-            if isinstance(child, _GroupHeader):
-                try:
-                    child.styles.column_span = columns
-                except Exception:
-                    pass
+        container.set_group_headers(order, headers, buckets, columns=columns)
 
         for card in cards:
             card.styles.width = width

--- a/src/augint_tools/dashboard/widgets/card_container.py
+++ b/src/augint_tools/dashboard/widgets/card_container.py
@@ -82,11 +82,15 @@ class CardContainer(Container):
         order: list[str],
         headers: dict[str, str],
         buckets: dict[str, list[RepoCard]],
+        *,
+        columns: int = 0,
     ) -> None:
         """Rebuild children: header, cards, header, cards, ... per ``order``.
 
         Cards are kept; only headers are torn down and rebuilt, then cards are
-        reordered via move_child to land between headers.
+        reordered via move_child to land between headers. When ``columns`` is
+        given, each header's ``column_span`` is set before mounting so the
+        header stretches across the full grid width.
         """
         from .repo_card import RepoCard as _RepoCard
 
@@ -99,6 +103,8 @@ class CardContainer(Container):
         target: list = []
         for team_key in order:
             header = _GroupHeader(headers.get(team_key, team_key), classes="group-header")
+            if columns > 0:
+                header.styles.column_span = columns
             target.append(header)
             target.extend(buckets.get(team_key, []))
 

--- a/src/augint_tools/dashboard/widgets/repo_card.py
+++ b/src/augint_tools/dashboard/widgets/repo_card.py
@@ -289,9 +289,8 @@ class RepoCard(Widget):
             t = Text()
             icon = spec.severity_icons.get(finding.severity, "*")
             t.append(f"{icon} ", style=self._severity_style(finding.severity, spec))
-            t.append(f"{finding.check_name.replace('_', ' ')}: ", style="bold")
             t.append(
-                _truncate(finding.summary, 28), style=self._severity_style(finding.severity, spec)
+                _truncate(finding.summary, 40), style=self._severity_style(finding.severity, spec)
             )
             lines.append(t)
             if len(lines) >= limit:

--- a/src/augint_tools/dashboard/widgets/status_bar.py
+++ b/src/augint_tools/dashboard/widgets/status_bar.py
@@ -153,6 +153,20 @@ class StatusBar(Static):
         t = Text()
         owner_label = " + ".join(self._owners) if self._owners else self._org_name or "no-org"
         t.append(f" {owner_label} ", style="bold")
+        # Refresh / staleness first -- most important at a glance.
+        stale_chip = self._staleness_chip(state)
+        if stale_chip:
+            t.append("| ")
+            t.append(stale_chip[0], style=stale_chip[1])
+            t.append(" ")
+        refresh_chip = self._refresh_chip(state)
+        if refresh_chip:
+            t.append("| ")
+            t.append(refresh_chip[0], style=refresh_chip[1])
+            t.append(" ")
+        error_chip = self._error_chip(state)
+        if error_chip:
+            t.append(f"| {error_chip} ", style="bold red")
         filter_label = _describe_active_filters(state.active_filters, state.team_labels)
         t.append(
             f"| sort: {state.sort_mode} "
@@ -160,19 +174,6 @@ class StatusBar(Static):
             f"| layout: {state.layout_name} "
             f"| theme: {state.theme_name}"
         )
-        # Staleness first (brighter): users glance here to see whether data
-        # is current or still loading. Countdown is secondary.
-        stale_chip = self._staleness_chip(state)
-        if stale_chip:
-            t.append(" | ")
-            t.append(stale_chip[0], style=stale_chip[1])
-        refresh_chip = self._refresh_chip(state)
-        if refresh_chip:
-            t.append(" | ")
-            t.append(refresh_chip[0], style=refresh_chip[1])
-        error_chip = self._error_chip(state)
-        if error_chip:
-            t.append(f" | {error_chip}", style="bold red")
         self.update(t)
 
     def _staleness_chip(self, state: AppState) -> tuple[str, str] | None:


### PR DESCRIPTION
## Summary

- **Group headers span full width**: Column span is now set on `_GroupHeader` widgets *before* mounting via `set_group_headers(columns=N)`, fixing the race condition where async `mount()`/`remove()` meant headers weren't in `container.children` when the post-mount loop ran
- **Finding counts visible in dense layouts**: Card findings now show the summary directly (e.g. `(3) Renovate PRs piling up`) instead of prefixing the redundant check name (`renovate prs piling: (3) Renovate...`) which ate 24 chars before the count
- **Refresh timer always visible**: Moved staleness (`updated 30s ago`) and countdown (`next: 9m30s`) chips to the front of the status bar, before sort/filter/layout/theme info that can be truncated

## Test plan
- [ ] Grouped layout: group headers span full terminal width at any column count
- [ ] Severity layout: same full-width headers
- [ ] Dense layout: renovate PR count visible without scrolling
- [ ] Status bar: refresh countdown visible at default terminal width