### PR TITLE
fix(dashboard): retry transient GraphQL network errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,7 @@ module = "github.*"
 ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
-module = ["textual.*", "loguru", "dotenv"]
+module = ["textual.*", "loguru", "dotenv", "requests.*"]
 ignore_missing_imports = true
 
 [tool.pytest.ini_options]

--- a/src/augint_tools/dashboard/_gql.py
+++ b/src/augint_tools/dashboard/_gql.py
@@ -13,11 +13,14 @@ fraction of repos on any given refresh.
 
 from __future__ import annotations
 
+import time
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
 from loguru import logger
+from requests.exceptions import ChunkedEncodingError, Timeout
+from requests.exceptions import ConnectionError as RequestsConnectionError
 
 if TYPE_CHECKING:
     from github import Github
@@ -46,6 +49,16 @@ PIPELINE_PATHS: tuple[str, ...] = (
 # complexity budget; at ~35 fields per repo this keeps us well under the cap
 # while still collapsing workspace-scale fetches into a handful of queries.
 _BATCH_SIZE = 25
+
+# Transient network failures worth retrying. GraphQL/HTTP-level errors (4xx,
+# rate-limit, schema) surface as other exception types and should NOT retry.
+_TRANSIENT_NETWORK_ERRORS: tuple[type[Exception], ...] = (
+    ChunkedEncodingError,
+    RequestsConnectionError,
+    Timeout,
+)
+_RETRY_ATTEMPTS = 3
+_RETRY_BACKOFF_SECONDS = (0.5, 1.0)
 
 
 # ---------------------------------------------------------------------------
@@ -428,14 +441,39 @@ def parse_response(
 
 
 def _execute_query(gh: Github, query: str) -> dict:
-    """POST a single GraphQL query via PyGithub's requester and return JSON."""
+    """POST a single GraphQL query via PyGithub's requester and return JSON.
+
+    Retries on transient network failures (connection drops, incomplete
+    chunked reads, timeouts). GraphQL-level errors and PyGithub exceptions
+    are not retried -- they surface to the caller immediately.
+    """
     # PyGithub's internal requester is the only path that reuses the existing
     # token / session. We access it via the name-mangled private attribute;
     # this is a well-worn pattern in projects that layer GraphQL on top of
     # PyGithub, and it keeps us from pulling in another HTTP client.
     requester = gh._Github__requester  # type: ignore[attr-defined]
-    _headers, data = requester.requestJsonAndCheck("POST", "/graphql", input={"query": query})
-    return data
+    last_exc: Exception | None = None
+    for attempt in range(_RETRY_ATTEMPTS):
+        try:
+            _headers, data = requester.requestJsonAndCheck(
+                "POST", "/graphql", input={"query": query}
+            )
+            return data
+        except _TRANSIENT_NETWORK_ERRORS as exc:
+            last_exc = exc
+            if attempt == _RETRY_ATTEMPTS - 1:
+                break
+            backoff = _RETRY_BACKOFF_SECONDS[attempt]
+            logger.debug(
+                "graphql transient network error ({}); retrying in {}s ({}/{})",
+                exc.__class__.__name__,
+                backoff,
+                attempt + 1,
+                _RETRY_ATTEMPTS - 1,
+            )
+            time.sleep(backoff)
+    assert last_exc is not None
+    raise last_exc
 
 
 def fetch_workspace_snapshot(gh: Github, repos: list[Repository]) -> WorkspaceSnapshot:
@@ -461,7 +499,7 @@ def fetch_workspace_snapshot(gh: Github, repos: list[Repository]) -> WorkspaceSn
             response = _execute_query(gh, query)
         except Exception as exc:
             logger.warning(
-                "graphql workspace fetch failed for chunk %d-%d: %s: %s",
+                "graphql workspace fetch failed for chunk {}-{}: {}: {}",
                 start,
                 start + len(chunk) - 1,
                 exc.__class__.__name__,
@@ -692,7 +730,7 @@ def fetch_workspace_teams(gh: Github, owners: list[str]) -> TeamsSnapshot:
     try:
         response = _execute_query(gh, query)
     except Exception as exc:
-        logger.warning("graphql teams fetch failed: %s: %s", exc.__class__.__name__, exc)
+        logger.warning("graphql teams fetch failed: {}: {}", exc.__class__.__name__, exc)
         return TeamsSnapshot(
             errored=dict.fromkeys(owners, f"graphql: {exc.__class__.__name__}: {exc}")
         )

--- a/tests/unit/test_gql.py
+++ b/tests/unit/test_gql.py
@@ -313,6 +313,60 @@ class TestFetchWorkspaceSnapshot:
         assert result.by_full_name == {}
         assert all(name in result.errored for name in (r.full_name for r in repos))
 
+    def test_transient_network_error_is_retried(self, monkeypatch):
+        from requests.exceptions import ChunkedEncodingError
+
+        import augint_tools.dashboard._gql as gql
+
+        monkeypatch.setattr(gql, "_RETRY_BACKOFF_SECONDS", (0.0, 0.0))
+
+        repos = [_mock_repo("org/a")]
+        calls = {"n": 0}
+
+        def _request(method, url, **kwargs):  # noqa: ARG001
+            calls["n"] += 1
+            if calls["n"] < 3:
+                raise ChunkedEncodingError("Connection broken: IncompleteRead")
+            return (
+                {},
+                {
+                    "data": {
+                        "r0": _graphql_repo_payload(full_name="org/a", main_state="SUCCESS"),
+                        "rateLimit": {
+                            "limit": 5000,
+                            "cost": 1,
+                            "remaining": 4999,
+                            "resetAt": None,
+                        },
+                    }
+                },
+            )
+
+        gh = MagicMock()
+        gh._Github__requester.requestJsonAndCheck.side_effect = _request  # type: ignore[attr-defined]
+
+        result = fetch_workspace_snapshot(gh, repos)
+        assert calls["n"] == 3
+        assert "org/a" in result.by_full_name
+        assert result.errored == {}
+
+    def test_transient_network_error_gives_up_after_retries(self, monkeypatch):
+        from requests.exceptions import ChunkedEncodingError
+
+        import augint_tools.dashboard._gql as gql
+
+        monkeypatch.setattr(gql, "_RETRY_BACKOFF_SECONDS", (0.0, 0.0))
+
+        repos = [_mock_repo("org/a")]
+        gh = MagicMock()
+        gh._Github__requester.requestJsonAndCheck.side_effect = ChunkedEncodingError(  # type: ignore[attr-defined]
+            "Connection broken"
+        )
+        result = fetch_workspace_snapshot(gh, repos)
+        assert result.by_full_name == {}
+        assert "org/a" in result.errored
+        assert gh._Github__requester.requestJsonAndCheck.call_count == gql._RETRY_ATTEMPTS  # type: ignore[attr-defined]
+
 
 # ---------------------------------------------------------------------------
 # Pickers


### PR DESCRIPTION
## Summary
- Wrap `_execute_query` in a 3-attempt retry (0.5s / 1.0s backoff) for `ChunkedEncodingError`, `ConnectionError`, and `Timeout`. A single dropped connection from GitHub's GraphQL endpoint no longer flags every repo in the drawer as errored.
- Fix two `logger.warning` calls in `_gql.py` that used stdlib `%`-format specifiers — loguru prints them literally. Switched to `{}` placeholders.

## Context
Observed live in `tui.log`: one refresh at 15:15:54 raised `ChunkedEncodingError('IncompleteRead')` mid-response and bubbled up as 21 per-repo errors. The next cycle recovered cleanly. This is a transient-network class of failure; retrying masks it from the user.

## Test plan
- [x] New unit test: request fails twice with `ChunkedEncodingError`, succeeds on the 3rd — asserts 3 calls and data lands.
- [x] New unit test: all attempts fail — repo marked errored, exactly `_RETRY_ATTEMPTS` calls made.
- [x] Existing `test_failed_request_errors_chunk` (RuntimeError) still fails fast — confirms we don't retry non-network errors.
- [x] `uv run pre-commit run --all-files` passes
- [x] `uv run pytest` — 683 passed