### PR TITLE
fix(dashboard): graceful degradation for OpenAI and Copilot usage errors

### DIFF
--- a/src/augint_tools/dashboard/app.py
+++ b/src/augint_tools/dashboard/app.py
@@ -1662,7 +1662,21 @@ class DashboardApp(App[None]):
         try:
             stats = fetch_all_usage()
         except Exception as exc:
-            self.state.log_error("usage", f"{exc.__class__.__name__}: {exc}")
+            # fetch_all_usage handles per-provider errors internally and returns
+            # graceful "unavailable" stats. Only truly unexpected errors (bugs)
+            # reach here -- log those so they surface in the error drawer.
+            import subprocess
+            import urllib.error
+
+            expected_types = (
+                urllib.error.HTTPError,
+                urllib.error.URLError,
+                subprocess.SubprocessError,
+                OSError,
+                TimeoutError,
+            )
+            if not isinstance(exc, expected_types):
+                self.state.log_error("usage", f"{exc.__class__.__name__}: {exc}")
             return
         self.state.usage_stats = stats
         self.call_from_thread(self._rerender_usage_only)

--- a/src/augint_tools/dashboard/usage.py
+++ b/src/augint_tools/dashboard/usage.py
@@ -68,7 +68,7 @@ class UsageStats:
     window_total_seconds: int | None = None
     # Subscription / plan tier label for display.
     tier: str | None = None
-    status: str = "ok"  # ok, warning, critical, unknown, unconfigured, empty
+    status: str = "ok"  # ok, warning, critical, unknown, unconfigured, unavailable, empty
     error: str | None = None
     # Free-form note shown under the progress bar (e.g. data source).
     note: str | None = None
@@ -465,7 +465,7 @@ def fetch_copilot_usage(window_days: int = 7, limit: int | None = None) -> Usage
             display_name="Copilot",
             window_days=window_days,
             status="unconfigured",
-            error="gh CLI not installed -- copilot auth rides on gh",
+            note="gh CLI not installed",
         )
     billing = _gh_copilot_billing()
     if billing:
@@ -497,7 +497,7 @@ def fetch_copilot_usage(window_days: int = 7, limit: int | None = None) -> Usage
         display_name="Copilot",
         window_days=window_days,
         status="unconfigured",
-        error="no Copilot subscription on gh-authed account",
+        note="no Copilot subscription detected",
     )
 
 
