### PR TITLE
fix(dashboard): stop flagging valid CI + non-standard pipelines as warnings

### DIFF
--- a/src/augint_tools/dashboard/_data.py
+++ b/src/augint_tools/dashboard/_data.py
@@ -115,6 +115,11 @@ class RepoStatus:
     oldest_issue_created_at: str | None = None
     # Default branch name, used by checks that build links to files on GitHub.
     default_branch: str = "main"
+    # Whether the repo has at least one workflow file checked in. Lets
+    # broken_ci distinguish "truly no CI configured" from "latest commit
+    # happened not to trigger any workflow" (common for semantic-release
+    # chore commits that intentionally skip CI).
+    has_workflows: bool = False
 
 
 # ---------------------------------------------------------------------------
@@ -192,6 +197,7 @@ def build_status_from_snapshot(
         human_open_issues=human_open_issues,
         oldest_issue_created_at=oldest_iso,
         default_branch=snapshot.default_branch or "main",
+        has_workflows=bool(snapshot.workflow_files),
     )
 
 

--- a/src/augint_tools/dashboard/_gql.py
+++ b/src/augint_tools/dashboard/_gql.py
@@ -94,6 +94,10 @@ class RepoSnapshot:
     dev_head_sha: str | None
     # Root-tree entry names for framework/IaC detection without extra REST calls.
     root_entries: tuple[str, ...]
+    # Workflow filenames present under .github/workflows/ -- used by broken_ci
+    # to distinguish "truly no CI configured" from "latest commit happened not
+    # to trigger any workflow" (common for semantic-release chore commits).
+    workflow_files: tuple[str, ...] = ()
     # Open PRs (up to 100 per repo; more would be extraordinary).
     pull_requests: list[PRSnapshot] = field(default_factory=list)
     pr_total_count: int = 0
