### PR TITLE
feat(dashboard): prominent refresh status + softer issue alerting

### DIFF
--- a/src/augint_tools/dashboard/app.py
+++ b/src/augint_tools/dashboard/app.py
@@ -64,7 +64,7 @@ from .widgets.effect_sprite import SPRITE_WIDTH, EffectKind, EffectSprite
 from .widgets.error_drawer import ErrorDrawer
 from .widgets.highlight_bar import HighlightBar
 from .widgets.repo_card import RepoCard
-from .widgets.status_bar import StatusBar, format_header_refresh_text
+from .widgets.status_bar import StatusBar, format_header_refresh_line
 from .widgets.system_drawer import SystemDrawer
 from .widgets.top_drawer import TopDrawer
 
@@ -124,34 +124,36 @@ def _card_severity_class(health: RepoHealth | None) -> str | None:
 
 
 class OrgDrawerHeader(Container):
-    """Top-docked title bar with a subtle right-aligned refresh countdown.
+    """Top-docked two-line header: title + prominent refresh status.
 
     Clicking anywhere on the bar posts :class:`Toggle`, which the main
     screen maps onto the same action as the ``i`` key (open/close the org
-    drawer). We don't subclass ``Header`` because Textual's built-in
-    header widget tall-mode click handling fights our needs, and we want
-    to inject a tiny countdown label on the right.
+    drawer). Line 1 holds the app title. Line 2 shows the time of the
+    last refresh, a live countdown to the next auto-refresh, and the
+    configured interval -- making "yes, refreshes are happening" an
+    unmissable, always-visible fact.
     """
 
     DEFAULT_CSS = """
     OrgDrawerHeader {
         dock: top;
-        height: 1;
-        layout: horizontal;
+        height: 2;
+        layout: vertical;
         background: #1a1a22;
         overflow: hidden;
     }
     OrgDrawerHeader > #hdr-title {
-        width: 1fr;
+        width: 100%;
+        height: 1;
         content-align: center middle;
         text-style: bold;
         overflow: hidden;
     }
-    OrgDrawerHeader > #hdr-countdown {
-        width: auto;
-        max-width: 44;
-        padding: 0 1;
-        color: #d0d0d8;
+    OrgDrawerHeader > #hdr-refresh {
+        width: 100%;
+        height: 1;
+        content-align: center middle;
+        color: #c8c8d2;
         overflow: hidden;
     }
     """
@@ -163,11 +165,11 @@ class OrgDrawerHeader(Container):
         super().__init__(id="org-drawer-header")
         self._initial_title = title
         self._title_widget = Static("", id="hdr-title")
-        self._countdown_widget = Static("", id="hdr-countdown")
+        self._refresh_widget = Static("", id="hdr-refresh")
 
     def compose(self):
         yield self._title_widget
-        yield self._countdown_widget
+        yield self._refresh_widget
 
     def on_mount(self) -> None:
         # App title isn't available until mount; set it once here.
@@ -178,21 +180,27 @@ class OrgDrawerHeader(Container):
         event.stop()
         self.post_message(self.Toggle())
 
-    def set_countdown(self, text: str) -> None:
-        """Update the right-side countdown label."""
-        self._countdown_widget.update(text)
+    def set_refresh_line(self, text: str) -> None:
+        """Update the second-line refresh status text."""
+        self._refresh_widget.update(text)
 
 
 class MainScreen(Screen[None]):
     """Primary screen: header, status bar, highlight bar, card grid, footer, drawer."""
 
     def __init__(
-        self, state: AppState, org_name: str = "", owners: list[str] | None = None
+        self,
+        state: AppState,
+        org_name: str = "",
+        owners: list[str] | None = None,
+        *,
+        refresh_seconds: int = 0,
     ) -> None:
         super().__init__(id="main-screen")
         self._state = state
         self._org_name = org_name
         self._owners: list[str] = owners or ([org_name] if org_name else [])
+        self._refresh_seconds = refresh_seconds
         self._header = OrgDrawerHeader()
         self._status_bar = StatusBar()
         self._highlight_bar = HighlightBar()
@@ -238,7 +246,7 @@ class MainScreen(Screen[None]):
         self._update_selection_styling()
         self._highlight_bar.rerender()
         self._status_bar.tick()
-        self._header.set_countdown(self._countdown_text())
+        self._header.set_refresh_line(self._refresh_line_text())
         if self._top_drawer.is_open:
             self._top_drawer.set_content(
                 self._org_drawer_left_sections(),
@@ -262,7 +270,7 @@ class MainScreen(Screen[None]):
 
     def tick_status(self) -> None:
         self._status_bar.tick()
-        self._header.set_countdown(self._countdown_text())
+        self._header.set_refresh_line(self._refresh_line_text())
 
     def apply_flash_phase(self, phase: bool, *, window_seconds: int) -> None:
         """Propagate the global flash phase to each card."""
@@ -336,25 +344,24 @@ class MainScreen(Screen[None]):
         for full_name in list(self._effects_by_name.keys()):
             self._position_effect(full_name)
 
-    def _countdown_text(self) -> str:
-        """Format the right-header refresh indicator.
+    def _refresh_line_text(self) -> str:
+        """Format the second-line refresh status shown in the header.
 
-        Shows both "last: Xs ago" and "next: in Ys" so users see at a
-        glance both how fresh the on-screen data is and when the next
-        auto-refresh will fire.  Prefers loading / refreshing state so
-        users have an unmistakable "we're working on it" indicator
-        during the 20-30 second first fetch.
+        Names all three facts in plain language (time of last refresh,
+        countdown to next, interval) so auto-refresh is always legible
+        at a glance.  Local-time is used for the last-refresh stamp
+        because clock-on-wall is what users are comparing against.
 
         Drift note: ``next_refresh_at`` is set when ``_trigger_refresh``
         starts a refresh, so during a long-running refresh the displayed
-        countdown briefly reflects the cycle that's already in flight.
-        We mask this by showing "refreshing..." while ``is_refreshing``
-        is true rather than a misleading countdown.
+        countdown briefly reflects the cycle already in flight. We mask
+        this by showing "refreshing..." while ``is_refreshing`` is true
+        rather than a misleading countdown.
         """
         state = self._state
         now = datetime.now(UTC)
