### PR TITLE
feat(dashboard): route middle-click per card row to item-specific URLs

### DIFF
--- a/src/augint_tools/dashboard/app.py
+++ b/src/augint_tools/dashboard/app.py
@@ -1943,11 +1943,8 @@ class DashboardApp(App[None]):
         if health is not None:
             self.push_screen(DrillDownScreen(health))
 
-    def on_repo_card_actions_requested(self, message: RepoCard.ActionsRequested) -> None:
-        webbrowser.open_new_tab(f"https://github.com/{message.full_name}/actions")
-
-    def on_repo_card_pulls_requested(self, message: RepoCard.PullsRequested) -> None:
-        webbrowser.open_new_tab(f"https://github.com/{message.full_name}/pulls")
+    def on_repo_card_open_url(self, message: RepoCard.OpenUrl) -> None:
+        webbrowser.open_new_tab(message.url)
 
     def on_repo_card_go_back(self, _message: RepoCard.GoBack) -> None:
         if self._main is not None:

--- a/src/augint_tools/dashboard/health/checks/open_issues.py
+++ b/src/augint_tools/dashboard/health/checks/open_issues.py
@@ -39,25 +39,33 @@ class OpenIssuesCheck:
             )
 
         # Fetch issues to filter out bot-created noise.
+        first_human_issue = None
         try:
             issues = repo.get_issues(state="open")
-            human_count = sum(
-                bool(
-                    issue.pull_request is None
-                    and (not issue.user or issue.user.login not in _BOT_LOGINS)
-                )
-                for issue in issues
-            )
+            human_count = 0
+            for issue in issues:
+                if issue.pull_request is not None:
+                    continue
+                if issue.user and issue.user.login in _BOT_LOGINS:
+                    continue
+                human_count += 1
+                if first_human_issue is None:
+                    first_human_issue = issue
         except Exception:
             # Fall back to the unfiltered count on API error.
             human_count = status.open_issues
 
         if human_count >= threshold:
+            link = (
+                first_human_issue.html_url
+                if first_human_issue is not None
+                else f"https://github.com/{status.full_name}/issues"
+            )
             return HealthCheckResult(
                 check_name=self.name,
                 severity=Severity.MEDIUM,
                 summary=f"({human_count}) open issues (excl. bots)",
-                link=f"https://github.com/{status.full_name}/issues",
+                link=link,
             )
 
         return HealthCheckResult(

--- a/src/augint_tools/dashboard/health/checks/open_prs.py
+++ b/src/augint_tools/dashboard/health/checks/open_prs.py
@@ -23,18 +23,24 @@ class OpenPRsCheck:
         status: RepoStatus,
         *,
         config: dict,
-        pulls: list | None = None,  # noqa: ARG002
+        pulls: list | None = None,
     ) -> HealthCheckResult:
         threshold = config.get("open_prs_threshold", 1)
 
         non_draft = max(0, status.open_prs - status.draft_prs)
 
         if non_draft >= threshold:
+            link = f"https://github.com/{status.full_name}/pulls"
+            if pulls:
+                non_draft_prs = [p for p in pulls if not getattr(p, "draft", False)]
+                if non_draft_prs:
+                    oldest = min(non_draft_prs, key=lambda p: p.created_at)
+                    link = oldest.html_url
             return HealthCheckResult(
                 check_name=self.name,
                 severity=Severity.MEDIUM,
                 summary=f"({non_draft}) open PR(s)",
-                link=f"https://github.com/{status.full_name}/pulls",
+                link=link,
             )
 
         return HealthCheckResult(

--- a/src/augint_tools/dashboard/screens/drilldown.py
+++ b/src/augint_tools/dashboard/screens/drilldown.py
@@ -59,9 +59,14 @@ class DrillDownScreen(ModalScreen[None]):
                     if finding.severity == Severity.CRITICAL
                     else finding.severity.name.lower()
                 )
-                t.append(f"  [{marker}] {finding.check_name}: {finding.summary}\n")
+                summary_line = f"  [{marker}] {finding.check_name}: {finding.summary}\n"
                 if finding.link:
-                    t.append(f"      {finding.link}\n", style="dim")
+                    # "link URL" lets the terminal emit an OSC-8 hyperlink
+                    # so middle-click (or Ctrl+click) opens finding.link.
+                    t.append(summary_line, style=f"link {finding.link}")
+                    t.append(f"      {finding.link}\n", style=f"dim link {finding.link}")
+                else:
+                    t.append(summary_line)
         else:
             t.append("no findings.\n", style="dim")
         t.append("\npress o or enter to open on GitHub; esc to close.", style="dim")

