### PR TITLE
fix(dashboard): soften open-issues alerting, add subtle card hints

### DIFF
--- a/src/augint_tools/dashboard/_data.py
+++ b/src/augint_tools/dashboard/_data.py
@@ -22,6 +22,8 @@ from loguru import logger
 CACHE_DIR = Path.home() / ".cache" / "ai-gh"
 CACHE_FILE = CACHE_DIR / "tui_cache.json"
 
+_BOT_LOGINS = {"renovate[bot]", "renovate-bot", "dependabot[bot]", "github-actions[bot]"}
+
 
 def has_dev_branch(repo: Repository) -> bool:
     """Check if the repository has a dev branch."""
@@ -112,6 +114,13 @@ class RepoStatus:
     tags: tuple[str, ...] = ()
     # Whether the repo is private on GitHub.
     private: bool = False
+    # Human-filed open issues (bots + PRs filtered out). Populated only when
+    # open_issues > 0 -- otherwise zero and skipped to save an API call.
+    human_open_issues: int = 0
+    # ISO-8601 UTC creation timestamp of the oldest human-filed open issue.
+    # None when there are no human-filed open issues. Drives the "stale" tint
+    # on the counts line when any issue is older than three days.
+    oldest_issue_created_at: str | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -266,6 +275,32 @@ def _to_iso_utc(when) -> str | None:
         return None
 
 
