### PR TITLE
fix(dashboard): put refresh status on the visible highlight bar line 2

### DIFF
--- a/src/augint_tools/dashboard/app.py
+++ b/src/augint_tools/dashboard/app.py
@@ -220,7 +220,7 @@ class MainScreen(Screen[None]):
         yield self._header
         self._status_bar.bind_state(self._state, self._org_name, owners=self._owners)
         yield self._status_bar
-        self._highlight_bar.bind_state(self._state)
+        self._highlight_bar.bind_state(self._state, refresh_seconds=self._refresh_seconds)
         yield self._highlight_bar
         yield self._top_drawer
         yield Container(self._card_container)
@@ -271,6 +271,10 @@ class MainScreen(Screen[None]):
     def tick_status(self) -> None:
         self._status_bar.tick()
         self._header.set_refresh_line(self._refresh_line_text())
+        # Drive the HighlightBar's second-line countdown every second so
+        # the user sees a live "next: in Xs" tick down -- proof that the
+        # refresh loop is running even when the data itself hasn't changed.
+        self._highlight_bar.rerender()
 
     def apply_flash_phase(self, phase: bool, *, window_seconds: int) -> None:
         """Propagate the global flash phase to each card."""

--- a/src/augint_tools/dashboard/widgets/highlight_bar.py
+++ b/src/augint_tools/dashboard/widgets/highlight_bar.py
@@ -2,19 +2,28 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
 from rich.text import Text
 from textual.widgets import Static
 
 from ..health import Severity
+from .status_bar import format_header_refresh_line
 
 if TYPE_CHECKING:
     from ..state import AppState
 
 
 class HighlightBar(Static):
-    """Three-line at-a-glance summary bar."""
+    """Three-line at-a-glance summary bar.
+
+    Line 1 is the worst-repo / totals summary. Line 2 is the prominent
+    refresh status (time of last refresh, live countdown, interval) --
+    the header above the status bar is only a single row so the refresh
+    line needs to live here to be actually visible at a glance.
+    Line 3 is a spacer that the status bar docks into the gap above.
+    """
 
     DEFAULT_CSS = """
     HighlightBar { height: 3; }
@@ -23,17 +32,20 @@ class HighlightBar(Static):
     def __init__(self, id: str = "highlight-bar") -> None:
         super().__init__("", id=id)
         self._state: AppState | None = None
+        self._refresh_seconds: int = 0
 
-    def bind_state(self, state: AppState) -> None:
+    def bind_state(self, state: AppState, *, refresh_seconds: int = 0) -> None:
         self._state = state
+        self._refresh_seconds = refresh_seconds
 
     def rerender(self) -> None:
         state = self._state
         if state is None or not state.healths:
             if state is not None and state.is_refreshing:
-                self.update(Text("loading repository data...", style="bold yellow"))
+                top = Text("loading repository data...", style="bold yellow")
             else:
-                self.update(Text("no data yet. press r to refresh.", style="dim"))
+                top = Text("no data yet. press r to refresh.", style="dim")
+            self.update(Text("\n").join([top, self._refresh_line(), Text(" ")]))
             return
 
         worst = min(state.healths, key=lambda h: h.score)
@@ -51,4 +63,32 @@ class HighlightBar(Static):
         line1.append("   prs: ", style="bold")
         line1.append(str(total_prs))
 
-        self.update(Text("\n").join([line1, Text(" "), Text(" ")]))
+        self.update(Text("\n").join([line1, self._refresh_line(), Text(" ")]))
+
+    def _refresh_line(self) -> Text:
+        """Build the bold second-line refresh status.
+
+        Styled bold cyan so the user's eye lands on it -- the whole point
+        is that "refreshes are happening" must be unmissable.
+        """
+        state = self._state
+        if state is None:
+            return Text(" ")
+        now = datetime.now(UTC)
+        last_label = (
+            state.last_refresh_at.astimezone().strftime("%H:%M:%S")
+            if state.last_refresh_at is not None
+            else None
+        )
+        remaining = (
+            int((state.next_refresh_at - now).total_seconds())
+            if state.next_refresh_at is not None
+            else None
+        )
+        text = format_header_refresh_line(
+            is_refreshing=state.is_refreshing,
+            last_refresh_label=last_label,
+            next_refresh_remaining_seconds=remaining,
+            interval_seconds=self._refresh_seconds,
+        )
+        return Text(text, style="bold cyan")


### PR DESCRIPTION
## Summary
Follow-up to #67. The previous commit added the refresh line to OrgDrawerHeader, but the bar the user actually sees between the status bar and the cards is the three-line HighlightBar -- its line 2 was rendered blank. Move the last-refresh / countdown / interval string there and tick it every second so the countdown updates live.

## Test plan
- [x] uv run pytest (630 passed)
- [x] uv run pre-commit run --all-files (all passed)
- [ ] Manual: launch dashboard, confirm line directly below "worst: X (...) problems: N ..." reads "last refresh: HH:MM:SS  ·  next: in Xs  ·  interval: Ym"
- [ ] Manual: confirm the "next: in" value ticks down every second
- [ ] Manual: press r, confirm the line flips to "refreshing..." and then back with an updated timestamp