### PR TITLE
feat(dashboard): add coverage health check

### DIFF
--- a/src/augint_tools/dashboard/health/checks/__init__.py
+++ b/src/augint_tools/dashboard/health/checks/__init__.py
@@ -1,9 +1,10 @@
 """Built-in health checks. Importing this module triggers registration."""
 
-from . import broken_ci, open_issues, open_prs, renovate, renovate_prs, stale_prs
+from . import broken_ci, coverage, open_issues, open_prs, renovate, renovate_prs, stale_prs
 
 __all__ = [
     "broken_ci",
+    "coverage",
     "open_issues",
     "open_prs",
     "renovate",

--- a/src/augint_tools/dashboard/health/checks/coverage.py
+++ b/src/augint_tools/dashboard/health/checks/coverage.py
@@ -1,0 +1,274 @@
+"""Health check: test-coverage threshold enforcement in CI.
+
+Parses the repository's canonical GitHub Actions workflow
+(``.github/workflows/pipeline.yaml``) and inspects the ``unit-tests`` job
+for signals that the coverage gate has been weakened:
+
+- Python: ``pytest --cov-fail-under=N`` with N below the canonical 80% baseline
+  (see the ai-standardize-pipeline standard).
+- Any coverage-related step that ignores failures via ``continue-on-error: true``
+  or shell suffixes such as ``|| true``, ``|| :``, ``|| echo ...``.
+
+For Node repos using ``vitest``/``jest --coverage`` the threshold lives in
+``vitest.config.*``/``jest.config.*`` rather than the workflow, so this check
+is intentionally workflow-only and reports OK on seeing the coverage flag --
+config-level parsing is out of scope.
+
+When the workflow can't be fetched or the ``unit-tests`` job / coverage step
+is missing, the check returns MEDIUM severity with a summary prefixed
+``unverified:`` so it is visibly distinguishable from a verified regression.
+MEDIUM matches the precedent set by ``broken_ci`` for governance gaps and
+avoids silently signalling OK for a repo we never actually validated.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING, Any
+
+import yaml
+from github.GithubException import GithubException
+
+from .._models import HealthCheckResult, Severity
+from .._registry import register
+
+if TYPE_CHECKING:
+    from github.Repository import Repository
+
+    from ..._data import RepoStatus
+
+# Canonical Python coverage threshold enforced by ai-standardize-pipeline.
+_STANDARD_THRESHOLD = 80
+
+# Workflow file candidates, in preference order. The canonical name is
+# ``pipeline.yaml`` (see the ai-standardize templates); ``pipeline.yml`` is a
+# tolerated fallback for older repos that haven't been standardized yet.
+_WORKFLOW_PATHS = (
+    ".github/workflows/pipeline.yaml",
+    ".github/workflows/pipeline.yml",
+)
+
+# Regex for extracting ``--cov-fail-under=N`` or ``--cov-fail-under N``.
+_FAIL_UNDER_RE = re.compile(r"--cov-fail-under[=\s]+(\d+)")
+
+# Matches shell suffixes that swallow a non-zero exit code on the same line.
+# ``|| true``, ``|| :``, ``|| echo "whatever"``.
+_IGNORE_SUFFIX_RE = re.compile(r"\|\|\s*(true|:|echo\b)")
+
+
+class CoverageCheck:
+    """Detect lowered or disabled test-coverage gates in CI."""
+
+    name = "coverage"
+    description = "Detect lowered or ignored test-coverage thresholds in CI"
+
+    def evaluate(
+        self,
+        repo: Repository,
+        status: RepoStatus,
+        *,
+        config: dict,
+        pulls: list | None = None,
+    ) -> HealthCheckResult:
+        try:
+            default_branch = repo.default_branch
+        except Exception:
+            default_branch = "main"
+
+        workflow_link = (
+            f"https://github.com/{status.full_name}/blob/{default_branch}"
+            "/.github/workflows/pipeline.yaml"
+        )
+
+        raw, used_path = self._fetch_workflow(repo, default_branch)
+        if raw is None:
+            return HealthCheckResult(
+                check_name=self.name,
+                severity=Severity.MEDIUM,
+                summary="unverified: no pipeline.yaml",
+                link=f"https://github.com/{status.full_name}",
+            )
+
+        try:
+            workflow = yaml.safe_load(raw)
+        except yaml.YAMLError:
+            return HealthCheckResult(
+                check_name=self.name,
+                severity=Severity.MEDIUM,
+                summary="unverified: pipeline.yaml parse error",
+                link=workflow_link,
+            )
+
+        if not isinstance(workflow, dict):
+            return HealthCheckResult(
+                check_name=self.name,
+                severity=Severity.MEDIUM,
+                summary="unverified: pipeline.yaml not a mapping",
+                link=workflow_link,
+            )
+
+        # Rebuild the link using the workflow path we actually found so clicks
+        # land on the right file (pipeline.yaml vs pipeline.yml).
+        workflow_link = f"https://github.com/{status.full_name}/blob/{default_branch}/{used_path}"
+
+        jobs = workflow.get("jobs")
+        if not isinstance(jobs, dict):
+            return HealthCheckResult(
+                check_name=self.name,
+                severity=Severity.MEDIUM,
+                summary="unverified: no jobs in pipeline.yaml",
+                link=workflow_link,
+            )
+
+        unit_tests = jobs.get("unit-tests")
+        if not isinstance(unit_tests, dict):
+            return HealthCheckResult(
+                check_name=self.name,
+                severity=Severity.MEDIUM,
+                summary="unverified: no unit-tests job",
+                link=workflow_link,
+            )
+
+        steps = unit_tests.get("steps")
+        if not isinstance(steps, list):
+            return HealthCheckResult(
+                check_name=self.name,
+                severity=Severity.MEDIUM,
+                summary="unverified: unit-tests has no steps",
+                link=workflow_link,
+            )
+
+        return self._evaluate_steps(steps, workflow_link)
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _fetch_workflow(
+        self, repo: Repository, default_branch: str
+    ) -> tuple[str | None, str | None]:
+        """Fetch the first existing workflow file. Returns (text, path) or (None, None)."""
+        for path in _WORKFLOW_PATHS:
+            try:
+                content_file = repo.get_contents(path, ref=default_branch)
+            except GithubException:
+                continue
+            except Exception:
+                # Any other failure (network, auth) is treated like "not found"
+                # so the refresh loop stays alive; the caller returns UNVERIFIED.
+                continue
+            if isinstance(content_file, list):
+                # Directory listing -- skip; shouldn't happen for a file path.
+                continue
+            try:
+                raw = content_file.decoded_content.decode("utf-8")
+            except Exception:
+                continue
+            return raw, path
+        return None, None
+
+    def _evaluate_steps(self, steps: list[Any], workflow_link: str) -> HealthCheckResult:
+        """Walk unit-tests steps and classify the coverage posture."""
+        coverage_seen = False
+        coverage_ignored = False
+        lowered_threshold: int | None = None
+        has_python_cov_flag = False
+        has_python_fail_under = False
+        has_node_coverage = False
+
+        for step in steps:
+            if not isinstance(step, dict):
+                continue
+            run = step.get("run")
+            if not isinstance(run, str):
+                continue
+
+            is_python = "pytest" in run and "--cov" in run
+            is_node = ("vitest" in run or "jest" in run) and "--coverage" in run
+            if not (is_python or is_node):
+                continue
+
+            coverage_seen = True
+            continue_on_error = bool(step.get("continue-on-error"))
+            has_ignore_suffix = bool(_IGNORE_SUFFIX_RE.search(run))
+            if continue_on_error or has_ignore_suffix:
+                coverage_ignored = True
+
+            if is_python:
+                has_python_cov_flag = True
+                match = _FAIL_UNDER_RE.search(run)
+                if match:
+                    has_python_fail_under = True
+                    threshold = int(match.group(1))
+                    # Track the lowest threshold seen across all matching steps.
+                    if lowered_threshold is None or threshold < lowered_threshold:
+                        lowered_threshold = threshold
+
+            if is_node:
+                has_node_coverage = True
+
+        if not coverage_seen:
+            return HealthCheckResult(
+                check_name=self.name,
+                severity=Severity.MEDIUM,
+                summary="unverified: no coverage command in unit-tests",
+                link=workflow_link,
+            )
+
+        # Ignoring failures is worse than lowering the bar: still run tests,
+        # but a red coverage report has no consequence.
+        if coverage_ignored:
+            return HealthCheckResult(
+                check_name=self.name,
+                severity=Severity.MEDIUM,
+                summary="coverage failures ignored",
+                link=workflow_link,
+            )
+
+        if has_python_fail_under:
+            assert lowered_threshold is not None
+            if lowered_threshold < _STANDARD_THRESHOLD:
+                return HealthCheckResult(
+                    check_name=self.name,
+                    severity=Severity.LOW,
+                    summary=(
+                        f"coverage threshold lowered to {lowered_threshold}% "
+                        f"(std: {_STANDARD_THRESHOLD}%)"
+                    ),
+                    link=workflow_link,
+                )
+            return HealthCheckResult(
+                check_name=self.name,
+                severity=Severity.OK,
+                summary=f"coverage threshold {lowered_threshold}%",
+            )
+
+        if has_python_cov_flag:
+            # Coverage is collected but no fail-under gate -- the CI will not
+            # fail on regressions. Treat as a lowered gate (equivalent to 0%).
+            return HealthCheckResult(
+                check_name=self.name,
+                severity=Severity.LOW,
+                summary="coverage reported but no fail-under threshold",
+                link=workflow_link,
+            )
+
+        if has_node_coverage:
+            # Workflow-only scope: threshold lives in vitest/jest config files
+            # and is out of scope for this check. Trust the flag's presence.
+            return HealthCheckResult(
+                check_name=self.name,
+                severity=Severity.OK,
+                summary="coverage enforced (threshold in config)",
+            )
+
+        # Defensive fallback -- should be unreachable given the checks above.
+        return HealthCheckResult(
+            check_name=self.name,
+            severity=Severity.MEDIUM,
+            summary="unverified: coverage signal unclear",
+            link=workflow_link,
+        )
+
+
+register(CoverageCheck())

--- a/tests/unit/test_health.py
+++ b/tests/unit/test_health.py
@@ -191,6 +191,7 @@ class TestRegistry:
         assert "stale_prs" in names
         assert "open_issues" in names
         assert "open_prs" in names
+        assert "coverage" in names
 
     def test_all_checks_returns_instances(self):
         checks = all_checks()
@@ -501,6 +502,200 @@ class TestOpenPRs:
             _mock_repo(), _status(open_prs=1), config={"open_prs_threshold": 2}
         )
         assert result.severity == Severity.OK
+
+
+def _mock_workflow_repo(
+    pipeline_yaml: str | None,
+    *,
+    default_branch: str = "main",
+    path: str = ".github/workflows/pipeline.yaml",
+):
+    """Return a repo mock whose ``get_contents`` returns pipeline_yaml.
+
+    If ``pipeline_yaml`` is None, all paths raise GithubException (not found).
+    Otherwise, the provided yaml is returned for ``path`` and all other paths
+    raise GithubException.
+    """
+    repo = _mock_repo()
+    repo.default_branch = default_branch
+
+    def _get_contents(requested_path, ref=None):
+        if pipeline_yaml is None or requested_path != path:
+            raise GithubException(404, "not found", None)
+        content = MagicMock()
+        content.decoded_content = pipeline_yaml.encode("utf-8")
+        return content
+
+    repo.get_contents.side_effect = _get_contents
+    return repo
+
+
+class TestCoverageCheck:
+    _STANDARD_PY = """\
+jobs:
+  unit-tests:
+    name: Unit tests
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Run pytest
+        run: |
+          uv run pytest --cov=src --cov-fail-under=80 --cov-report=xml
+"""
+
+    _LOWERED_PY = """\
+jobs:
+  unit-tests:
+    steps:
+      - name: Run pytest
+        run: uv run pytest --cov=src --cov-fail-under=60
+"""
+
+    _NO_FAIL_UNDER_PY = """\
+jobs:
+  unit-tests:
+    steps:
+      - name: Run pytest
+        run: uv run pytest --cov=src --cov-report=xml
+"""
+
+    _CONTINUE_ON_ERROR_PY = """\
+jobs:
+  unit-tests:
+    steps:
+      - name: Run pytest
+        continue-on-error: true
+        run: uv run pytest --cov=src --cov-fail-under=80
+"""
+
+    _OR_TRUE_PY = """\
+jobs:
+  unit-tests:
+    steps:
+      - name: Run pytest
+        run: uv run pytest --cov=src --cov-fail-under=80 || true
+"""
+
+    _NODE_VITEST = """\
+jobs:
+  unit-tests:
+    steps:
+      - name: Vitest
+        run: npx vitest run --coverage
+"""
+
+    _NO_UNIT_TESTS = """\
+jobs:
+  lint:
+    steps:
+      - run: echo hi
+"""
+
+    _NO_COVERAGE_COMMAND = """\
+jobs:
+  unit-tests:
+    steps:
+      - name: Run pytest
+        run: uv run pytest -v
+"""
+
+    def test_standard_threshold_is_ok(self):
+        repo = _mock_workflow_repo(self._STANDARD_PY)
+        result = get_check("coverage").evaluate(repo, _status(), config={})
+        assert result.severity == Severity.OK
+        assert "80" in result.summary
+
+    def test_lowered_threshold_is_low(self):
+        repo = _mock_workflow_repo(self._LOWERED_PY)
+        result = get_check("coverage").evaluate(repo, _status(), config={})
+        assert result.severity == Severity.LOW
+        assert "60" in result.summary
+        assert "lowered" in result.summary
+        assert result.link is not None
+        assert "pipeline.yaml" in result.link
+
+    def test_no_fail_under_is_low(self):
+        repo = _mock_workflow_repo(self._NO_FAIL_UNDER_PY)
+        result = get_check("coverage").evaluate(repo, _status(), config={})
+        assert result.severity == Severity.LOW
+        assert "fail-under" in result.summary
+
+    def test_continue_on_error_is_medium(self):
+        repo = _mock_workflow_repo(self._CONTINUE_ON_ERROR_PY)
+        result = get_check("coverage").evaluate(repo, _status(), config={})
+        assert result.severity == Severity.MEDIUM
+        assert "ignored" in result.summary
+
+    def test_or_true_suffix_is_medium(self):
+        repo = _mock_workflow_repo(self._OR_TRUE_PY)
+        result = get_check("coverage").evaluate(repo, _status(), config={})
+        assert result.severity == Severity.MEDIUM
+        assert "ignored" in result.summary
+
+    def test_node_vitest_is_ok(self):
+        repo = _mock_workflow_repo(self._NODE_VITEST)
+        result = get_check("coverage").evaluate(repo, _status(), config={})
+        assert result.severity == Severity.OK
+        assert "coverage" in result.summary.lower()
+
+    def test_missing_pipeline_is_unverified(self):
+        repo = _mock_workflow_repo(None)
+        result = get_check("coverage").evaluate(repo, _status(), config={})
+        assert result.severity == Severity.MEDIUM
+        assert result.summary.startswith("unverified:")
+
+    def test_missing_unit_tests_job_is_unverified(self):
+        repo = _mock_workflow_repo(self._NO_UNIT_TESTS)
+        result = get_check("coverage").evaluate(repo, _status(), config={})
+        assert result.severity == Severity.MEDIUM
+        assert "unverified" in result.summary
+        assert "unit-tests" in result.summary
+
+    def test_missing_coverage_command_is_unverified(self):
+        repo = _mock_workflow_repo(self._NO_COVERAGE_COMMAND)
+        result = get_check("coverage").evaluate(repo, _status(), config={})
+        assert result.severity == Severity.MEDIUM
+        assert "unverified" in result.summary
+        assert "coverage" in result.summary
+
+    def test_yml_fallback(self):
+        repo = _mock_workflow_repo(self._STANDARD_PY, path=".github/workflows/pipeline.yml")
+        result = get_check("coverage").evaluate(repo, _status(), config={})
+        assert result.severity == Severity.OK
+
+    def test_github_exception_is_unverified(self):
+        repo = _mock_repo()
+        repo.default_branch = "main"
+        repo.get_contents.side_effect = GithubException(500, "boom", None)
+        result = get_check("coverage").evaluate(repo, _status(), config={})
+        assert result.severity == Severity.MEDIUM
+        assert result.summary.startswith("unverified:")
+
+    def test_yaml_parse_error_is_unverified(self):
+        repo = _mock_workflow_repo("jobs: [this is: not valid")
+        result = get_check("coverage").evaluate(repo, _status(), config={})
+        assert result.severity == Severity.MEDIUM
+        assert "unverified" in result.summary
+
+    def test_lowest_threshold_wins(self):
+        yaml_text = """\
+jobs:
+  unit-tests:
+    steps:
+      - run: uv run pytest --cov=src --cov-fail-under=80
+      - run: uv run pytest tests/integration --cov=src --cov-fail-under=50
+"""
+        repo = _mock_workflow_repo(yaml_text)
+        result = get_check("coverage").evaluate(repo, _status(), config={})
+        assert result.severity == Severity.LOW
+        assert "50" in result.summary
+
+    def test_link_targets_default_branch(self):
+        repo = _mock_workflow_repo(self._LOWERED_PY, default_branch="trunk")
+        result = get_check("coverage").evaluate(repo, _status(full_name="org/myrepo"), config={})
+        assert result.link == (
+            "https://github.com/org/myrepo/blob/trunk/.github/workflows/pipeline.yaml"
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- New `coverage` health check surfaces repos that have lowered their test-coverage threshold or are ignoring coverage failures in CI.
- Parses `.github/workflows/pipeline.yaml` (with `.yml` fallback) on the default branch. Workflow-only scope; Node config-file parsing is out of scope and treated as OK.
- Returns MEDIUM with `unverified:` prefix when the signal can't be validated, matching the precedent `broken_ci` set for governance gaps.

## Severity matrix
| Condition | Severity |
|---|---|
| Python `--cov-fail-under=N`, N >= 80 | OK |
| Python `--cov-fail-under=N`, N < 80 | LOW |
| Python `--cov` with no `--cov-fail-under` | LOW (treated as 0% threshold) |
| Any coverage step with `continue-on-error: true` or `\|\| true`/`\|\| :`/`\|\| echo` | MEDIUM |
| Node `vitest`/`jest` with `--coverage` | OK |
| Missing pipeline / no unit-tests job / YAML parse error | MEDIUM (unverified:) |

## Test plan
- [x] 14 new test cases in `tests/unit/test_health.py::TestCoverageCheck`
- [x] Full suite: 644 tests pass
- [x] `pre-commit run --all-files` clean

## Note
Adds 1-2 REST calls per repo per refresh (fetches pipeline.yaml). Will become free once the GraphQL refresh migration lands and fetches pipeline.yaml text in the batched query.