### PR TITLE
feat(dashboard): informative OK-state summaries with clickable links

### DIFF
--- a/src/augint_tools/dashboard/app.py
+++ b/src/augint_tools/dashboard/app.py
@@ -546,16 +546,67 @@ class MainScreen(Screen[None]):
         t.append(f"main ci: {status.main_status}\n")
         if status.is_service and status.dev_status:
             t.append(f"dev ci:  {status.dev_status}\n")
-        t.append(f"issues:  {status.open_issues}\n")
-        t.append(f"prs:     {status.open_prs} ({status.draft_prs} drafts)\n\n")
+        # issues + PRs counts are emitted as OSC-8 hyperlinks so clicking the
+        # number opens the matching GitHub listing. Matches the card's click
+        # routing in spirit -- drawer widgets don't support per-line click
+        # handlers, so the terminal's native link handler carries the click.
+        issues_url = f"https://github.com/{status.full_name}/issues"
+        pulls_url = f"https://github.com/{status.full_name}/pulls"
+        t.append("issues:  ")
+        t.append(str(status.open_issues), style=f"link {issues_url}")
+        t.append("\n")
+        t.append("prs:     ")
+        t.append(
+            f"{status.open_prs} ({status.draft_prs} drafts)",
+            style=f"link {pulls_url}",
+        )
+        t.append("\n\n")
         if health.findings:
             t.append("findings:\n", style="bold")
             for finding in health.findings:
                 t.append(f"  • {finding.check_name}: {finding.summary}\n")
         else:
-            t.append("all checks green.\n", style="dim")
+            # Mirror the card's OK-state summary so the drawer is useful even
+            # when the repo is fully green. Empty body -> just the closing hint.
+            summary = self._healthy_summary_line(status, issues_url, pulls_url)
+            if summary.plain:
+                t.append_text(summary)
+                t.append("\n")
         t.append("\npress d to close, enter for full drilldown.", style="dim")
         return t
+
+    def _healthy_summary_line(
+        self,
+        status: RepoStatus,
+        issues_url: str,
+        pulls_url: str,
+    ) -> Text:
+        """Single-line OK-state summary with clickable counts.
+
+        Each count is wrapped in an OSC-8 hyperlink via ``style="link ..."`` so
+        the terminal treats the number as directly clickable. Drafts share the
+        PRs URL since GitHub's /pulls page lists both.
+        """
+        line = Text()
+        pieces: list[tuple[str, str]] = []
+        if status.open_issues > 0:
+            noun = "issue" if status.open_issues == 1 else "issues"
+            pieces.append((f"{status.open_issues} {noun}", issues_url))
+        ready_prs = max(0, status.open_prs - status.draft_prs)
+        if ready_prs > 0:
+            noun = "pr" if ready_prs == 1 else "prs"
+            pieces.append((f"{ready_prs} {noun}", pulls_url))
+        if status.draft_prs > 0:
+            noun = "draft" if status.draft_prs == 1 else "drafts"
+            pieces.append((f"{status.draft_prs} {noun}", pulls_url))
+        if not pieces:
+            return line
+        line.append("no findings. open: ", style="dim")
+        for idx, (label, url) in enumerate(pieces):
+            if idx:
+                line.append(", ", style="dim")
+            line.append(label, style=f"dim link {url}")
+        return line
 
     # ------------------------------------------------------------------
     # Org drawer content
@@ -619,7 +670,7 @@ class MainScreen(Screen[None]):
         sections.append(("header", header))
 
         sev_bar = Text()
-        self._append_severity_bar(sev_bar, by_sev, total, spec)
+        self._append_severity_bar(sev_bar, by_sev, total, spec, healths=state.healths)
         sections.append(("severity_bar", sev_bar))
 
         glyphs = Text()
@@ -981,8 +1032,15 @@ class MainScreen(Screen[None]):
         spec,  # ThemeSpec
         *,
         width: int = 24,
+        healths: list | None = None,
     ) -> None:
-        """Render a colour-segmented block bar representing severity distribution."""
+        """Render a colour-segmented block bar representing severity distribution.
+
+        When every repo is green we still surface useful OK-severity info by
+        aggregating open-issue and open-PR counts across the whole workspace
+        and rendering them as clickable hyperlinks to the user's GitHub
+        dashboard (which scopes to repos they can see).
+        """
         from .health import Severity as _Sev
 
         order = [
@@ -1013,13 +1071,61 @@ class MainScreen(Screen[None]):
             if n > 0:
                 t.append("\u2588" * n, style=spec.severity_colors[sev])
         t.append("]   ")
-        pieces: list[str] = []
+        non_ok_pieces: list[tuple[str, str | None]] = []
         for sev, label in order:
+            if sev is _Sev.OK:
+                continue
             count = by_sev.get(sev, 0)
             if count:
-                pieces.append(f"{label} {count}")
-        t.append("  ".join(pieces) if pieces else "all green")
+                non_ok_pieces.append((f"{label} {count}", None))
+        pieces: list[tuple[str, str | None]] = list(non_ok_pieces)
+        # When nothing is wrong, surface aggregated OK-state info (open issues
+        # / PRs) as clickable totals instead of a flat "all green" string. The
+        # legend keeps a trailing "ok N" chip for continuity with the prior
+        # behaviour.
+        ok_count = by_sev.get(_Sev.OK, 0)
+        if not non_ok_pieces and healths:
+            pieces.extend(self._healthy_org_pieces(healths))
+        if ok_count:
+            pieces.append((f"ok {ok_count}", None))
+        if pieces:
+            for idx, (label, url) in enumerate(pieces):
+                if idx:
+                    t.append("  ")
+                if url:
+                    t.append(label, style=f"link {url}")
+                else:
+                    t.append(label)
+        else:
+            t.append("all green")
         t.append("\n\n")
+
+    def _healthy_org_pieces(self, healths: list) -> list[tuple[str, str | None]]:
+        """Aggregate OK-state totals across all healths into clickable labels.
+
+        Returns ``(label, url)`` pairs; ``url`` is attached as an OSC-8 link on
+        the rendered text. Targets GitHub's global issues/pulls dashboard --
+        when signed in this scopes to repos the user can see, giving a single
+        click-through that works across all the owners shown in the header.
+        """
+        total_issues = sum(max(0, h.status.open_issues) for h in healths)
+        total_prs = sum(max(0, h.status.open_prs) for h in healths)
+        pieces: list[tuple[str, str | None]] = []
+        if total_issues > 0:
+            pieces.append(
+                (
+                    f"issues {total_issues}",
+                    "https://github.com/issues?q=is%3Aopen+is%3Aissue",
+                )
+            )
+        if total_prs > 0:
+            pieces.append(
+                (
+                    f"prs {total_prs}",
+                    "https://github.com/pulls?q=is%3Aopen+is%3Apr",
+                )
+            )
+        return pieces
 
     def _append_repo_glyphs(self, t: Text, spec) -> None:
         """One coloured dot per repo (worst severity), capped so we don't overflow."""

--- a/src/augint_tools/dashboard/screens/widget_help.py
+++ b/src/augint_tools/dashboard/screens/widget_help.py
@@ -42,8 +42,10 @@ WIDGET_HELP: dict[str, tuple[str, str]] = {
         (
             "Horizontal stacked bar showing what fraction of repos sit in each "
             "severity bucket: critical, high, medium, low, and ok. The legend on "
-            "the right lists every non-zero bucket with its count; if nothing is "
-            'wrong it simply reads "all green".'
+            "the right lists every non-zero bucket with its count; when nothing "
+            "is wrong it falls back to an aggregated view of open issues and "
+            "PRs across the workspace, each clickable through to GitHub so you "
+            "can pick up work directly from here."
         ),
     ),
     "repo_glyphs": (

--- a/src/augint_tools/dashboard/widgets/repo_card.py
+++ b/src/augint_tools/dashboard/widgets/repo_card.py
@@ -326,7 +326,14 @@ class RepoCard(Widget):
         return ""
 
     def _findings_lines(self, health: RepoHealth, limit: int) -> list[tuple[Text, str]]:
-        """Return up to ``limit`` finding rows paired with their click-target URLs."""
+        """Return up to ``limit`` finding rows paired with their click-target URLs.
+
+        When there are no real findings we still want the slot to carry useful
+        signal rather than a flat "all green" string, so we emit OK-severity
+        info lines summarising what work is sitting on this repo (open issues,
+        open PRs, drafts). Each info line routes to the matching GitHub page
+        so the user can click straight in to start working.
+        """
         spec = self._theme_spec
         actions_url = self._actions_url(health)
         lines: list[tuple[Text, str]] = []
@@ -352,13 +359,59 @@ class RepoCard(Widget):
             if len(lines) >= limit:
                 return lines
         if not lines:
-            lines.append(
+            lines.extend(self._healthy_info_lines(health, limit))
+        return lines
+
+    def _healthy_info_lines(self, health: RepoHealth, limit: int) -> list[tuple[Text, str]]:
+        """Informative OK-severity rows used when this repo has zero findings.
+
+        Surfaces open issues / PRs / drafts with click targets, so a green card
+        still offers a jumping-off point. Falls back to a single "healthy"
+        line linking to the repo home when there's nothing to show at all.
+        """
+        spec = self._theme_spec
+        status = health.status
+        ok_style = spec.severity_colors[Severity.OK]
+        full_name = status.full_name
+        issues_url = f"https://github.com/{full_name}/issues"
+        pulls_url = f"https://github.com/{full_name}/pulls"
+
+        info: list[tuple[Text, str]] = []
+        if status.open_issues > 0:
+            noun = "issue" if status.open_issues == 1 else "issues"
+            info.append(
                 (
-                    Text("all checks green", style=spec.severity_colors[Severity.OK]),
+                    Text(f"{status.open_issues} open {noun}", style=ok_style),
+                    issues_url,
+                )
+            )
+        # "open PRs" here means non-draft PRs -- drafts get their own line so
+        # the reader can tell at a glance which ones are actually review-ready.
+        ready_prs = max(0, status.open_prs - status.draft_prs)
+        if ready_prs > 0:
+            noun = "pr" if ready_prs == 1 else "prs"
+            info.append(
+                (
+                    Text(f"{ready_prs} open {noun}", style=ok_style),
+                    pulls_url,
+                )
+            )
+        if status.draft_prs > 0:
+            noun = "draft" if status.draft_prs == 1 else "drafts"
+            info.append(
+                (
+                    Text(f"{status.draft_prs} {noun}", style=ok_style),
+                    pulls_url,
+                )
+            )
+        if not info:
+            info.append(
+                (
+                    Text("healthy", style=ok_style),
                     self._repo_url(health),
                 )
             )
-        return lines
+        return info[:limit] if limit > 0 else info
 
     def _render_packed(self, health: RepoHealth) -> Text:
         self._click_map = {}

--- a/tests/unit/test_dashboard.py
+++ b/tests/unit/test_dashboard.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from click.testing import CliRunner
 from github.GithubException import GithubException
+from rich.text import Text
 
 from augint_tools.cli.__main__ import cli as main
 from augint_tools.dashboard import state
@@ -827,6 +828,196 @@ class TestRepoCardRender:
         styles = [str(span.style) for span in line.spans]
         assert any(medium_color in s for s in styles)
         assert not any(low_color in s for s in styles if low_color != medium_color)
+
+
+class TestFindingsLinesHealthyInfo:
+    """When no real findings, _findings_lines returns OK-severity info with URLs."""
+
+    def _spec(self):
+        from augint_tools.dashboard.widgets.repo_card import RepoCard
+
+        return RepoCard, get_theme("paper")
+
+    def test_no_findings_no_info_returns_healthy_line_linking_to_repo(self):
+        RepoCard, spec = self._spec()
+        card = RepoCard(_health(full_name="org/quiet"), theme_spec=spec)
+        lines = card._findings_lines(card.health, limit=2)
+        assert len(lines) == 1
+        text, url = lines[0]
+        assert text.plain == "healthy"
+        assert url == "https://github.com/org/quiet"
+
+    def test_no_findings_with_open_issues_returns_issues_line(self):
+        RepoCard, spec = self._spec()
+        status = _status(full_name="org/busy", open_issues=4)
+        health = RepoHealth(status=status)
+        card = RepoCard(health, theme_spec=spec)
+        lines = card._findings_lines(health, limit=2)
+        assert any(
+            line.plain == "4 open issues" and url == "https://github.com/org/busy/issues"
+            for line, url in lines
+        )
+
+    def test_no_findings_single_issue_uses_singular_noun(self):
+        RepoCard, spec = self._spec()
+        status = _status(full_name="org/busy", open_issues=1)
+        health = RepoHealth(status=status)
+        card = RepoCard(health, theme_spec=spec)
+        lines = card._findings_lines(health, limit=2)
+        assert lines[0][0].plain == "1 open issue"
+
+    def test_no_findings_with_issues_and_prs_returns_both_lines(self):
+        RepoCard, spec = self._spec()
+        status = _status(full_name="org/busy", open_issues=2, open_prs=3)
+        health = RepoHealth(status=status)
+        card = RepoCard(health, theme_spec=spec)
+        lines = card._findings_lines(health, limit=4)
+        plain = [(line.plain, url) for line, url in lines]
+        assert ("2 open issues", "https://github.com/org/busy/issues") in plain
+        assert ("3 open prs", "https://github.com/org/busy/pulls") in plain
+
+    def test_no_findings_drafts_line_separate_from_ready_prs(self):
+        RepoCard, spec = self._spec()
+        status = _status(full_name="org/busy", open_prs=3)
+        status.draft_prs = 2
+        health = RepoHealth(status=status)
+        card = RepoCard(health, theme_spec=spec)
+        lines = card._findings_lines(health, limit=4)
+        plain = [(line.plain, url) for line, url in lines]
+        # 3 open total, 2 drafts -> 1 ready PR, 2 drafts.
+        assert ("1 open pr", "https://github.com/org/busy/pulls") in plain
+        assert ("2 drafts", "https://github.com/org/busy/pulls") in plain
+
+    def test_no_findings_respects_limit(self):
+        RepoCard, spec = self._spec()
+        status = _status(full_name="org/busy", open_issues=4, open_prs=3)
+        status.draft_prs = 1
+        health = RepoHealth(status=status)
+        card = RepoCard(health, theme_spec=spec)
+        lines = card._findings_lines(health, limit=1)
+        assert len(lines) == 1
+
+    def test_healthy_line_uses_ok_severity_color(self):
+        RepoCard, spec = self._spec()
+        card = RepoCard(_health(), theme_spec=spec)
+        lines = card._findings_lines(card.health, limit=2)
+        ok_style = spec.severity_colors[Severity.OK]
+        assert lines[0][0].style == ok_style
+
+    def test_real_findings_still_take_precedence(self):
+        RepoCard, spec = self._spec()
+        warning = HealthCheckResult(
+            check_name="stale_prs", severity=Severity.MEDIUM, summary="2 stale"
+        )
+        status = _status(full_name="org/busy", open_issues=5)
+        health = RepoHealth(status=status, checks=[warning])
+        card = RepoCard(health, theme_spec=spec)
+        lines = card._findings_lines(health, limit=2)
+        # First line is the real finding; no "N open issues" line when findings exist.
+        assert "stale" in lines[0][0].plain
+        assert not any("open issues" in line.plain for line, _ in lines)
+
+
+class TestDetailDrawerHealthySummary:
+    """_detail_drawer_content surfaces OK info with clickable links when green."""
+
+    def _app_and_health(self, **status_kwargs):
+        from augint_tools.dashboard.app import MainScreen
+
+        status = _status(**status_kwargs)
+        health = RepoHealth(status=status)
+        state = AppState()
+        state.healths = [health]
+        screen = MainScreen(state)
+        return screen, health
+
+    def test_no_findings_with_issues_includes_clickable_summary(self):
+        screen, health = self._app_and_health(full_name="org/quiet", open_issues=3)
+        text = screen._detail_drawer_content(health)
+        plain = text.plain
+        assert "no findings. open:" in plain
+        assert "3 issues" in plain
+        # The summary line should carry an OSC-8 hyperlink to the issues page.
+        link_styles = [str(span.style) for span in text.spans]
+        assert any("link https://github.com/org/quiet/issues" in s for s in link_styles)
+
+    def test_no_findings_no_info_hides_summary(self):
+        screen, health = self._app_and_health(full_name="org/quiet")
+        plain = screen._detail_drawer_content(health).plain
+        assert "no findings. open:" not in plain
+        # Previous wording must not leak back in.
+        assert "all checks green" not in plain
+
+    def test_counts_row_is_always_clickable(self):
+        screen, health = self._app_and_health(full_name="org/quiet", open_issues=2, open_prs=1)
+        text = screen._detail_drawer_content(health)
+        link_styles = [str(span.style) for span in text.spans]
+        assert any("link https://github.com/org/quiet/issues" in s for s in link_styles)
+        assert any("link https://github.com/org/quiet/pulls" in s for s in link_styles)
+
+
+class TestOrgSeverityBarHealthyInfo:
+    """_append_severity_bar aggregates OK info when there are zero findings."""
+
+    def _screen(self):
+        from augint_tools.dashboard.app import MainScreen
+
+        return MainScreen(AppState())
+
+    def test_all_green_with_issues_renders_clickable_totals(self):
+        screen = self._screen()
+        spec = get_theme("paper")
+        h1 = RepoHealth(status=_status(full_name="org/a", open_issues=3, open_prs=0))
+        h2 = RepoHealth(status=_status(full_name="org/b", open_issues=2, open_prs=4))
+        by_sev = {Severity.OK: 2}
+        t = Text()
+        screen._append_severity_bar(t, by_sev, total=2, spec=spec, healths=[h1, h2])
+        plain = t.plain
+        assert "issues 5" in plain
+        assert "prs 4" in plain
+        # "all green" literal is reserved for the truly-nothing-to-show case.
+        assert "all green" not in plain
+        styles = [str(span.style) for span in t.spans]
+        assert any("link https://github.com/issues" in s for s in styles)
+        assert any("link https://github.com/pulls" in s for s in styles)
+
+    def test_all_green_with_no_info_still_renders_ok_chip(self):
+        screen = self._screen()
+        spec = get_theme("paper")
+        h = RepoHealth(status=_status(full_name="org/a"))
+        by_sev = {Severity.OK: 1}
+        t = Text()
+        screen._append_severity_bar(t, by_sev, total=1, spec=spec, healths=[h])
+        plain = t.plain
+        # No issues / PRs to link -- still shows the OK count chip; no stray
+        # clickable links get emitted.
+        assert "ok 1" in plain
+        styles = [str(span.style) for span in t.spans]
+        assert not any("link https://github.com/issues" in s for s in styles)
+        assert not any("link https://github.com/pulls" in s for s in styles)
+
+    def test_non_green_pieces_take_precedence(self):
+        screen = self._screen()
+        spec = get_theme("paper")
+        h = RepoHealth(status=_status(full_name="org/a", open_issues=5))
+        by_sev = {Severity.CRITICAL: 1}
+        t = Text()
+        screen._append_severity_bar(t, by_sev, total=1, spec=spec, healths=[h])
+        plain = t.plain
+        assert "crit 1" in plain
+        # Don't duplicate aggregated OK info when there's real severity to show.
+        assert "issues 5" not in plain
+
+    def test_all_green_carries_trailing_ok_chip(self):
+        screen = self._screen()
+        spec = get_theme("paper")
+        h = RepoHealth(status=_status(full_name="org/a", open_issues=2))
+        by_sev = {Severity.OK: 1}
+        t = Text()
+        screen._append_severity_bar(t, by_sev, total=1, spec=spec, healths=[h])
+        plain = t.plain
+        # Aggregated chip comes first, ok chip trails for continuity.
+        assert plain.index("issues 2") < plain.index("ok 1")
 
 
 class TestDrillDown:


### PR DESCRIPTION
## Summary
- Replaces "all checks green" / "all green" in three places with OK-severity summaries of what's still sitting on a repo (open issues, open PRs, drafts).
- Every new line is clickable and routes to GitHub's issue/PR page for that repo (or the user's personal dashboard for the org bar).
- Card uses per-line `_ClickRegion`; drawer + org bar use OSC-8 hyperlinks (`style="link URL"`) since those surfaces have no per-line click map — matches the existing `_append_ci_matrix` pattern.

## Surfaces
- **Repo card** — `_healthy_info_lines()` replaces the flat "all checks green" string when no findings exist. Links to `/issues` and `/pulls`.
- **Detail drawer** — new `_healthy_summary_line()` embeds OSC-8 links on issue/PR counts.
- **Org summary bar** — aggregated totals across all OK-severity repos link to `github.com/issues?q=is:open+is:issue` and `/pulls?q=is:open+is:pr`.
- `screens/widget_help.py` — help text for the severity bar updated.

## Test plan
- [x] 15 new test cases across `TestFindingsLinesHealthyInfo`, `TestDetailDrawerHealthySummary`, `TestOrgSeverityBarHealthyInfo`
- [x] Full suite: 585 tests pass (existing tests still green)
- [x] `pre-commit run --all-files` clean