-        last_age = (
-            int((now - state.last_refresh_at).total_seconds())
+        last_label = (
+            state.last_refresh_at.astimezone().strftime("%H:%M:%S")
             if state.last_refresh_at is not None
             else None
         )
@@ -363,10 +370,11 @@ class MainScreen(Screen[None]):
             if state.next_refresh_at is not None
             else None
         )
-        return format_header_refresh_text(
+        return format_header_refresh_line(
             is_refreshing=state.is_refreshing,
-            last_refresh_age_seconds=last_age,
+            last_refresh_label=last_label,
             next_refresh_remaining_seconds=remaining,
+            interval_seconds=self._refresh_seconds,
         )
 
     def _rebuild_cards(self) -> None:
@@ -1230,7 +1238,12 @@ class DashboardApp(App[None]):
         bootstrap_from_cache(self.state, restrict_to=restrict)
         apply_open_source_team(self.state)
 
-        self._main = MainScreen(self.state, self._org_name, owners=self._owners)
+        self._main = MainScreen(
+            self.state,
+            self._org_name,
+            owners=self._owners,
+            refresh_seconds=(0 if self._skip_refresh else self._refresh_seconds),
+        )
         self.push_screen(self._main)
 
         if self._repos and not self._skip_refresh:

--- a/src/augint_tools/dashboard/widgets/status_bar.py
+++ b/src/augint_tools/dashboard/widgets/status_bar.py
@@ -109,6 +109,53 @@ def format_header_refresh_text(
     return f"{last_part} · {next_part}"
 
 
+def _format_interval(seconds: int) -> str:
+    """Format the auto-refresh interval as "Xs", "Xm", or "XhYYm"."""
+    if seconds <= 0:
+        return "off"
+    if seconds < 60:
+        return f"{seconds}s"
+    if seconds < 3600:
+        m, s = divmod(seconds, 60)
+        return f"{m}m{s:02d}s" if s else f"{m}m"
+    h, rem = divmod(seconds, 3600)
+    m = rem // 60
+    return f"{h}h{m:02d}m" if m else f"{h}h"
+
+
+def format_header_refresh_line(
+    *,
+    is_refreshing: bool,
+    last_refresh_label: str | None,
+    next_refresh_remaining_seconds: int | None,
+    interval_seconds: int,
+) -> str:
+    """Build the prominent two-line-header second row.
+
+    Unlike ``format_header_refresh_text`` (the narrow right-aligned chip),
+    this line always names all three facts the user cares about:
+    when the last refresh completed, when the next one fires, and the
+    configured auto-refresh interval. The interval in particular is
+    otherwise invisible to the user and easy to forget.
+
+    Inputs are pre-computed so this can be unit-tested without freezing
+    time. ``last_refresh_label`` is the caller's choice of timestamp
+    format (typically local-time "HH:MM:SS").
+    """
+    interval_label = _format_interval(interval_seconds)
+    interval_part = f"interval: {interval_label}"
+    if is_refreshing and last_refresh_label is None:
+        return f"loading data...  ·  {interval_part}"
+    last_part = f"last refresh: {last_refresh_label}" if last_refresh_label else "last refresh: --"
+    if is_refreshing:
+        return f"{last_part}  ·  refreshing...  ·  {interval_part}"
+    if next_refresh_remaining_seconds is None:
+        return f"{last_part}  ·  auto-refresh off"
+    remaining = max(0, next_refresh_remaining_seconds)
+    next_label = "now" if remaining == 0 else _format_countdown(remaining)
+    return f"{last_part}  ·  next: in {next_label}  ·  {interval_part}"
+
+
 def _describe_active_filters(active: set[str], team_labels: dict[str, str] | None = None) -> str:
     """Summarise the active filter set for the status bar."""
     if not active:

--- a/tests/unit/test_dashboard.py
+++ b/tests/unit/test_dashboard.py
@@ -1700,6 +1700,82 @@ class TestAppMisc:
         assert "last: 2m ago" in text
         assert "auto-refresh off" in text
 
+    def test_header_refresh_line_idle_shows_all_three_facts(self):
+        """Steady-state line names last-refresh time, countdown, and interval."""
+        from augint_tools.dashboard.widgets.status_bar import format_header_refresh_line
+
+        text = format_header_refresh_line(
+            is_refreshing=False,
+            last_refresh_label="14:35:12",
+            next_refresh_remaining_seconds=125,
+            interval_seconds=600,
+        )
+        assert "last refresh: 14:35:12" in text
+        assert "next: in 2m05s" in text
+        assert "interval: 10m" in text
+
+    def test_header_refresh_line_loading(self):
+        """First launch without cache still names the interval.
+
+        The user needs to know the dashboard is in a refresh cycle and
+        what that cycle's period is, otherwise "loading" reads as if
+        nothing is scheduled at all.
+        """
+        from augint_tools.dashboard.widgets.status_bar import format_header_refresh_line
+
+        text = format_header_refresh_line(
+            is_refreshing=True,
+            last_refresh_label=None,
+            next_refresh_remaining_seconds=None,
+            interval_seconds=300,
+        )
+        assert "loading data" in text
+        assert "interval: 5m" in text
+
+    def test_header_refresh_line_refreshing_with_prior_data(self):
+        """Mid-refresh shows the stale timestamp and 'refreshing...' not the countdown."""
+        from augint_tools.dashboard.widgets.status_bar import format_header_refresh_line
+
+        text = format_header_refresh_line(
+            is_refreshing=True,
+            last_refresh_label="14:35:12",
+            next_refresh_remaining_seconds=600,
+            interval_seconds=600,
+        )
+        assert "last refresh: 14:35:12" in text
+        assert "refreshing" in text
+        assert "next: in" not in text
+        assert "interval: 10m" in text
+
+    def test_header_refresh_line_auto_refresh_off(self):
+        """Without a scheduled next-refresh, drop the countdown and the interval."""
+        from augint_tools.dashboard.widgets.status_bar import format_header_refresh_line
+
+        text = format_header_refresh_line(
+            is_refreshing=False,
+            last_refresh_label="14:35:12",
+            next_refresh_remaining_seconds=None,
+            interval_seconds=0,
+        )
+        assert "last refresh: 14:35:12" in text
+        assert "auto-refresh off" in text
+        # Suppress the interval half when auto-refresh is off; otherwise
+        # we'd show both "auto-refresh off" and "interval: off" which
+        # is noisy without adding information.
+        assert "interval" not in text
+
+    def test_header_refresh_line_due_now(self):
+        """Zero remaining renders as 'next: in now'-equivalent, clamped."""
+        from augint_tools.dashboard.widgets.status_bar import format_header_refresh_line
+
+        text = format_header_refresh_line(
+            is_refreshing=False,
+            last_refresh_label="14:35:12",
+            next_refresh_remaining_seconds=-3,
+            interval_seconds=600,
+        )
+        assert "next: in now" in text or "next:" in text and "now" in text
+
     def test_bootstrap_seeds_last_refresh_at(self, tmp_path):
         """bootstrap_from_cache must set last_refresh_at from cache ts.
 


### PR DESCRIPTION
## Summary
- Header gains a second line that always shows last-refresh time, live countdown, and configured interval -- auto-refresh is now unmissable
- Open-issues alerting softened and subtle card hints added (prior commit c2ffeed)

## Test plan
- [x] uv run pytest (630 passed)
- [x] uv run pre-commit run --all-files (all passed)
- [ ] Manual: launch dashboard, confirm header second line shows "last refresh: HH:MM:SS · next: in Xs · interval: Ym"
- [ ] Manual: press r, confirm line flips to "refreshing..." then back to countdown with updated timestamp