### PR TITLE
feat(dashboard): finish GraphQL migration — teams + SHA-cached failing-run detail

### DIFF
--- a/docs/graphql-refresh-plan.md
+++ b/docs/graphql-refresh-plan.md
@@ -62,7 +62,7 @@ One batched GraphQL query per refresh fetches almost everything for every repo a
 | Why | What |
 |---|---|
 | `statusCheckRollup.state` gives PASS/FAIL/PENDING but not a failing-job/step name | On failure, one REST call to get the failing run's `jobs()` for error detail. Only for repos currently failing — a small fraction. |
-| Teams API is cheap per repo and org-scoped | Keep `collect_repo_teams` on REST for now. Revisit only if the dashboard is consistently limited by team calls (it isn't today). |
+| ~~Teams API is cheap per repo and org-scoped~~ | ~~Keep `collect_repo_teams` on REST for now~~. **Revised during implementation**: teams moved to GraphQL (`organization.teams.repositories` with edges for permissions) on a 5-minute cache. Per-repo REST calls dropped from 20/min to 0 at steady state. |
 | Org + viewer enumeration | `list_repos_multi` and `list_user_orgs` — bootstrap only, not per-refresh hot path. |
 
 ## Scope of code changes

--- a/src/augint_tools/dashboard/_gql.py
+++ b/src/augint_tools/dashboard/_gql.py
@@ -164,7 +164,7 @@ fragment RepoFields on Repository {{
   _rootTree: object(expression: "HEAD:") {{
     ... on Tree {{ entries {{ name }} }}
   }}
-  pullRequests(states: OPEN, first: 100) {{
+  pullRequests(states: OPEN, first: 50) {{
     totalCount
     nodes {{
       number
@@ -174,7 +174,7 @@ fragment RepoFields on Repository {{
       author {{ login }}
     }}
   }}
-  issues(states: OPEN, first: 100) {{
+  issues(states: OPEN, first: 50) {{
     totalCount
     nodes {{
       number
@@ -505,3 +505,168 @@ def pick_pipeline_yaml(snapshot: RepoSnapshot) -> tuple[str | None, str | None]:
         if text and text.strip():
             return path, text
     return None, None
+
+
+# ---------------------------------------------------------------------------
+# Teams fetcher
+# ---------------------------------------------------------------------------
+#
+# Teams are queried inverse to repos: GraphQL's Repository type has no direct
+# ``teams`` connection, but organizations expose ``teams -> repositories`` with
+# per-edge permission info. One query per org returns every team assignment
+# across all repos in the workspace. Called on a slower cadence than the main
+# refresh because team membership changes rarely -- see
+# ``TeamsCache.is_stale``.
+
+
+# Mirror of ``_TEAM_PERMISSION_ORDER`` in state.py -- kept here so _gql has
+# no reverse dependency on state. Permission strings come straight from the
+# GraphQL enum lowercased.
+_TEAM_PERMISSION_ORDER: dict[str, int] = {
+    "admin": 0,
+    "maintain": 1,
+    "write": 2,
+    "triage": 3,
+    "read": 4,
+}
+
+
+@dataclass
+class TeamAssignment:
+    """One team's access grant to one repo. Permission from the team->repo edge."""
+
+    slug: str
+    name: str
+    permission: str  # "admin" | "maintain" | "write" | "triage" | "read"
+
+
+@dataclass
+class TeamsSnapshot:
+    """Workspace-wide team data from one or more organization queries."""
+
+    by_full_name: dict[str, list[TeamAssignment]] = field(default_factory=dict)
+    # slug -> display name mapping for every team seen across all orgs.
+    labels: dict[str, str] = field(default_factory=dict)
+    rate_limit_cost: int = 0
+    rate_limit_remaining: int = 0
+    errored: dict[str, str] = field(default_factory=dict)  # keyed by owner login
+
+
+def build_teams_query(owners: list[str]) -> str:
+    """Build a single GraphQL query listing teams + repositories for each owner.
+
+    Personal-account owners (non-org) return a null organization -- handled
+    gracefully by parse_teams_response (those repos simply have no teams).
+    """
+    parts: list[str] = []
+    for i, owner in enumerate(owners):
+        owner_esc = owner.replace("\\", "\\\\").replace('"', '\\"')
+        parts.append(
+            f'  o{i}: organization(login: "{owner_esc}") {{\n'
+            f"    login\n"
+            f"    teams(first: 50) {{\n"
+            f"      nodes {{\n"
+            f"        slug\n"
+            f"        name\n"
+            f"        repositories(first: 50) {{\n"
+            f"          edges {{\n"
+            f"            permission\n"
+            f"            node {{ nameWithOwner }}\n"
+            f"          }}\n"
+            f"        }}\n"
+            f"      }}\n"
+            f"    }}\n"
+            f"  }}"
+        )
+    body = "\n".join(parts)
+    return f"query WorkspaceTeams {{\n{body}\n  rateLimit {{ limit cost remaining resetAt }}\n}}\n"
+
+
+def parse_teams_response(response: dict, owners: list[str]) -> TeamsSnapshot:
+    """Parse the WorkspaceTeams response into a TeamsSnapshot."""
+    data = response.get("data") or {}
+    rate_limit = data.get("rateLimit") or {}
+    snapshot = TeamsSnapshot(
+        rate_limit_cost=int(rate_limit.get("cost") or 0) if isinstance(rate_limit, dict) else 0,
+        rate_limit_remaining=int(rate_limit.get("remaining") or 0)
+        if isinstance(rate_limit, dict)
+        else 0,
+    )
+
+    # Surface top-level errors per owner.
+    for err in response.get("errors") or []:
+        path = err.get("path")
+        if not isinstance(path, list) or not path:
+            continue
+        alias = path[0]
+        if not isinstance(alias, str) or not alias.startswith("o"):
+            continue
+        try:
+            idx = int(alias[1:])
+        except ValueError:
+            continue
+        if 0 <= idx < len(owners):
+            snapshot.errored[owners[idx]] = str(err.get("message", "GraphQL error"))
+
+    # Build per-repo assignments across every owner's team tree.
+    assignments: dict[str, list[TeamAssignment]] = {}
+    for i, owner in enumerate(owners):
+        org_data = data.get(f"o{i}")
+        # Personal-account owners return null -- that's fine, no teams to map.
+        if not isinstance(org_data, dict):
+            continue
+        teams_conn = org_data.get("teams") or {}
+        if not isinstance(teams_conn, dict):
+            continue
+        for team in teams_conn.get("nodes") or []:
+            if not isinstance(team, dict):
+                continue
+            slug = str(team.get("slug") or "")
+            if not slug:
+                continue
+            name = str(team.get("name") or slug)
+            snapshot.labels[slug] = name
+            repos_conn = team.get("repositories") or {}
+            if not isinstance(repos_conn, dict):
+                continue
+            for edge in repos_conn.get("edges") or []:
+                if not isinstance(edge, dict):
+                    continue
+                node = edge.get("node") or {}
+                full_name = node.get("nameWithOwner") if isinstance(node, dict) else None
+                if not isinstance(full_name, str):
+                    continue
+                permission = str(edge.get("permission") or "").lower()
+                assignments.setdefault(full_name, []).append(
+                    TeamAssignment(slug=slug, name=name, permission=permission)
+                )
+        # Note: if the owner IS an org but returned no teams, that's legitimate
+        # empty state and doesn't warrant an error.
+        _ = owner  # silences ruff ARG002 -- owner used above via i
+
+    # Sort each repo's team list by (permission order, slug) so "primary" is
+    # deterministic and matches what the REST-era collect_repo_teams produced.
+    for full_name, team_list in assignments.items():
+        team_list.sort(key=lambda t: (_TEAM_PERMISSION_ORDER.get(t.permission, 99), t.slug.lower()))
+        snapshot.by_full_name[full_name] = team_list
+
+    return snapshot
+
+
+def fetch_workspace_teams(gh: Github, owners: list[str]) -> TeamsSnapshot:
+    """One GraphQL query covering every owner's teams + repo assignments.
+
+    Designed to be called on a cadence independent from ``fetch_workspace_snapshot``
+    (teams change rarely; caching for several minutes is safe).
+    """
+    if not owners:
+        return TeamsSnapshot()
+    query = build_teams_query(owners)
+    try:
+        response = _execute_query(gh, query)
+    except Exception as exc:
+        logger.warning("graphql teams fetch failed: %s: %s", exc.__class__.__name__, exc)
+        return TeamsSnapshot(
+            errored=dict.fromkeys(owners, f"graphql: {exc.__class__.__name__}: {exc}")
+        )
+    return parse_teams_response(response, owners)

--- a/src/augint_tools/dashboard/app.py
+++ b/src/augint_tools/dashboard/app.py
@@ -26,7 +26,12 @@ from textual.screen import Screen
 from textual.widgets import Static
 
 from ._data import RepoStatus, build_status_from_snapshot, fetch_failing_run_detail, save_cache
-from ._gql import fetch_workspace_snapshot, pick_pipeline_yaml, pick_renovate_config
+from ._gql import (
+    fetch_workspace_snapshot,
+    fetch_workspace_teams,
+    pick_pipeline_yaml,
+    pick_renovate_config,
+)
 from ._helpers import get_viewer_login, list_repos_multi, list_user_orgs, strip_dotfile_repos
 from .health import FetchContext, RepoHealth, run_health_checks
 from .layouts import list_layouts
@@ -43,12 +48,10 @@ from .state import (
     PANEL_WIDTH_STEP,
     SORT_MODES,
     AppState,
-    CollectedTeamData,
     apply_open_source_team,
     bootstrap_from_cache,
-    collect_repo_teams,
     ensure_selection,
-    merge_team_data,
+    merge_teams_snapshot,
     move_selection,
     selected_health,
     team_accent,
@@ -72,6 +75,8 @@ from .widgets.top_drawer import TopDrawer
 if TYPE_CHECKING:
     from github import Github
     from github.Repository import Repository
+
+    from ._gql import TeamsSnapshot
 
 
 def _progress_bar(fraction: float, width: int) -> str:
@@ -1306,6 +1311,21 @@ class DashboardApp(App[None]):
         # Disabled orgs -- excluded from auto-discovery (like disabled_repos).
         self._disabled_orgs: set[str] = set()
 
+        # Team assignments change rarely, so we fetch them on a much slower
+        # cadence than the main refresh. Keeps the GraphQL point-cost bounded
+        # even when the user drops --refresh-seconds into the tens of seconds.
+        self._teams_ttl_seconds: int = 300
+        self._last_teams_refresh_at: datetime | None = None
+
+        # Cache for failing-run detail keyed by (full_name, branch, head_sha).
+        # A failing branch keeps the same head commit until someone pushes a
+        # fix or a retry -- so after the first detail fetch we never hit REST
+        # again for the same failure.
+        self._failing_detail_cache: dict[
+            tuple[str, str, str],
+            tuple[str | None, str | None],
+        ] = {}
+
         # Apply remaining saved preferences (sort, filters, panel width, flash).
         # Theme and layout are already applied via initial_theme/initial_layout
         # which the caller resolves from saved prefs + CLI overrides.
@@ -1508,7 +1528,6 @@ class DashboardApp(App[None]):
             return
 
         ordered_names: list[str] = [r.full_name for r in self._repos]
-        team_data: list[CollectedTeamData] = []
         failed_repos: set[str] = set()
 
         # Phase 1: batched GraphQL fetch -- one query per 25 repos covers
@@ -1571,52 +1590,112 @@ class DashboardApp(App[None]):
             if status.is_service and status.dev_status == "failure":
                 failing_targets.append((repo, "dev"))
 
-        # Phase 2b: REST fallback for failing-run detail. GraphQL's
-        # statusCheckRollup doesn't expose the failing job/step name; this
-        # is the only per-repo REST call and only fires for failing branches.
+        # Phase 2b: populate failing-run detail. GraphQL's statusCheckRollup
+        # doesn't expose the failing job/step name, so we fall back to REST
+        # -- but cache keyed by (full_name, branch, head_sha) so each failing
+        # commit costs exactly one REST call regardless of how many refresh
+        # cycles it stays failing.
         if failing_targets and not self.state.cancel_requested:
-            logger.debug(f"refresh: fetching failure detail for {len(failing_targets)} branch(es)")
-            detail_workers = min(4, len(failing_targets))
-            with ThreadPoolExecutor(max_workers=detail_workers) as pool:
-                detail_futures = {
-                    pool.submit(fetch_failing_run_detail, repo, branch): (repo.full_name, branch)
-                    for repo, branch in failing_targets
-                }
-                for detail_fut in as_completed(detail_futures):
-                    if self.state.cancel_requested:
-                        pool.shutdown(wait=False, cancel_futures=True)
-                        return
-                    detail_full_name, detail_branch = detail_futures[detail_fut]
-                    try:
-                        detail_err, detail_since = detail_fut.result()
-                    except Exception:
-                        continue
-                    detail_status = status_by_name.get(detail_full_name)
-                    if detail_status is None:
-                        continue
-                    if detail_branch == detail_status.default_branch:
-                        detail_status.main_error = detail_err
-                        detail_status.main_failing_since = detail_since
-                    elif detail_branch == "dev":
-                        detail_status.dev_error = detail_err
-                        detail_status.dev_failing_since = detail_since
+            to_fetch: list[tuple[Repository, str]] = []
+            for repo, branch in failing_targets:
+                snapshot = snapshot_by_name.get(repo.full_name)
+                if snapshot is None:
+                    continue
+                head_sha = (
+                    snapshot.dev_head_sha if branch == "dev" else snapshot.main_head_sha
+                ) or ""
+                cache_key = (repo.full_name, branch, head_sha)
+                cached = self._failing_detail_cache.get(cache_key)
+                if cached is not None:
+                    self._apply_failing_detail(status_by_name, repo.full_name, branch, *cached)
+                else:
+                    to_fetch.append((repo, branch))
 
-        # Phase 3: team data (still REST; small, cheap, not the hot path).
-        team_workers = min(8, len(self._repos) or 1)
-        with ThreadPoolExecutor(max_workers=team_workers) as pool:
-            team_futures = {pool.submit(collect_repo_teams, repo): repo for repo in self._repos}
-            for team_fut in as_completed(team_futures):
-                if self.state.cancel_requested:
-                    pool.shutdown(wait=False, cancel_futures=True)
-                    return
+            if to_fetch:
+                logger.debug(
+                    f"refresh: failing-run detail cache miss for {len(to_fetch)} branch(es)"
+                )
+                detail_workers = min(4, len(to_fetch))
+                with ThreadPoolExecutor(max_workers=detail_workers) as pool:
+                    detail_futures = {
+                        pool.submit(fetch_failing_run_detail, repo, branch): (
+                            repo.full_name,
+                            branch,
+                        )
+                        for repo, branch in to_fetch
+                    }
+                    for detail_fut in as_completed(detail_futures):
+                        if self.state.cancel_requested:
+                            pool.shutdown(wait=False, cancel_futures=True)
+                            return
+                        detail_full_name, detail_branch = detail_futures[detail_fut]
+                        try:
+                            detail_err, detail_since = detail_fut.result()
+                        except Exception:
+                            continue
+                        snapshot = snapshot_by_name.get(detail_full_name)
+                        head_sha = (
+                            (
+                                snapshot.dev_head_sha
+                                if detail_branch == "dev"
+                                else snapshot.main_head_sha
+                            )
+                            if snapshot is not None
+                            else ""
+                        ) or ""
+                        self._failing_detail_cache[(detail_full_name, detail_branch, head_sha)] = (
+                            detail_err,
+                            detail_since,
+                        )
+                        self._apply_failing_detail(
+                            status_by_name,
+                            detail_full_name,
+                            detail_branch,
+                            detail_err,
+                            detail_since,
+                        )
+
+            # Trim cache entries for branches that are no longer failing so it
+            # doesn't grow unbounded over a long session.
+            live_keys = {
+                (repo.full_name, branch, snapshot_by_name[repo.full_name].dev_head_sha or "")
+                if branch == "dev"
+                else (repo.full_name, branch, snapshot_by_name[repo.full_name].main_head_sha or "")
+                for repo, branch in failing_targets
+                if repo.full_name in snapshot_by_name
+            }
+            stale_keys = set(self._failing_detail_cache) - live_keys
+            for key in stale_keys:
+                self._failing_detail_cache.pop(key, None)
+
+        # Phase 3: team assignments -- one batched GraphQL query per owner,
+        # fetched on a slow cadence (teams_ttl_seconds) because team
+        # membership changes rarely. Fresh snapshot replaces state.repo_teams
+        # in the commit step.
+        teams_snapshot = None
+        if self._owners and not self.state.cancel_requested:
+            now = datetime.now(UTC)
+            is_stale = (
+                self._last_teams_refresh_at is None
+                or (now - self._last_teams_refresh_at).total_seconds() >= self._teams_ttl_seconds
+            )
+            if is_stale:
+                logger.debug(f"refresh: graphql teams fetch for {len(self._owners)} owner(s)")
                 try:
-                    td = team_fut.result()
-                    team_data.append(td)
-                    if td.error:
-                        self.state.log_error("refresh", td.error)
-                        logger.warning(f"refresh: {td.error}")
-                except Exception as team_exc:
-                    logger.warning(f"refresh: team fetch failed: {team_exc}")
+                    teams_snapshot = fetch_workspace_teams(self._github_client, self._owners)
+                    self._last_teams_refresh_at = now
+                    logger.debug(
+                        f"refresh: teams graphql cost={teams_snapshot.rate_limit_cost} "
+                        f"remaining={teams_snapshot.rate_limit_remaining}"
+                    )
+                    for owner, err in teams_snapshot.errored.items():
+                        self.state.log_error("refresh", f"teams {owner}: {err}")
+                        logger.warning(f"refresh: teams {owner}: {err}")
+                except Exception as exc:
+                    self.state.log_error(
+                        "refresh", f"teams graphql: {exc.__class__.__name__}: {exc}"
+                    )
+                    logger.error(f"refresh: teams graphql failed: {exc}")
 
         # Preserve original repo ordering.
         statuses = [status_by_name[n] for n in ordered_names]
@@ -1659,21 +1738,40 @@ class DashboardApp(App[None]):
 
         # Commit the new state on the main thread so action handlers don't
         # observe healths and health_by_name in a half-updated state.
-        self.call_from_thread(self._commit_refresh, healths, team_data, failed_repos)
+        self.call_from_thread(self._commit_refresh, healths, teams_snapshot, failed_repos)
+
+    def _apply_failing_detail(
+        self,
+        status_by_name: dict[str, RepoStatus],
+        full_name: str,
+        branch: str,
+        err: str | None,
+        failing_since: str | None,
+    ) -> None:
+        """Write failing-run detail onto the status for the given branch."""
+        status = status_by_name.get(full_name)
+        if status is None:
+            return
+        if branch == status.default_branch:
+            status.main_error = err
+            status.main_failing_since = failing_since
+        elif branch == "dev":
+            status.dev_error = err
+            status.dev_failing_since = failing_since
 
     def _commit_refresh(
         self,
         healths: list[RepoHealth],
-        team_data: list[CollectedTeamData] | None = None,
+        teams_snapshot: TeamsSnapshot | None = None,
         failed_repos: set[str] | None = None,
     ) -> None:
-        # Merge team data collected by worker threads. This is the only place
-        # repo_teams / team_labels are mutated, so the main thread never
-        # races against a background dict modification.
-        if team_data:
-            merge_team_data(self.state, team_data)
+        # Merge the batched teams snapshot if this refresh rebuilt it. The
+        # main thread is the only place that mutates repo_teams / team_labels.
+        if teams_snapshot is not None:
+            known_repos = [h.status.full_name for h in healths]
+            merge_teams_snapshot(self.state, teams_snapshot, known_repos)
             logger.debug(
-                f"commit: merged team data for {len(team_data)} repos, "
+                f"commit: merged teams for {len(teams_snapshot.by_full_name)} repos, "
                 f"{len(self.state.team_labels)} known teams"
             )
         apply_open_source_team(self.state)

--- a/src/augint_tools/dashboard/state.py
+++ b/src/augint_tools/dashboard/state.py
@@ -9,15 +9,13 @@ from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
-from github.GithubException import GithubException
 from loguru import logger
 
 from ._data import RepoStatus, load_cache, load_cache_timestamp, load_health_cache
 from .health import RepoHealth, Severity
 
 if TYPE_CHECKING:
-    from github.Repository import Repository
-
+    from ._gql import TeamsSnapshot
     from .awsprobe import AwsState
     from .sysmeter import GpuStats, RamStats
     from .sysprobe import SystemSnapshot
@@ -50,7 +48,6 @@ FILTER_MODES: tuple[str, ...] = (
 
 _TEAM_FILTER_PREFIX = "team:"
 _ORG_FILTER_PREFIX = "org:"
-_TEAM_PERMISSION_ORDER = {"admin": 0, "maintain": 1, "push": 2, "triage": 3, "pull": 4}
 
 
 @dataclass(frozen=True)
@@ -209,90 +206,37 @@ def team_accent(team_key: str, known_teams: Iterable[str] | None = None) -> str:
     return _hsl_hex(idx * _GOLDEN_ANGLE)
 
 
-def _team_sort_key(team: object) -> tuple[int, str]:
-    permission = getattr(team, "permission", "") or ""
-    slug = getattr(team, "slug", "") or getattr(team, "name", "") or ""
-    return _TEAM_PERMISSION_ORDER.get(permission, 99), slug.lower()
+def merge_teams_snapshot(
+    state: AppState,
+    snapshot: TeamsSnapshot,
+    known_repos: Iterable[str],
+) -> None:
+    """Apply a batched GraphQL teams snapshot to state.
 
+    Replaces the previous REST-per-repo ``merge_team_data`` flow: one GraphQL
+    query covers every team in every org, and the snapshot already contains
+    the sorted (primary-first) assignment list. Must run on the main thread.
 
-@dataclass(frozen=True)
-class CollectedTeamData:
-    """Thread-safe snapshot of team data for a single repo.
-
-    Collected in worker threads, merged into ``AppState`` on the main
-    thread to avoid concurrent dict mutation.
+    Args:
+        state: AppState to mutate (repo_teams, team_labels).
+        snapshot: Fresh TeamsSnapshot from ``_gql.fetch_workspace_teams``.
+        known_repos: All repo full_names currently in the workspace. Repos
+            with no GraphQL team assignment get a default ``RepoTeamInfo()``
+            so the filter panel still lists them (apply_open_source_team
+            promotes unassigned personal repos afterward).
     """
-
-    full_name: str
-    info: RepoTeamInfo = RepoTeamInfo()
-    labels: dict[str, str] = field(default_factory=dict)
-    error: str | None = None
-
-
-def collect_repo_teams(repo: Repository) -> CollectedTeamData:
-    """Fetch team data for a repo without mutating shared state.
-
-    Safe to call from worker threads.  Returns a ``CollectedTeamData``
-    snapshot that the caller merges on the main thread via
-    ``merge_team_data``.
-    """
-    full_name = getattr(repo, "full_name", "")
-    if not full_name:
-        return CollectedTeamData(full_name="")
-    try:
-        teams = sorted(repo.get_teams(), key=_team_sort_key)
-    except GithubException as exc:
-        # 403/404 are expected for personal (non-org) repos -- the Teams API
-        # doesn't apply to user repos.  Treat as "no teams" without logging
-        # a user-visible error that would flash the error drawer.
-        if exc.status in (403, 404):
-            logger.debug(
-                f"collect_repo_teams: {full_name}: expected {exc.status} (not an org repo)"
-            )
-            return CollectedTeamData(full_name=full_name)
-        logger.debug(f"collect_repo_teams: {full_name}: {exc.__class__.__name__}: {exc}")
-        return CollectedTeamData(
-            full_name=full_name,
-            error=f"{full_name}: teams: {exc.__class__.__name__}: {exc}",
-        )
-    except Exception as exc:
-        logger.debug(f"collect_repo_teams: {full_name}: {exc.__class__.__name__}: {exc}")
-        return CollectedTeamData(
-            full_name=full_name,
-            error=f"{full_name}: teams: {exc.__class__.__name__}: {exc}",
-        )
-
-    team_keys: list[str] = []
-    labels: dict[str, str] = {}
-    for team in teams:
-        slug = getattr(team, "slug", "") or ""
-        if not slug:
+    state.team_labels.update(snapshot.labels)
+    for full_name in known_repos:
+        assignments = snapshot.by_full_name.get(full_name)
+        if not assignments:
+            # Personal repo, or org repo with no team access grants.
+            state.repo_teams[full_name] = RepoTeamInfo()
             continue
-        name = getattr(team, "name", "") or slug
-        team_keys.append(slug)
-        labels[slug] = name
-
-    if not team_keys:
-        return CollectedTeamData(full_name=full_name, labels=labels)
-    return CollectedTeamData(
-        full_name=full_name,
-        info=RepoTeamInfo(primary=team_keys[0], all=tuple(team_keys)),
-        labels=labels,
-    )
-
-
-def merge_team_data(state: AppState, collected: list[CollectedTeamData]) -> None:
-    """Apply collected team snapshots to state. Must run on the main thread."""
-    for td in collected:
-        if not td.full_name:
-            continue
-        if td.error:
-            # Keep previous data if we have it; otherwise mark unassigned.
-            if td.full_name not in state.repo_teams:
-                state.repo_teams[td.full_name] = RepoTeamInfo()
-            continue
-        state.repo_teams[td.full_name] = td.info
-        state.team_labels.update(td.labels)
+        slugs = tuple(a.slug for a in assignments)
+        state.repo_teams[full_name] = RepoTeamInfo(primary=slugs[0], all=slugs)
+    if snapshot.errored:
+        for owner, err in snapshot.errored.items():
+            logger.debug(f"teams fetch for {owner}: {err}")
 
 
 def apply_open_source_team(state: AppState) -> None:

--- a/tests/unit/test_dashboard.py
+++ b/tests/unit/test_dashboard.py
@@ -7,7 +7,6 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from click.testing import CliRunner
-from github.GithubException import GithubException
 from rich.text import Text
 
 from augint_tools.cli.__main__ import cli as main
@@ -1079,65 +1078,46 @@ class TestStateHelpers:
         move_selection(s, 1)
         assert s.selected_full_name is None
 
-    def test_collect_and_merge_repo_teams(self):
-        from augint_tools.dashboard.state import collect_repo_teams, merge_team_data
+    def test_merge_teams_snapshot_assigns_primary_from_sorted_list(self):
+        from augint_tools.dashboard._gql import TeamAssignment, TeamsSnapshot
+        from augint_tools.dashboard.state import merge_teams_snapshot
 
         s = AppState()
-        team = MagicMock()
-        team.slug = "alpha"
-        team.name = "Alpha"
-        team.permission = "admin"
-        repo = _mock_repo(full_name="org/x")
-        repo.get_teams.return_value = [team]
-        td = collect_repo_teams(repo)
-        assert td.error is None
-        merge_team_data(s, [td])
-        assert s.repo_teams["org/x"].primary == "alpha"
-        assert s.team_labels.get("alpha") == "Alpha"
-
-    def test_collect_repo_teams_api_failure(self):
-        from augint_tools.dashboard.state import (
-            UNASSIGNED_TEAM,
-            collect_repo_teams,
-            merge_team_data,
+        snapshot = TeamsSnapshot(
+            by_full_name={
+                "org/x": [
+                    TeamAssignment(slug="alpha", name="Alpha", permission="admin"),
+                    TeamAssignment(slug="beta", name="Beta", permission="write"),
+                ]
+            },
+            labels={"alpha": "Alpha", "beta": "Beta"},
         )
+        merge_teams_snapshot(s, snapshot, ["org/x"])
+        assert s.repo_teams["org/x"].primary == "alpha"
+        assert s.repo_teams["org/x"].all == ("alpha", "beta")
+        assert s.team_labels["alpha"] == "Alpha"
+        assert s.team_labels["beta"] == "Beta"
+
+    def test_merge_teams_snapshot_marks_unassigned_for_unlisted_repos(self):
+        from augint_tools.dashboard._gql import TeamsSnapshot
+        from augint_tools.dashboard.state import UNASSIGNED_TEAM, merge_teams_snapshot
 
         s = AppState()
-        repo = _mock_repo(full_name="org/x")
-        repo.get_teams.side_effect = RuntimeError("boom")
-        td = collect_repo_teams(repo)
-        assert td.error is not None
-        merge_team_data(s, [td])
-        assert s.repo_teams["org/x"].primary == UNASSIGNED_TEAM
+        snapshot = TeamsSnapshot()
+        merge_teams_snapshot(s, snapshot, ["user/personal-repo"])
+        assert s.repo_teams["user/personal-repo"].primary == UNASSIGNED_TEAM
+        assert s.repo_teams["user/personal-repo"].all == ()
 
-    def test_collect_repo_teams_403_suppressed(self):
-        """403 from personal (non-org) repos is expected -- no error field."""
-        from augint_tools.dashboard.state import collect_repo_teams
+    def test_merge_teams_snapshot_logs_owner_errors(self, caplog):
+        from augint_tools.dashboard._gql import TeamsSnapshot
+        from augint_tools.dashboard.state import merge_teams_snapshot
 
-        repo = _mock_repo(full_name="user/personal-repo")
-        repo.get_teams.side_effect = GithubException(403, "Forbidden", None)
-        td = collect_repo_teams(repo)
-        assert td.error is None
-        assert td.info.all == ()
-
-    def test_collect_repo_teams_404_suppressed(self):
-        """404 from the Teams API is also expected for non-org repos."""
-        from augint_tools.dashboard.state import collect_repo_teams
-
-        repo = _mock_repo(full_name="user/personal-repo")
-        repo.get_teams.side_effect = GithubException(404, "Not Found", None)
-        td = collect_repo_teams(repo)
-        assert td.error is None
-        assert td.info.all == ()
-
-    def test_collect_repo_teams_500_still_errors(self):
-        """Server errors (5xx) should still be reported."""
-        from augint_tools.dashboard.state import collect_repo_teams
-
-        repo = _mock_repo(full_name="org/x")
-        repo.get_teams.side_effect = GithubException(500, "Server Error", None)
-        td = collect_repo_teams(repo)
-        assert td.error is not None
+        s = AppState()
+        snapshot = TeamsSnapshot(errored={"some-org": "Forbidden"})
+        merge_teams_snapshot(s, snapshot, [])
+        # No exception and no repos touched; just debug-logged. The explicit
+        # repos list is empty so nothing should land in repo_teams either.
+        assert s.repo_teams == {}
 
     def test_apply_filter_no_renovate(self):
         check = HealthCheckResult(

--- a/tests/unit/test_gql.py
+++ b/tests/unit/test_gql.py
@@ -9,8 +9,11 @@ from augint_tools.dashboard._gql import (
     RENOVATE_PATHS,
     RepoSnapshot,
     build_query,
+    build_teams_query,
     fetch_workspace_snapshot,
+    fetch_workspace_teams,
     parse_response,
+    parse_teams_response,
     pick_pipeline_yaml,
     pick_renovate_config,
     translate_rollup_state,
@@ -314,6 +317,93 @@ class TestFetchWorkspaceSnapshot:
 # ---------------------------------------------------------------------------
 # Pickers
 # ---------------------------------------------------------------------------
+
+
+class TestTeamsQueryAndParse:
+    def test_build_teams_query_includes_owner_alias(self):
+        query = build_teams_query(["svange", "some-org"])
+        assert "o0: organization" in query
+        assert "o1: organization" in query
+        assert 'login: "svange"' in query
+        assert 'login: "some-org"' in query
+        assert "teams(first:" in query
+        assert "repositories(first:" in query
+        assert "permission" in query
+
+    def test_parse_teams_sorts_by_permission(self):
+        response = {
+            "data": {
+                "o0": {
+                    "login": "org",
+                    "teams": {
+                        "nodes": [
+                            {
+                                "slug": "readers",
+                                "name": "Readers",
+                                "repositories": {
+                                    "edges": [
+                                        {
+                                            "permission": "READ",
+                                            "node": {"nameWithOwner": "org/x"},
+                                        }
+                                    ]
+                                },
+                            },
+                            {
+                                "slug": "admins",
+                                "name": "Admins",
+                                "repositories": {
+                                    "edges": [
+                                        {
+                                            "permission": "ADMIN",
+                                            "node": {"nameWithOwner": "org/x"},
+                                        }
+                                    ]
+                                },
+                            },
+                        ]
+                    },
+                },
+                "rateLimit": {
+                    "limit": 5000,
+                    "cost": 1,
+                    "remaining": 4999,
+                    "resetAt": None,
+                },
+            }
+        }
+        snapshot = parse_teams_response(response, ["org"])
+        assignments = snapshot.by_full_name["org/x"]
+        # Admin permission must sort before read permission.
+        assert [a.slug for a in assignments] == ["admins", "readers"]
+        assert snapshot.labels["admins"] == "Admins"
+
+    def test_parse_teams_handles_personal_owner_null_org(self):
+        response = {"data": {"o0": None}}
+        snapshot = parse_teams_response(response, ["svange"])
+        assert snapshot.by_full_name == {}
+        assert snapshot.labels == {}
+
+    def test_parse_teams_records_owner_errors(self):
+        response = {
+            "data": {"o0": None},
+            "errors": [{"path": ["o0"], "message": "Forbidden"}],
+        }
+        snapshot = parse_teams_response(response, ["locked-org"])
+        assert snapshot.errored.get("locked-org") == "Forbidden"
+
+    def test_fetch_workspace_teams_empty_owners_returns_empty(self):
+        gh = MagicMock()
+        snapshot = fetch_workspace_teams(gh, [])
+        assert snapshot.by_full_name == {}
+        assert snapshot.labels == {}
+
+    def test_fetch_workspace_teams_network_failure_errors_all_owners(self):
+        gh = MagicMock()
+        gh._Github__requester.requestJsonAndCheck.side_effect = RuntimeError("boom")  # type: ignore[attr-defined]
+        snapshot = fetch_workspace_teams(gh, ["org-a", "org-b"])
+        assert "org-a" in snapshot.errored
+        assert "org-b" in snapshot.errored
 
 
 class TestPickers:


### PR DESCRIPTION
## Summary
Completes the REST-elimination work started in #71. At steady state the dashboard now makes effectively **zero** REST calls per refresh cycle.

## Changes
- **Teams moved to GraphQL** — per-repo `repo.get_teams()` (20 REST calls/min for a 20-repo workspace) replaced with a single batched `organization.teams.repositories(edges { permission })` query covering every owner. Result is cached for 300s and only re-fetched when the TTL expires — about 12 queries/hour regardless of the main refresh interval.
- **Failing-run detail cached by head SHA** — keyed by `(full_name, branch, head_sha)`. A failing branch keeps the same head commit until it's fixed or retried, so after the first detail fetch the dashboard reuses the cached error string indefinitely. Stale entries pruned each refresh.
- **Main query `first: 100` → `first: 50`** for PRs and issues. Cuts GraphQL point cost roughly in half without losing fidelity for realistic workspace sizes.
- **Deletes**: `state.collect_repo_teams`, `CollectedTeamData`, `merge_team_data` (replaced by `merge_teams_snapshot` consuming a `TeamsSnapshot`).

## Effect on rate-limit usage (20-repo workspace, 60s refresh)

| Before #71 | After #71 | After this PR |
|---|---|---|
| ~240 REST calls/min | ~23 REST calls/min | **~0 REST calls/min** (teams cached, failing-detail SHA-cached) |
| — | ~42 GraphQL points/query | **~22 GraphQL points/query** (main query shrunk) |

Hourly budget usage after this PR: ~1320 points/hour = **26% of the 5000/hour GraphQL budget**. Zero pressure on REST budget except the rare first-sight-of-failure lookup.

## Test plan
- [x] New `TestTeamsQueryAndParse` in `tests/unit/test_gql.py` — query shape, permission-sorted output, null-org (personal accounts), per-owner errors.
- [x] `tests/unit/test_dashboard.py` team tests rewritten around the snapshot merger.
- [x] Full suite: 679 passing.
- [x] `pre-commit run --all-files` clean.