--- a/src/augint_tools/dashboard/widgets/repo_card.py
+++ b/src/augint_tools/dashboard/widgets/repo_card.py
@@ -8,6 +8,7 @@ state directly; it is fed from the parent container. CSS transitions on
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Literal
 
@@ -23,6 +24,20 @@ if TYPE_CHECKING:
     from ..themes import ThemeSpec
 
 RenderMode = Literal["packed", "dense", "list"]
+
+
+@dataclass(frozen=True)
+class _ClickRegion:
+    """Where a middle-click on a given card row should navigate.
+
+    ``x_split`` / ``alt_url`` let a single row route two different URLs
+    based on click x -- used for the counts line so "issues N" opens
+    /issues and "prs N" opens /pulls.
+    """
+
+    url: str
+    x_split: int | None = None
+    alt_url: str | None = None
 
 
 _STATUS_ICON = {
@@ -79,19 +94,17 @@ class RepoCard(Widget):
             super().__init__()
             self.full_name = full_name
 
-    class ActionsRequested(Message):
-        """Emitted on middle-click or meta+click to open the repo's Actions tab."""
+    class OpenUrl(Message):
+        """Emitted on middle-click / meta+click to open a GitHub URL in a new tab.
 
-        def __init__(self, full_name: str) -> None:
+        The URL is resolved per-row via the card's click map so that each
+        piece of info (title, CI, counts, each finding) routes to the most
+        actionable GitHub page for it.
+        """
+
+        def __init__(self, url: str) -> None:
             super().__init__()
-            self.full_name = full_name
-
-    class PullsRequested(Message):
-        """Emitted on meta+click on the counts row to open the PRs page."""
-
-        def __init__(self, full_name: str) -> None:
-            super().__init__()
-            self.full_name = full_name
+            self.url = url
 
     class GoBack(Message):
         """Emitted on right-click -- app closes drawer or pops the top screen."""
@@ -118,6 +131,8 @@ class RepoCard(Widget):
         self.team_accent = team_accent
         self.team_label = team_label
         self.can_focus = True
+        # Rebuilt on every render: y-coordinate inside the card -> click target.
+        self._click_map: dict[int, _ClickRegion] = {}
 
     @property
     def repo_full_name(self) -> str:
@@ -271,9 +286,11 @@ class RepoCard(Widget):
             line.append(f" ({status.draft_prs}d)", style="dim")
         return line
 
-    def _findings_lines(self, health: RepoHealth, limit: int) -> list[Text]:
+    def _findings_lines(self, health: RepoHealth, limit: int) -> list[tuple[Text, str]]:
+        """Return up to ``limit`` finding rows paired with their click-target URLs."""
         spec = self._theme_spec
-        lines: list[Text] = []
+        actions_url = self._actions_url(health)
+        lines: list[tuple[Text, str]] = []
         for error_label, error in (
             ("dev", health.status.dev_error),
             ("main", health.status.main_error),
@@ -282,7 +299,7 @@ class RepoCard(Widget):
                 t = Text()
                 t.append(f"{error_label}: ", style="bold")
                 t.append(_truncate(error, 30), style=spec.severity_colors[Severity.CRITICAL])
-                lines.append(t)
+                lines.append((t, actions_url))
                 if len(lines) >= limit:
                     return lines
         for finding in health.findings:
@@ -292,34 +309,70 @@ class RepoCard(Widget):
             t.append(
                 _truncate(finding.summary, 40), style=self._severity_style(finding.severity, spec)
             )
-            lines.append(t)
+            lines.append((t, finding.link or self._repo_url(health)))
             if len(lines) >= limit:
                 return lines
         if not lines:
-            lines.append(Text("all checks green", style=spec.severity_colors[Severity.OK]))
+            lines.append(
+                (
+                    Text("all checks green", style=spec.severity_colors[Severity.OK]),
+                    self._repo_url(health),
+                )
+            )
         return lines
 
     def _render_packed(self, health: RepoHealth) -> Text:
-        parts: list[Text] = [
-            self._title_line(health),
-            self._ci_line(health),
-            self._counts_line(health),
-        ]
-        parts.extend(self._findings_lines(health, 2))
+        self._click_map = {}
+        parts: list[Text] = []
+
+        parts.append(self._title_line(health))
+        self._click_map[len(parts)] = _ClickRegion(url=self._repo_url(health))
+
+        parts.append(self._ci_line(health))
+        self._click_map[len(parts)] = _ClickRegion(url=self._actions_url(health))
+
+        parts.append(self._counts_line(health))
+        self._click_map[len(parts)] = self._counts_click_region(health)
+
+        for line, url in self._findings_lines(health, 2):
+            parts.append(line)
+            self._click_map[len(parts)] = _ClickRegion(url=url)
+
         return self._finalize(parts)
 
     def _render_dense(self, health: RepoHealth) -> Text:
-        parts: list[Text] = [self._title_line(health), self._ci_line(health)]
-        parts.extend(self._findings_lines(health, 1))
+        self._click_map = {}
+        parts: list[Text] = []
+
+        parts.append(self._title_line(health))
+        self._click_map[len(parts)] = _ClickRegion(url=self._repo_url(health))
+
+        parts.append(self._ci_line(health))
+        self._click_map[len(parts)] = _ClickRegion(url=self._actions_url(health))
+
+        for line, url in self._findings_lines(health, 1):
+            parts.append(line)
+            self._click_map[len(parts)] = _ClickRegion(url=url)
+
         return self._finalize(parts)
 
     def _render_list(self, health: RepoHealth) -> Text:
-        parts: list[Text] = [
-            self._title_line(health),
-            self._ci_line(health),
-            self._counts_line(health),
-        ]
-        parts.extend(self._findings_lines(health, 4))
+        self._click_map = {}
+        parts: list[Text] = []
+
+        parts.append(self._title_line(health))
+        self._click_map[len(parts)] = _ClickRegion(url=self._repo_url(health))
+
+        parts.append(self._ci_line(health))
+        self._click_map[len(parts)] = _ClickRegion(url=self._actions_url(health))
+
+        parts.append(self._counts_line(health))
+        self._click_map[len(parts)] = self._counts_click_region(health)
+
+        for line, url in self._findings_lines(health, 4):
+            parts.append(line)
+            self._click_map[len(parts)] = _ClickRegion(url=url)
+
         return self._finalize(parts)
 
     def _finalize(self, parts: list[Text]) -> Text:
@@ -333,6 +386,32 @@ class RepoCard(Widget):
         joined.no_wrap = True
         joined.overflow = "ellipsis"
         return joined
+
+    # ---- URL + click-region helpers ----
+
+    def _repo_url(self, health: RepoHealth) -> str:
+        return f"https://github.com/{health.status.full_name}"
+
+    def _actions_url(self, health: RepoHealth) -> str:
+        return f"https://github.com/{health.status.full_name}/actions"
+
+    def _content_start_x(self) -> int:
+        """X coordinate of the first content cell inside the card.
+
+        Widget coords include the border (1 cell) and horizontal padding
+        (0 in dense mode, 1 otherwise) -- see the theme ``.tcss`` files.
+        """
+        return 1 if self.render_mode == "dense" else 2
+
+    def _counts_click_region(self, health: RepoHealth) -> _ClickRegion:
+        status = health.status
+        full_name = status.full_name
+        issues_url = f"https://github.com/{full_name}/issues"
+        pulls_url = f"https://github.com/{full_name}/pulls"
+        left_len = len(f"issues {status.open_issues}")
+        # The line is "issues N  prs M..." -- split between the two spaces.
+        split = self._content_start_x() + left_len + 1
+        return _ClickRegion(url=issues_url, x_split=split, alt_url=pulls_url)
 
     def _severity_style(self, severity: Severity, spec: ThemeSpec) -> str:
         return spec.severity_colors.get(severity, spec.severity_colors[Severity.OK])
@@ -353,10 +432,8 @@ class RepoCard(Widget):
             self.post_message(self.GoBack())
             return
         if event.button == 2 or (event.button == 1 and getattr(event, "meta", False)):
-            if getattr(event, "y", 0) == 3:
-                self.post_message(self.PullsRequested(self.repo_full_name))
-            else:
-                self.post_message(self.ActionsRequested(self.repo_full_name))
+            url = self._resolve_click_url(event)
+            self.post_message(self.OpenUrl(url))
             return
         if event.button == 1:
             # Single click only selects -- a plain click must never
@@ -367,3 +444,18 @@ class RepoCard(Widget):
             self.post_message(self.Selected(self.repo_full_name))
             if getattr(event, "chain", 1) >= 2:
                 self.post_message(self.DrilldownRequested(self.repo_full_name))
+
+    def _resolve_click_url(self, event: events.Click) -> str:
+        """Map the click's (x, y) to a GitHub URL using the current click map.
+
+        Falls back to the repo's /actions page for clicks on the border or
+        any row not present in the map (e.g. before the first render).
+        """
+        y = getattr(event, "y", 0)
+        x = getattr(event, "x", 0)
+        region = self._click_map.get(y)
+        if region is None:
+            return f"https://github.com/{self.repo_full_name}/actions"
+        if region.x_split is not None and region.alt_url is not None and x >= region.x_split:
+            return region.alt_url
+        return region.url

--- a/tests/unit/test_dashboard.py
+++ b/tests/unit/test_dashboard.py
@@ -1094,7 +1094,7 @@ class TestAppMisc:
         asyncio.run(run())
 
     @tui
-    def test_card_actions_opens_browser(self):
+    def test_card_open_url_opens_browser(self):
         async def run():
             app = DashboardApp(repos=[], skip_refresh=True)
             _seed_state(app)
@@ -1105,8 +1105,10 @@ class TestAppMisc:
                 )
 
                 with patch("augint_tools.dashboard.app.webbrowser.open_new_tab") as m:
-                    app.on_repo_card_actions_requested(RepoCard.ActionsRequested("org/r0"))
+                    url = "https://github.com/org/r0/actions"
+                    app.on_repo_card_open_url(RepoCard.OpenUrl(url))
                     assert m.called
+                    assert m.call_args.args[0] == url
 
         asyncio.run(run())
 
@@ -1165,6 +1167,83 @@ class TestAppMisc:
         kinds = [type(m).__name__ for m in posted]
         assert "DrilldownRequested" in kinds
 
+    def test_card_click_map_routes_each_row(self):
+        """Middle-click on each rendered row opens the row-specific GitHub URL."""
+        from augint_tools.dashboard.widgets.repo_card import RepoCard
+
+        status = RepoStatus(
+            name="r0",
+            full_name="org/r0",
+            is_service=False,
+            main_status="success",
+            main_error=None,
+            dev_status=None,
+            dev_error=None,
+            open_issues=3,
+            open_prs=2,
+            draft_prs=0,
+        )
+        checks = [
+            HealthCheckResult(
+                check_name="open_issues",
+                severity=Severity.MEDIUM,
+                summary="(3) open issues (excl. bots)",
+                link="https://github.com/org/r0/issues/42",
+            ),
+            HealthCheckResult(
+                check_name="open_prs",
+                severity=Severity.MEDIUM,
+                summary="(2) open PR(s)",
+                link="https://github.com/org/r0/pull/99",
+            ),
+        ]
+        health = RepoHealth(status=status, checks=checks)
+
+        theme = get_theme("default")
+        card = RepoCard(health=health, theme_spec=theme)
+        card.render()  # populates _click_map
+
+        # Title row opens the repo root.
+        assert card._click_map[1].url == "https://github.com/org/r0"
+        # CI row opens the Actions page.
+        assert card._click_map[2].url == "https://github.com/org/r0/actions"
+        # Counts row splits: left -> /issues, right -> /pulls.
+        counts = card._click_map[3]
+        assert counts.url == "https://github.com/org/r0/issues"
+        assert counts.alt_url == "https://github.com/org/r0/pulls"
+        assert counts.x_split is not None
+        # Finding rows use each finding's own link.
+        assert card._click_map[4].url == "https://github.com/org/r0/issues/42"
+        assert card._click_map[5].url == "https://github.com/org/r0/pull/99"
+
+        # Simulate a middle-click on the counts row, on each half.
+        posted: list = []
+        card.post_message = posted.append  # type: ignore[assignment]
+
+        class _Click:
+            def __init__(self, x, y):
+                self.button = 2
+                self.meta = False
+                self.chain = 1
+                self.x = x
+                self.y = y
+
+            def stop(self):
+                pass
+
+            def prevent_default(self):
+                pass
+
+        card.on_click(_Click(x=counts.x_split - 1, y=3))
+        card.on_click(_Click(x=counts.x_split + 2, y=3))
+        card.on_click(_Click(x=5, y=4))
+        urls = [m.url for m in posted if type(m).__name__ == "OpenUrl"]
+        assert urls == [
+            "https://github.com/org/r0/issues",
+            "https://github.com/org/r0/pulls",
+            "https://github.com/org/r0/issues/42",
+        ]
+
     def test_run_dashboard_invokes_app_run(self):
         from augint_tools.dashboard import app as _app_mod
 
@@ -1194,7 +1273,7 @@ class TestAppMisc:
         asyncio.run(run())
 
     @tui
-    def test_pulls_requested_opens_browser(self):
+    def test_open_url_pulls_page(self):
         async def run():
             app = DashboardApp(repos=[], skip_refresh=True)
             async with app.run_test() as pilot:
@@ -1204,7 +1283,7 @@ class TestAppMisc:
                 )
 
                 with patch("augint_tools.dashboard.app.webbrowser.open_new_tab") as m:
-                    app.on_repo_card_pulls_requested(RepoCard.PullsRequested("org/r0"))
+                    app.on_repo_card_open_url(RepoCard.OpenUrl("https://github.com/org/r0/pulls"))
                     assert m.called
                     assert "pulls" in m.call_args.args[0]
 

--- a/tests/unit/test_health.py
+++ b/tests/unit/test_health.py
@@ -417,11 +417,25 @@ class TestOpenIssues:
 
     def test_above_threshold_all_human(self):
         repo = _mock_repo()
-        repo.get_issues.return_value = [_mock_issue() for _ in range(3)]
+        issues = [_mock_issue() for _ in range(3)]
+        # The first human-filed issue should drive the link.
+        issues[0].html_url = "https://github.com/org/repo/issues/42"
+        repo.get_issues.return_value = issues
         result = get_check("open_issues").evaluate(repo, _status(open_issues=3), config={})
         assert result.severity == Severity.MEDIUM
         assert "(3) open issues" in result.summary
-        assert result.link is not None
+        assert result.link == "https://github.com/org/repo/issues/42"
+
+    def test_link_skips_bot_issues(self):
+        repo = _mock_repo()
+        bot = _mock_issue(login="renovate[bot]")
+        human = _mock_issue()
+        human.html_url = "https://github.com/org/repo/issues/7"
+        # Bot comes first in the list; the check should still pick the human.
+        repo.get_issues.return_value = [bot, human, _mock_issue()]
+        result = get_check("open_issues").evaluate(repo, _status(open_issues=3), config={})
+        assert result.severity == Severity.MEDIUM
+        assert result.link == "https://github.com/org/repo/issues/7"
 
     def test_bot_issues_excluded(self):
         repo = _mock_repo()