+def _fetch_human_issue_summary(repo: Repository, open_issues: int) -> tuple[int, str | None]:
+    """Count human-filed open issues and find the oldest one's creation time.
+
+    Skipped entirely when ``open_issues == 0`` to avoid an API call. On any
+    error we return ``(0, None)`` rather than degrading the whole refresh.
+    """
+    if open_issues <= 0:
+        return 0, None
+    try:
+        issues = repo.get_issues(state="open")
+        human_count = 0
+        oldest: datetime | None = None
+        for issue in issues:
+            if issue.pull_request is not None:
+                continue
+            if issue.user and issue.user.login in _BOT_LOGINS:
+                continue
+            human_count += 1
+            created = getattr(issue, "created_at", None)
+            if created is not None and (oldest is None or created < oldest):
+                oldest = created
+        return human_count, _to_iso_utc(oldest)
+    except GithubException:
+        return 0, None
+
+
 def fetch_repo_status(
     repo: Repository,
     previous: RepoStatus | None = None,
@@ -305,6 +340,8 @@ def fetch_repo_status_with_pulls(
         # open_issues_count includes PRs in GitHub's API
         open_issues = max(0, repo.open_issues_count - open_prs)
 
+        human_open_issues, oldest_issue_created_at = _fetch_human_issue_summary(repo, open_issues)
+
         return (
             RepoStatus(
                 name=repo.name,
@@ -322,6 +359,8 @@ def fetch_repo_status_with_pulls(
                 is_workspace=is_workspace,
                 tags=tags,
                 private=getattr(repo, "private", False) or False,
+                human_open_issues=human_open_issues,
+                oldest_issue_created_at=oldest_issue_created_at,
             ),
             pulls_list,
         )

--- a/src/augint_tools/dashboard/health/checks/open_issues.py
+++ b/src/augint_tools/dashboard/health/checks/open_issues.py
@@ -27,7 +27,7 @@ class OpenIssuesCheck:
         config: dict,
         pulls: list | None = None,
     ) -> HealthCheckResult:
-        threshold = config.get("open_issues_threshold", 1)
+        threshold = config.get("open_issues_threshold", 10)
 
         # Fast path: if the total (including bots) is below threshold,
         # the human-only count can't exceed it either.
@@ -39,7 +39,6 @@ class OpenIssuesCheck:
             )
 
         # Fetch issues to filter out bot-created noise.
-        first_human_issue = None
         try:
             issues = repo.get_issues(state="open")
             human_count = 0
@@ -49,23 +48,16 @@ class OpenIssuesCheck:
                 if issue.user and issue.user.login in _BOT_LOGINS:
                     continue
                 human_count += 1
-                if first_human_issue is None:
-                    first_human_issue = issue
         except Exception:
             # Fall back to the unfiltered count on API error.
             human_count = status.open_issues
 
         if human_count >= threshold:
-            link = (
-                first_human_issue.html_url
-                if first_human_issue is not None
-                else f"https://github.com/{status.full_name}/issues"
-            )
             return HealthCheckResult(
                 check_name=self.name,
-                severity=Severity.MEDIUM,
+                severity=Severity.LOW,
                 summary=f"({human_count}) open issues (excl. bots)",
-                link=link,
+                link=f"https://github.com/{status.full_name}/issues",
             )
 
         return HealthCheckResult(

--- a/src/augint_tools/dashboard/widgets/repo_card.py
+++ b/src/augint_tools/dashboard/widgets/repo_card.py
@@ -9,7 +9,7 @@ state directly; it is fed from the parent container. CSS transitions on
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, Literal
 
 from rich.text import Text
@@ -47,6 +47,15 @@ _STATUS_ICON = {
     "unknown": "? ",
 }
 
+# Upper bound for the subtle blue hint on the counts line. Matches the default
+# ``open_issues_threshold`` -- at or above this, the open_issues health check
+# flags the card and its severity styling already communicates the concern.
+_ISSUE_HINT_THRESHOLD = 10
+
+# An open issue older than this turns the issues count yellow so it stands
+# out without escalating the whole card's severity.
+_ISSUE_STALE_AGE = timedelta(days=3)
+
 
 def _within_window(iso_ts: str | None, window_seconds: int) -> bool:
     """True if ``iso_ts`` is set and less than ``window_seconds`` in the past."""
@@ -60,6 +69,19 @@ def _within_window(iso_ts: str | None, window_seconds: int) -> bool:
         ts = ts.replace(tzinfo=UTC)
     delta = (datetime.now(UTC) - ts).total_seconds()
     return 0 <= delta < window_seconds
+
+
+def _older_than(iso_ts: str | None, age: timedelta) -> bool:
+    """True if ``iso_ts`` is set and strictly older than ``age``."""
+    if not iso_ts:
+        return False
+    try:
+        ts = datetime.fromisoformat(iso_ts)
+    except ValueError:
+        return False
+    if ts.tzinfo is None:
+        ts = ts.replace(tzinfo=UTC)
+    return datetime.now(UTC) - ts > age
 
 
 def _truncate(value: str | None, width: int) -> str:
@@ -280,11 +302,28 @@ class RepoCard(Widget):
 
     def _counts_line(self, health: RepoHealth) -> Text:
         status = health.status
+        spec = self._theme_spec
         line = Text()
-        line.append(f"issues {status.open_issues}  prs {status.open_prs}")
+        line.append("issues ")
+        line.append(str(status.open_issues), style=self._issue_count_style(status, spec))
+        line.append(f"  prs {status.open_prs}")
         if status.draft_prs:
             line.append(f" ({status.draft_prs}d)", style="dim")
         return line
+
+    def _issue_count_style(self, status, spec: ThemeSpec) -> str:
+        """Return the inline style for the issue count number.
+
+        Yellow when any human-filed issue is older than three days; blue when
+        there is at least one human-filed issue but the count is still below
+        the health check's threshold. Otherwise no override -- inherit the
+        card's default text colour.
+        """
+        if _older_than(status.oldest_issue_created_at, _ISSUE_STALE_AGE):
+            return spec.severity_colors[Severity.MEDIUM]
+        if 0 < status.human_open_issues < _ISSUE_HINT_THRESHOLD:
+            return spec.severity_colors[Severity.LOW]
+        return ""
 
     def _findings_lines(self, health: RepoHealth, limit: int) -> list[tuple[Text, str]]:
         """Return up to ``limit`` finding rows paired with their click-target URLs."""

--- a/tests/unit/test_dashboard.py
+++ b/tests/unit/test_dashboard.py
@@ -789,6 +789,45 @@ class TestRepoCardRender:
         card.apply_theme(nord)
         assert card._theme_spec is nord
 
+    def test_counts_line_no_hint_when_no_issues(self):
+        RepoCard, spec = self._spec()
+        card = RepoCard(_health(), theme_spec=spec)
+        line = card._counts_line(card.health)
+        # No style override should be applied -- the spans inherit from the
+        # surrounding card text.
+        assert all(span.style in ("", "dim") for span in line.spans)
+
+    def test_counts_line_blue_hint_under_threshold(self):
+        from datetime import UTC, datetime, timedelta
+
+        RepoCard, spec = self._spec()
+        status = _status(open_issues=3)
+        status.human_open_issues = 3
+        status.oldest_issue_created_at = (datetime.now(UTC) - timedelta(days=1)).isoformat()
+        health = RepoHealth(status=status)
+        card = RepoCard(health, theme_spec=spec)
+        line = card._counts_line(health)
+        # paper theme maps Severity.LOW to "bright_black".
+        low_color = spec.severity_colors[Severity.LOW]
+        assert any(low_color in str(span.style) for span in line.spans)
+
+    def test_counts_line_yellow_hint_when_stale(self):
+        from datetime import UTC, datetime, timedelta
+
+        RepoCard, spec = self._spec()
+        status = _status(open_issues=2)
+        status.human_open_issues = 2
+        status.oldest_issue_created_at = (datetime.now(UTC) - timedelta(days=5)).isoformat()
+        health = RepoHealth(status=status)
+        card = RepoCard(health, theme_spec=spec)
+        line = card._counts_line(health)
+        # paper theme maps Severity.MEDIUM to "yellow"; stale overrides blue.
+        medium_color = spec.severity_colors[Severity.MEDIUM]
+        low_color = spec.severity_colors[Severity.LOW]
+        styles = [str(span.style) for span in line.spans]
+        assert any(medium_color in s for s in styles)
+        assert not any(low_color in s for s in styles if low_color != medium_color)
+
 
 class TestDrillDown:
     def test_drilldown_renders_findings(self):

--- a/tests/unit/test_health.py
+++ b/tests/unit/test_health.py
@@ -412,51 +412,39 @@ def _mock_issue(login="human-user", is_pr=False):
 
 class TestOpenIssues:
     def test_below_threshold(self):
-        result = get_check("open_issues").evaluate(_mock_repo(), _status(open_issues=0), config={})
+        result = get_check("open_issues").evaluate(_mock_repo(), _status(open_issues=5), config={})
         assert result.severity == Severity.OK
 
     def test_above_threshold_all_human(self):
         repo = _mock_repo()
-        issues = [_mock_issue() for _ in range(3)]
-        # The first human-filed issue should drive the link.
-        issues[0].html_url = "https://github.com/org/repo/issues/42"
-        repo.get_issues.return_value = issues
-        result = get_check("open_issues").evaluate(repo, _status(open_issues=3), config={})
-        assert result.severity == Severity.MEDIUM
-        assert "(3) open issues" in result.summary
-        assert result.link == "https://github.com/org/repo/issues/42"
-
-    def test_link_skips_bot_issues(self):
-        repo = _mock_repo()
-        bot = _mock_issue(login="renovate[bot]")
-        human = _mock_issue()
-        human.html_url = "https://github.com/org/repo/issues/7"
-        # Bot comes first in the list; the check should still pick the human.
-        repo.get_issues.return_value = [bot, human, _mock_issue()]
-        result = get_check("open_issues").evaluate(repo, _status(open_issues=3), config={})
-        assert result.severity == Severity.MEDIUM
-        assert result.link == "https://github.com/org/repo/issues/7"
+        repo.get_issues.return_value = [_mock_issue() for _ in range(15)]
+        result = get_check("open_issues").evaluate(repo, _status(open_issues=15), config={})
+        assert result.severity == Severity.LOW
+        assert "(15) open issues" in result.summary
+        assert result.link is not None
 
     def test_bot_issues_excluded(self):
         repo = _mock_repo()
-        # Only bot-filed issues (e.g. Renovate Dependency Dashboard) should not flip yellow.
-        issues = [
+        issues = [_mock_issue() for _ in range(5)] + [
             _mock_issue(login="renovate[bot]"),
             _mock_issue(login="dependabot[bot]"),
             _mock_issue(login="github-actions[bot]"),
         ]
+        # Total is 8 but only 5 are human-filed.
+        # Even though open_issues=12 triggers the API fetch,
+        # the filtered count (5) is below the default threshold (10).
         repo.get_issues.return_value = issues
-        result = get_check("open_issues").evaluate(repo, _status(open_issues=3), config={})
+        result = get_check("open_issues").evaluate(repo, _status(open_issues=12), config={})
         assert result.severity == Severity.OK
-        assert "(0) open issues" in result.summary
+        assert "(5) open issues" in result.summary
 
     def test_custom_threshold(self):
         repo = _mock_repo()
         repo.get_issues.return_value = [_mock_issue() for _ in range(3)]
         result = get_check("open_issues").evaluate(
-            repo, _status(open_issues=3), config={"open_issues_threshold": 5}
+            repo, _status(open_issues=3), config={"open_issues_threshold": 3}
         )
-        assert result.severity == Severity.OK
+        assert result.severity == Severity.LOW
 
 
 class TestOpenPRs:


### PR DESCRIPTION
## Summary
- Restore `open_issues_threshold` to 10 and severity to LOW. Yesterday's drop to 1/MEDIUM was too noisy for repos where issues routinely stay open for days.
- Add a subtler hint on the card counts line: the `issues N` number turns **blue** when there are human-filed issues still under threshold, and **yellow** when any open issue is older than three days. The rest of the card keeps its severity-driven styling.
- Thread the data through cleanly: two optional fields on `RepoStatus` (`human_open_issues`, `oldest_issue_created_at`) populated from a single pass over the open issues list, skipped entirely when the repo has none.

## Test plan
- [x] `uv run pytest tests/unit/test_health.py tests/unit/test_dashboard.py` — 212 passed
- [x] `uv run pre-commit run --all-files` — all hooks pass (ruff, mypy, uv.lock)
- [ ] Visual verification once merged: confirm blue/yellow hints render against the live dashboard