@@ -651,6 +651,14 @@ def fetch_openai_usage(
     try:
         payload = _openai_usage_request(api_key, org_id, start_time)
     except urllib.error.HTTPError as exc:
+        if exc.code in (401, 403):
+            return UsageStats(
+                provider="openai",
+                display_name=label,
+                window_days=window_days,
+                status="unavailable",
+                note="requires admin API key",
+            )
         body_tail = ""
         try:
             body_tail = exc.read().decode("utf-8", errors="replace")[:120]
@@ -663,16 +671,16 @@ def fetch_openai_usage(
             provider="openai",
             display_name=label,
             window_days=window_days,
-            status="unknown",
-            error=detail,
+            status="unavailable",
+            note=detail,
         )
     except (urllib.error.URLError, TimeoutError, json.JSONDecodeError, OSError) as exc:
         return UsageStats(
             provider="openai",
             display_name=label,
             window_days=window_days,
-            status="unknown",
-            error=f"{exc.__class__.__name__}",
+            status="unavailable",
+            note=f"{exc.__class__.__name__}",
         )
 
     messages = 0
@@ -710,19 +718,70 @@ def fetch_all_usage(
 
     OpenAI accounts are discovered dynamically from OPENAI_API_KEY_<LABEL>
     entries in the environment or .env file. Each gets its own usage row.
+
+    Individual provider failures are caught per-provider so one failure does
+    not affect others. Failed providers are included with status="unavailable".
     """
-    results: list[UsageStats] = [fetch_claude_code_usage(limit=claude_limit)]
+    results: list[UsageStats] = []
 
-    openai_accounts = _resolve_openai_keys()
-    if openai_accounts:
-        for label, key, org_id in openai_accounts:
-            results.append(
-                fetch_openai_usage(limit=openai_limit, api_key=key, org_id=org_id, label=label)
+    # Claude
+    try:
+        results.append(fetch_claude_code_usage(limit=claude_limit))
+    except Exception:
+        results.append(
+            UsageStats(
+                provider="claude_code",
+                display_name="Claude Code",
+                status="unavailable",
+                note="failed to fetch usage",
             )
-    else:
-        results.append(fetch_openai_usage(limit=openai_limit))
+        )
 
-    results.append(fetch_copilot_usage(limit=copilot_limit))
+    # OpenAI (one or more accounts)
+    try:
+        openai_accounts = _resolve_openai_keys()
+        if openai_accounts:
+            for label, key, org_id in openai_accounts:
+                try:
+                    results.append(
+                        fetch_openai_usage(
+                            limit=openai_limit, api_key=key, org_id=org_id, label=label
+                        )
+                    )
+                except Exception:
+                    results.append(
+                        UsageStats(
+                            provider="openai",
+                            display_name=label,
+                            status="unavailable",
+                            note="failed to fetch usage",
+                        )
+                    )
+        else:
+            results.append(fetch_openai_usage(limit=openai_limit))
+    except Exception:
+        results.append(
+            UsageStats(
+                provider="openai",
+                display_name="OpenAI",
+                status="unavailable",
+                note="failed to fetch usage",
+            )
+        )
+
+    # Copilot
+    try:
+        results.append(fetch_copilot_usage(limit=copilot_limit))
+    except Exception:
+        results.append(
+            UsageStats(
+                provider="copilot",
+                display_name="Copilot",
+                status="unavailable",
+                note="failed to fetch usage",
+            )
+        )
+
     return results
 
 

--- a/src/augint_tools/dashboard/widgets/highlight_bar.py
+++ b/src/augint_tools/dashboard/widgets/highlight_bar.py
@@ -85,11 +85,14 @@ class HighlightBar(Static):
                 self._append_claude_usage(t, stats)
             else:
                 t.append(f"{stats.display_name} ", style="bold")
-                usage = stats.usage_fraction
-                if usage is None:
-                    t.append(stats.status, style="dim")
+                if stats.status in ("unavailable", "error", "unconfigured"):
+                    t.append("unavailable", style="dim")
                 else:
-                    t.append(f"{int(usage * 100)}%")
+                    usage = stats.usage_fraction
+                    if usage is None:
+                        t.append(stats.status, style="dim")
+                    else:
+                        t.append(f"{int(usage * 100)}%")
         return t
 
     def _append_claude_usage(self, t: Text, stats: UsageStats) -> None:

--- a/tests/unit/test_dashboard.py
+++ b/tests/unit/test_dashboard.py
@@ -1903,7 +1903,7 @@ class TestAppMisc:
         monkeypatch.setattr(panel_usage.shutil, "which", lambda _cmd: None)
         stats = panel_usage.fetch_copilot_usage()
         assert stats.status == "unconfigured"
-        assert "gh CLI" in (stats.error or "")
+        assert "gh CLI" in (stats.note or "")
 
     def test_panel_usage_copilot_billing_path(self, monkeypatch):
         from augint_tools.dashboard import usage as panel_usage


### PR DESCRIPTION
## Summary
- OpenAI 401/403 responses now return `status="unavailable"` with a helpful note instead of spamming the error drawer with HTTP error strings
- Copilot unconfigured states moved from `error=` to `note=` so they don't trigger error drawer logging
- `fetch_all_usage` wraps each provider in try/except so one failure doesn't block others; failed providers are included with `status="unavailable"`
- Highlight bar shows dim "unavailable" label for unconfigured/error/unavailable providers instead of raw status strings or nothing
- App error drawer only logs truly unexpected exceptions, not expected 403s or missing CLI tools

## Test plan
- [x] `uv run pre-commit run --all-files` passes
- [x] `uv run pytest tests/ -x -q` passes (updated existing test assertion for copilot note field)