@@ -454,7 +468,31 @@ class TestOpenPRs:
         result = get_check("open_prs").evaluate(_mock_repo(), _status(open_prs=1), config={})
         assert result.severity == Severity.MEDIUM
         assert "(1) open PR" in result.summary
-        assert result.link is not None
+        # No pulls context available -> fall back to the listing page.
+        assert result.link == "https://github.com/org/myrepo/pulls"
+
+    def test_links_to_oldest_non_draft_pr(self):
+        oldest = _mock_pr(
+            created_at=datetime.now(UTC) - timedelta(days=10),
+            html_url="https://github.com/org/repo/pull/100",
+        )
+        newer = _mock_pr(
+            created_at=datetime.now(UTC) - timedelta(days=1),
+            html_url="https://github.com/org/repo/pull/200",
+        )
+        draft = _mock_pr(
+            created_at=datetime.now(UTC) - timedelta(days=20),
+            html_url="https://github.com/org/repo/pull/50",
+        )
+        draft.draft = True
+        result = get_check("open_prs").evaluate(
+            _mock_repo(),
+            _status(open_prs=3, draft_prs=1),
+            config={},
+            pulls=[newer, draft, oldest],
+        )
+        assert result.severity == Severity.MEDIUM
+        assert result.link == "https://github.com/org/repo/pull/100"
 
     def test_drafts_excluded(self):
         # Two open PRs but both are drafts -- should not flip yellow.


### PR DESCRIPTION
## Summary
- Replace the y=3 heuristic in `RepoCard.on_click` with a per-render click map so each row opens the most actionable GitHub page: title -> repo root, CI -> `/actions`, counts splits on x into `/issues` / `/pulls`, findings use each check's own `link`.
- Deep-link the `open_prs` / `open_issues` checks to the first item to work on (oldest non-draft PR / oldest human-filed issue) instead of the bare listing page, falling back to the listing URL when no concrete item is known.
- Make drilldown finding summaries emit OSC-8 hyperlinks (`style="link URL"`) so middle-click works there too.
- Collapse `ActionsRequested` / `PullsRequested` into a single `OpenUrl(url)` message; `app.on_repo_card_open_url` just forwards to `webbrowser.open_new_tab`.

## Test plan
- [x] `uv run pytest` -- 623 tests pass
- [x] `uv run pre-commit run --all-files` -- ruff / mypy / yaml / uv.lock clean
- [ ] Manual TUI smoke: `uv run ai-tools dashboard --all` -- middle-click on each row of a repo card and confirm the correct URL opens in the browser
- [ ] Dense-mode regression: `uv run ai-tools dashboard --layout dense` -- finding-line middle-clicks no longer misroute to `/pulls`