@@ -162,6 +166,9 @@ fragment RepoFields on Repository {{
     }}
   }}
   _rootTree: object(expression: "HEAD:") {{
+    ... on Tree {{ entries {{ name }} }}
+  }}
+  _workflowsTree: object(expression: "HEAD:.github/workflows") {{
     ... on Tree {{ entries {{ name }} }}
   }}
   pullRequests(states: OPEN, first: 50) {{
@@ -279,6 +286,19 @@ def _parse_repo(data: dict) -> RepoSnapshot:
     else:
         root_entries = ()
 
+    workflows_tree = data.get("_workflowsTree")
+    if isinstance(workflows_tree, dict):
+        wf_entries = workflows_tree.get("entries") or []
+        workflow_files = tuple(
+            str(e.get("name", ""))
+            for e in wf_entries
+            if isinstance(e, dict)
+            and e.get("name")
+            and str(e.get("name", "")).endswith((".yml", ".yaml"))
+        )
+    else:
+        workflow_files = ()
+
     primary_language_obj = data.get("primaryLanguage")
     primary_language = (
         primary_language_obj.get("name") if isinstance(primary_language_obj, dict) else None
@@ -341,6 +361,7 @@ def _parse_repo(data: dict) -> RepoSnapshot:
         main_head_sha=main_head_sha,
         dev_head_sha=dev_head_sha,
         root_entries=root_entries,
+        workflow_files=workflow_files,
         pull_requests=pulls,
         pr_total_count=pr_total_count,
         issues=issues,

--- a/src/augint_tools/dashboard/health/checks/broken_ci.py
+++ b/src/augint_tools/dashboard/health/checks/broken_ci.py
@@ -46,8 +46,17 @@ class BrokenCICheck:
                 link=actions_url,
             )
 
-        # No workflows at all is a governance gap worth surfacing.
-        if status.main_status == "unknown" and status.dev_status is None:
+        # "unknown" here means GraphQL's statusCheckRollup came back null for
+        # the latest commit on the default branch. That happens legitimately
+        # when the latest commit didn't trigger any workflow (semantic-release
+        # chore commits, [skip ci] on merges, workflow trigger filters that
+        # don't match). Only treat it as a real finding when the repo has no
+        # workflow files at all -- that's the actual governance gap.
+        if (
+            status.main_status == "unknown"
+            and status.dev_status is None
+            and not status.has_workflows
+        ):
             return HealthCheckResult(
                 check_name=self.name,
                 severity=Severity.MEDIUM,

--- a/src/augint_tools/dashboard/health/checks/coverage.py
+++ b/src/augint_tools/dashboard/health/checks/coverage.py
@@ -2,12 +2,21 @@
 
 Parses the repository's canonical GitHub Actions workflow
 (``.github/workflows/pipeline.yaml``) and inspects the ``unit-tests`` job
-for signals that the coverage gate has been weakened:
+for signals that the coverage gate has been **actively weakened**:
 
 - Python: ``pytest --cov-fail-under=N`` with N below the canonical 80% baseline
-  (see the ai-standardize-pipeline standard).
+  (see the ai-standardize-pipeline standard). Severity LOW.
 - Any coverage-related step that ignores failures via ``continue-on-error: true``
-  or shell suffixes such as ``|| true``, ``|| :``, ``|| echo ...``.
+  or shell suffixes such as ``|| true``, ``|| :``, ``|| echo ...``. Severity MEDIUM.
+- Python ``pytest --cov`` with no ``--cov-fail-under`` gate at all. Severity LOW
+  (equivalent to a 0% threshold).
+
+**Non-adoption is benign.** Repos that haven't adopted the
+ai-standardize-pipeline convention (no pipeline.yaml, or pipeline.yaml with
+no ``unit-tests`` job, or unit-tests job with no coverage command) return
+OK severity with an informative summary. This is observational, not a
+warning -- a repo is not "unhealthy" just because it doesn't follow the
+standard naming convention for its workflow files.
 
 For Node repos using ``vitest``/``jest --coverage`` the threshold lives in
 ``vitest.config.*``/``jest.config.*`` rather than the workflow, so this check
@@ -15,10 +24,7 @@ is intentionally workflow-only and reports OK on seeing the coverage flag --
 config-level parsing is out of scope.
 
 Workflow text comes from the batched GraphQL snapshot via
-``FetchContext.pipeline_text`` -- no per-repo REST call. When the workflow
-can't be fetched or the ``unit-tests`` job / coverage step is missing, the
-check returns MEDIUM with a summary prefixed ``unverified:`` so it is
-visibly distinguishable from a verified regression.
+``FetchContext.pipeline_text`` -- no per-repo REST call.
 """
 
 from __future__ import annotations
@@ -66,12 +72,16 @@ class CoverageCheck:
         used_path = context.pipeline_path
         raw = context.pipeline_text
 
+        # Missing / non-standard pipeline.yaml is benign -- it just means the
+        # repo hasn't adopted the ai-standardize-pipeline convention. Surface
+        # as OK (visible in the detail drawer) but never drives card coloring
+        # because this is a "standards adoption" observation, not a health
+        # warning.
         if raw is None or used_path is None:
             return HealthCheckResult(
                 check_name=self.name,
-                severity=Severity.MEDIUM,
-                summary="unverified: no pipeline.yaml",
-                link=f"https://github.com/{status.full_name}",
+                severity=Severity.OK,
+                summary="not standardized (no pipeline.yaml)",
             )
 
         workflow_link = f"https://github.com/{status.full_name}/blob/{default_branch}/{used_path}"
@@ -82,7 +92,7 @@ class CoverageCheck:
             return HealthCheckResult(
                 check_name=self.name,
                 severity=Severity.MEDIUM,
-                summary="unverified: pipeline.yaml parse error",
+                summary="pipeline.yaml parse error",
                 link=workflow_link,
             )
 
@@ -90,7 +100,7 @@ class CoverageCheck:
             return HealthCheckResult(
                 check_name=self.name,
                 severity=Severity.MEDIUM,
-                summary="unverified: pipeline.yaml not a mapping",
+                summary="pipeline.yaml not a mapping",
                 link=workflow_link,
             )
 
@@ -98,27 +108,24 @@ class CoverageCheck:
         if not isinstance(jobs, dict):
             return HealthCheckResult(
                 check_name=self.name,
-                severity=Severity.MEDIUM,
-                summary="unverified: no jobs in pipeline.yaml",
-                link=workflow_link,
+                severity=Severity.OK,
+                summary="pipeline.yaml has no jobs",
             )
 
         unit_tests = jobs.get("unit-tests")
         if not isinstance(unit_tests, dict):
             return HealthCheckResult(
                 check_name=self.name,
-                severity=Severity.MEDIUM,
-                summary="unverified: no unit-tests job",
-                link=workflow_link,
+                severity=Severity.OK,
+                summary="not standardized (no unit-tests job)",
             )
 
         steps = unit_tests.get("steps")
         if not isinstance(steps, list):
             return HealthCheckResult(
                 check_name=self.name,
-                severity=Severity.MEDIUM,
-                summary="unverified: unit-tests has no steps",
-                link=workflow_link,
+                severity=Severity.OK,
+                summary="unit-tests has no steps",
             )
 
         return self._evaluate_steps(steps, workflow_link)
@@ -166,9 +173,8 @@ class CoverageCheck:
         if not coverage_seen:
             return HealthCheckResult(
                 check_name=self.name,
-                severity=Severity.MEDIUM,
-                summary="unverified: no coverage command in unit-tests",
-                link=workflow_link,
+                severity=Severity.OK,
+                summary="no coverage command in unit-tests",
             )
 
         # Ignoring failures is worse than lowering the bar: still run tests,
@@ -221,9 +227,8 @@ class CoverageCheck:
         # Defensive fallback -- should be unreachable given the checks above.
         return HealthCheckResult(
             check_name=self.name,
-            severity=Severity.MEDIUM,
-            summary="unverified: coverage signal unclear",
-            link=workflow_link,
+            severity=Severity.OK,
+            summary="coverage signal unclear",
         )
 
 

--- a/tests/unit/test_health.py
+++ b/tests/unit/test_health.py
@@ -37,6 +37,7 @@ def _status(
     draft_prs=0,
     human_open_issues=0,
     default_branch="main",
+    has_workflows=True,
 ):
     return RepoStatus(
         name=name,
@@ -51,6 +52,7 @@ def _status(
         draft_prs=draft_prs,
         human_open_issues=human_open_issues,
         default_branch=default_branch,
+        has_workflows=has_workflows,
     )
 
 
@@ -283,15 +285,27 @@ class TestBrokenCI:
         assert result.severity == Severity.HIGH
         assert "dev pipeline failing" in result.summary
 
-    def test_no_ci_detected(self):
+    def test_no_ci_detected_only_when_no_workflow_files(self):
+        # Truly no workflows -> flagged.
         result = get_check("broken_ci").evaluate(
             _mock_repo(),
-            _status(main_status="unknown", dev_status=None),
+            _status(main_status="unknown", dev_status=None, has_workflows=False),
             config={},
             context=_ctx(),
         )
         assert result.severity == Severity.MEDIUM
         assert "No CI workflows" in result.summary
+
+    def test_unknown_rollup_with_workflows_is_ok(self):
+        # Workflows exist but the latest commit didn't trigger one (common for
+        # semantic-release chore commits). Not a health issue.
+        result = get_check("broken_ci").evaluate(
+            _mock_repo(),
+            _status(main_status="unknown", dev_status=None, has_workflows=True),
+            config={},
+            context=_ctx(),
+        )
+        assert result.severity == Severity.OK
 
     def test_main_takes_priority_over_dev(self):
         result = get_check("broken_ci").evaluate(
@@ -676,31 +690,33 @@ jobs:
         assert result.severity == Severity.OK
         assert "coverage" in result.summary.lower()
 
-    def test_missing_pipeline_is_unverified(self):
+    def test_missing_pipeline_is_ok_not_standardized(self):
+        # A repo that doesn't follow the standardized pipeline convention
+        # isn't unhealthy -- just not standardized. No severity.
         result = self._evaluate(None)
-        assert result.severity == Severity.MEDIUM
-        assert result.summary.startswith("unverified:")
+        assert result.severity == Severity.OK
+        assert "not standardized" in result.summary
 
-    def test_missing_unit_tests_job_is_unverified(self):
+    def test_missing_unit_tests_job_is_ok(self):
         result = self._evaluate(self._NO_UNIT_TESTS)
-        assert result.severity == Severity.MEDIUM
-        assert "unverified" in result.summary
+        assert result.severity == Severity.OK
+        assert "not standardized" in result.summary
         assert "unit-tests" in result.summary
 
-    def test_missing_coverage_command_is_unverified(self):
+    def test_missing_coverage_command_is_ok(self):
         result = self._evaluate(self._NO_COVERAGE_COMMAND)
-        assert result.severity == Severity.MEDIUM
-        assert "unverified" in result.summary
+        assert result.severity == Severity.OK
         assert "coverage" in result.summary
 
     def test_yml_fallback(self):
         result = self._evaluate(self._STANDARD_PY, path=".github/workflows/pipeline.yml")
         assert result.severity == Severity.OK
 
-    def test_yaml_parse_error_is_unverified(self):
+    def test_yaml_parse_error_is_medium(self):
+        # Broken YAML is a real problem -- stays at MEDIUM severity.
         result = self._evaluate("jobs: [this is: not valid")
         assert result.severity == Severity.MEDIUM
-        assert "unverified" in result.summary
+        assert "parse error" in result.summary
 
     def test_lowest_threshold_wins(self):
         yaml_text = """\


### PR DESCRIPTION
## Summary

Two false-positive health checks were flipping otherwise-healthy repos yellow:

### broken_ci — "No CI workflows detected"
GraphQL's \`statusCheckRollup\` is evaluated on the **latest commit** of the default branch. When that commit didn't trigger any workflow (semantic-release chore commits, \`[skip ci]\`, branch filters that don't match) the rollup is null — even when workflows clearly exist in the repo. My check was reading that as "no CI configured", which is wrong.

**Example**: \`svange/tagmania\` has both \`pipeline.yaml\` and \`cve-review.yaml\` workflows, but its latest main commit (\`chore(release): 2.6.1\`) produced zero check runs, so the rollup was null and the repo was incorrectly flagged.

**Fix**: add \`_workflowsTree: object(expression: "HEAD:.github/workflows")\` to the batched GraphQL query, populate \`RepoStatus.has_workflows\`, and only emit the warning when the workflows tree is actually empty.

### coverage — "unverified: no pipeline.yaml"
Was returning MEDIUM severity for any repo that doesn't follow the ai-standardize-pipeline convention (missing \`pipeline.yaml\`, no \`unit-tests\` job, no coverage command). Per user feedback: "I'd like to know if the pipelines are out of standards, but that shouldn't change the criticality of any repo, that's benign".

**Example**: \`augmenting-integrations/aillc-web\` uses \`web-deploy.yml\` instead of the standard \`pipeline.yaml\` name — fine, just not adopted.

**Fix**: demote all non-adoption returns to OK severity with informative summaries ("not standardized (no pipeline.yaml)", etc.). Actively-weakened coverage — lowered \`--cov-fail-under\`, \`continue-on-error: true\`, \`|| true\` suffixes, broken YAML — still surfaces at LOW or MEDIUM.

## Test plan
- [x] \`test_no_ci_detected_only_when_no_workflow_files\` + new \`test_unknown_rollup_with_workflows_is_ok\` cover both broken_ci branches.
- [x] Coverage tests renamed/retargeted to assert OK for non-adoption, MEDIUM only for actively-broken pipeline.
- [x] Full suite: 681 passing.
- [x] \`pre-commit run --all-files\` clean.