### PR TITLE
fix(dashboard): teams query handles personal accounts without error

### DIFF
--- a/src/augint_tools/dashboard/_gql.py
+++ b/src/augint_tools/dashboard/_gql.py
@@ -555,23 +555,29 @@ class TeamsSnapshot:
 def build_teams_query(owners: list[str]) -> str:
     """Build a single GraphQL query listing teams + repositories for each owner.
 
-    Personal-account owners (non-org) return a null organization -- handled
-    gracefully by parse_teams_response (those repos simply have no teams).
+    Uses ``repositoryOwner`` + an inline fragment on ``Organization`` so a
+    personal account (User owner) cleanly returns a null ``teams`` field
+    instead of triggering a top-level ``Could not resolve to an Organization
+    with the login of 'X'`` error. Only genuinely missing or inaccessible
+    owners surface as errors.
     """
     parts: list[str] = []
     for i, owner in enumerate(owners):
         owner_esc = owner.replace("\\", "\\\\").replace('"', '\\"')
         parts.append(
-            f'  o{i}: organization(login: "{owner_esc}") {{\n'
+            f'  o{i}: repositoryOwner(login: "{owner_esc}") {{\n'
+            f"    __typename\n"
             f"    login\n"
-            f"    teams(first: 50) {{\n"
-            f"      nodes {{\n"
-            f"        slug\n"
-            f"        name\n"
-            f"        repositories(first: 50) {{\n"
-            f"          edges {{\n"
-            f"            permission\n"
-            f"            node {{ nameWithOwner }}\n"
+            f"    ... on Organization {{\n"
+            f"      teams(first: 50) {{\n"
+            f"        nodes {{\n"
+            f"          slug\n"
+            f"          name\n"
+            f"          repositories(first: 50) {{\n"
+            f"            edges {{\n"
+            f"              permission\n"
+            f"              node {{ nameWithOwner }}\n"
+            f"            }}\n"
             f"          }}\n"
             f"        }}\n"
             f"      }}\n"

--- a/tests/unit/test_gql.py
+++ b/tests/unit/test_gql.py
@@ -322,8 +322,12 @@ class TestFetchWorkspaceSnapshot:
 class TestTeamsQueryAndParse:
     def test_build_teams_query_includes_owner_alias(self):
         query = build_teams_query(["svange", "some-org"])
-        assert "o0: organization" in query
-        assert "o1: organization" in query
+        # repositoryOwner lets personal accounts resolve to User without
+        # triggering a GraphQL error; the Organization fields are wrapped
+        # in an inline fragment.
+        assert "o0: repositoryOwner" in query
+        assert "o1: repositoryOwner" in query
+        assert "... on Organization" in query
         assert 'login: "svange"' in query
         assert 'login: "some-org"' in query
         assert "teams(first:" in query
@@ -378,11 +382,23 @@ class TestTeamsQueryAndParse:
         assert [a.slug for a in assignments] == ["admins", "readers"]
         assert snapshot.labels["admins"] == "Admins"
 
-    def test_parse_teams_handles_personal_owner_null_org(self):
-        response = {"data": {"o0": None}}
+    def test_parse_teams_handles_personal_user_owner(self):
+        # repositoryOwner resolves to a User -- no teams field, no error.
+        response = {
+            "data": {
+                "o0": {"__typename": "User", "login": "svange"},
+            }
+        }
         snapshot = parse_teams_response(response, ["svange"])
         assert snapshot.by_full_name == {}
         assert snapshot.labels == {}
+        assert snapshot.errored == {}
+
+    def test_parse_teams_handles_null_owner_payload(self):
+        # Defensive: even if the server returns null for the alias, don't crash.
+        response = {"data": {"o0": None}}
+        snapshot = parse_teams_response(response, ["svange"])
+        assert snapshot.by_full_name == {}
 
     def test_parse_teams_records_owner_errors(self):
         response = {


### PR DESCRIPTION
## Summary

You were seeing this warning every 5 minutes once teams started fetching via GraphQL:

> refresh: teams svange: Could not resolve to an Organization with the login of 'svange'.

The teams query was `organization(login: ...)`, which errors on personal accounts (User owners). This PR switches it to `repositoryOwner(login: ...)` with an inline fragment on `Organization`:

- Personal accounts resolve to a User cleanly with no teams field and no error.
- Real orgs still return teams + repositories exactly as before.
- Only genuinely missing or inaccessible owners surface as errors from here on.

## Test plan
- [x] `TestTeamsQueryAndParse` updated for new query shape + added coverage for the `User` owner case.
- [x] Full suite: 680 passing.
- [x] `pre-commit run --all-files` clean.