### PR TITLE
fix(dashboard): resolve unknown CI status by walking branch history

### DIFF
--- a/src/augint_tools/dashboard/_gql.py
+++ b/src/augint_tools/dashboard/_gql.py
@@ -50,6 +50,13 @@ PIPELINE_PATHS: tuple[str, ...] = (
 # while still collapsing workspace-scale fetches into a handful of queries.
 _BATCH_SIZE = 25
 
+# How far back to walk the default-branch / dev-branch history looking for a
+# non-null statusCheckRollup. Needed because semantic-release chore commits
+# intentionally skip CI, leaving the tip commit's rollup null even when the
+# pipeline is healthy. 5 covers the common case (a bump commit directly after
+# the PR merge) with generous headroom.
+_HISTORY_LOOKBACK = 5
+
 # Transient network failures worth retrying. GraphQL/HTTP-level errors (4xx,
 # rate-limit, schema) surface as other exception types and should NOT retry.
 _TRANSIENT_NETWORK_ERRORS: tuple[type[Exception], ...] = (
@@ -167,6 +174,9 @@ fragment RepoFields on Repository {{
       ... on Commit {{
         oid
         statusCheckRollup {{ state }}
+        history(first: {_HISTORY_LOOKBACK}) {{
+          nodes {{ statusCheckRollup {{ state }} }}
+        }}
       }}
     }}
   }}
@@ -175,6 +185,9 @@ fragment RepoFields on Repository {{
       ... on Commit {{
         oid
         statusCheckRollup {{ state }}
+        history(first: {_HISTORY_LOOKBACK}) {{
+          nodes {{ statusCheckRollup {{ state }} }}
+        }}
       }}
     }}
   }}
@@ -251,6 +264,33 @@ def _parse_ts(value: Any) -> datetime | None:
             return None
 
 
+def _resolve_rollup_state(target: Any) -> str | None:
+    """Pick the first non-null rollup state from the tip commit or its ancestors.
+
+    GraphQL's ``statusCheckRollup`` is null whenever the commit didn't trigger
+    any workflow -- common on semantic-release chore commits and ``[skip ci]``
+    merges. Falling back to ``history(first: _HISTORY_LOOKBACK)`` reflects the
+    branch's actual pipeline health rather than whatever happened to land on
+    the tip.
+    """
+    if not isinstance(target, dict):
+        return None
+    rollup = target.get("statusCheckRollup")
+    if isinstance(rollup, dict) and rollup.get("state"):
+        return str(rollup["state"])
+    history = target.get("history")
+    nodes = history.get("nodes") if isinstance(history, dict) else None
+    if not isinstance(nodes, list):
+        return None
+    for node in nodes:
+        if not isinstance(node, dict):
+            continue
+        node_rollup = node.get("statusCheckRollup")
+        if isinstance(node_rollup, dict) and node_rollup.get("state"):
+            return str(node_rollup["state"])
+    return None
+
+
 def _extract_blob_text(blob: dict | None) -> str | None:
     """Pull ``text`` out of a GraphQL Blob payload, respecting truncation.
 
@@ -277,17 +317,13 @@ def _parse_repo(data: dict) -> RepoSnapshot:
     default_branch_ref = data.get("defaultBranchRef") or {}
     default_branch = str(default_branch_ref.get("name", "main")) if default_branch_ref else "main"
     main_target = (default_branch_ref or {}).get("target") or {}
-    main_rollup = (
-        (main_target.get("statusCheckRollup") or {}) if isinstance(main_target, dict) else {}
-    )
-    main_rollup_state = main_rollup.get("state") if isinstance(main_rollup, dict) else None
+    main_rollup_state = _resolve_rollup_state(main_target)
     main_head_sha = main_target.get("oid") if isinstance(main_target, dict) else None
 
     dev_ref = data.get("_dev")
     has_dev_branch = dev_ref is not None
     dev_target = (dev_ref or {}).get("target") or {} if isinstance(dev_ref, dict) else {}
-    dev_rollup = (dev_target.get("statusCheckRollup") or {}) if isinstance(dev_target, dict) else {}
-    dev_rollup_state = dev_rollup.get("state") if isinstance(dev_rollup, dict) else None
+    dev_rollup_state = _resolve_rollup_state(dev_target)
     dev_head_sha = dev_target.get("oid") if isinstance(dev_target, dict) else None
 
     root_tree = data.get("_rootTree")

--- a/src/augint_tools/dashboard/health/checks/broken_ci.py
+++ b/src/augint_tools/dashboard/health/checks/broken_ci.py
@@ -46,21 +46,22 @@ class BrokenCICheck:
                 link=actions_url,
             )
 
-        # "unknown" here means GraphQL's statusCheckRollup came back null for
-        # the latest commit on the default branch. That happens legitimately
-        # when the latest commit didn't trigger any workflow (semantic-release
-        # chore commits, [skip ci] on merges, workflow trigger filters that
-        # don't match). Only treat it as a real finding when the repo has no
-        # workflow files at all -- that's the actual governance gap.
-        if (
-            status.main_status == "unknown"
-            and status.dev_status is None
-            and not status.has_workflows
-        ):
+        # "unknown" reaches here only after the GraphQL fetcher has walked
+        # several commits back through the default branch looking for a
+        # non-null statusCheckRollup. If nothing was found, either the repo
+        # has no workflows (governance gap) or the workflows exist but haven't
+        # produced a run recently enough to see. Both warrant a warning --
+        # silently rendering green would claim CI health we can't actually
+        # verify.
+        if status.main_status == "unknown" and status.dev_status is None:
+            if not status.has_workflows:
+                summary = "No CI workflows detected"
+            else:
+                summary = "CI status unknown: no recent workflow runs"
             return HealthCheckResult(
                 check_name=self.name,
                 severity=Severity.MEDIUM,
-                summary="No CI workflows detected",
+                summary=summary,
                 link=actions_url,
             )
 

--- a/tests/unit/test_gql.py
+++ b/tests/unit/test_gql.py
@@ -35,7 +35,9 @@ def _graphql_repo_payload(
     full_name: str,
     has_dev: bool = False,
     main_state: str = "SUCCESS",
+    main_history_states: list[str | None] | None = None,
     dev_state: str | None = None,
+    dev_history_states: list[str | None] | None = None,
     pr_nodes: list[dict] | None = None,
     pr_total: int | None = None,
     issue_nodes: list[dict] | None = None,
@@ -48,6 +50,17 @@ def _graphql_repo_payload(
 ) -> dict:
     """Build the per-repo shape that GraphQL would return for RepoFields."""
     owner, name = full_name.split("/", 1)
+
+    def _history(states: list[str | None] | None) -> dict:
+        # Default: history mirrors the tip rollup so callers that don't care
+        # about walkback behavior keep working unchanged.
+        return {
+            "nodes": [
+                {"statusCheckRollup": {"state": s} if s else None}
+                for s in (states if states is not None else [])
+            ]
+        }
+
     payload: dict = {
         "nameWithOwner": full_name,
         "name": name,
@@ -59,6 +72,7 @@ def _graphql_repo_payload(
             "target": {
                 "oid": "abc123",
                 "statusCheckRollup": {"state": main_state} if main_state else None,
+                "history": _history(main_history_states),
             },
         },
         "_dev": None,
@@ -77,6 +91,7 @@ def _graphql_repo_payload(
             "target": {
                 "oid": "def456",
                 "statusCheckRollup": {"state": dev_state} if dev_state else None,
+                "history": _history(dev_history_states),
             },
         }
     hits = renovate_hits or {}
@@ -220,6 +235,57 @@ class TestParseResponse:
         ppath, ptext = pick_pipeline_yaml(snap)
         assert ppath == ".github/workflows/pipeline.yaml"
         assert "unit-tests" in ptext
+
+    def test_rollup_walks_history_when_tip_has_no_rollup(self):
+        # Skip-ci release commit at tip -> null rollup on tip. History walkback
+        # should find the prior merge commit's SUCCESS state.
+        payload = _graphql_repo_payload(
+            full_name="org/a",
+            main_state="",  # empty string -> no statusCheckRollup on tip
+            main_history_states=[None, "SUCCESS", "SUCCESS"],
+        )
+        # Force the tip rollup to null; main_state="" above already does this
+        # but be explicit.
+        payload["defaultBranchRef"]["target"]["statusCheckRollup"] = None
+        response = {"data": {"r0": payload}}
+        snapshots, _, _ = parse_response(response, [_mock_repo("org/a")])
+        assert snapshots["org/a"].main_rollup_state == "SUCCESS"
+
+    def test_rollup_stays_unknown_when_history_also_empty(self):
+        payload = _graphql_repo_payload(
+            full_name="org/a",
+            main_state="",
+            main_history_states=[None, None, None],
+        )
+        payload["defaultBranchRef"]["target"]["statusCheckRollup"] = None
+        response = {"data": {"r0": payload}}
+        snapshots, _, _ = parse_response(response, [_mock_repo("org/a")])
+        assert snapshots["org/a"].main_rollup_state is None
+
+    def test_rollup_prefers_tip_when_present(self):
+        # Tip has a rollup -- history shouldn't be consulted, so put a bogus
+        # state there and confirm we still get the tip's.
+        payload = _graphql_repo_payload(
+            full_name="org/a",
+            main_state="FAILURE",
+            main_history_states=["SUCCESS", "SUCCESS"],
+        )
+        response = {"data": {"r0": payload}}
+        snapshots, _, _ = parse_response(response, [_mock_repo("org/a")])
+        assert snapshots["org/a"].main_rollup_state == "FAILURE"
+
+    def test_dev_rollup_walks_history_too(self):
+        payload = _graphql_repo_payload(
+            full_name="org/service",
+            has_dev=True,
+            main_state="SUCCESS",
+            dev_state="",
+            dev_history_states=[None, "FAILURE"],
+        )
+        payload["_dev"]["target"]["statusCheckRollup"] = None
+        response = {"data": {"r0": payload}}
+        snapshots, _, _ = parse_response(response, [_mock_repo("org/service")])
+        assert snapshots["org/service"].dev_rollup_state == "FAILURE"
 
     def test_truncated_blob_treated_as_absent(self):
         payload = _graphql_repo_payload(full_name="org/a")

--- a/tests/unit/test_health.py
+++ b/tests/unit/test_health.py
@@ -296,16 +296,19 @@ class TestBrokenCI:
         assert result.severity == Severity.MEDIUM
         assert "No CI workflows" in result.summary
 
-    def test_unknown_rollup_with_workflows_is_ok(self):
-        # Workflows exist but the latest commit didn't trigger one (common for
-        # semantic-release chore commits). Not a health issue.
+    def test_unknown_rollup_with_workflows_is_warning(self):
+        # History walkback in the GraphQL fetcher already absorbs the common
+        # skip-ci-chore-commit case. Anything that still arrives here as
+        # "unknown" means 5+ consecutive commits produced no rollup -- not
+        # verifiably healthy, so don't claim green.
         result = get_check("broken_ci").evaluate(
             _mock_repo(),
             _status(main_status="unknown", dev_status=None, has_workflows=True),
             config={},
             context=_ctx(),
         )
-        assert result.severity == Severity.OK
+        assert result.severity == Severity.MEDIUM
+        assert "unknown" in result.summary.lower()
 
     def test_main_takes_priority_over_dev(self):
         result = get_check("broken_ci").evaluate(


### PR DESCRIPTION
## Summary

- Walk `history(first: 5)` on both main and dev targets in the workspace GraphQL query and pick the first non-null `statusCheckRollup.state`. This absorbs the common case where `semantic-release` chore commits or `[skip ci]` merges leave the tip commit's rollup null.
- Update `broken_ci.py` so a status that's still unknown after walkback warrants MEDIUM severity rather than silently rendering green. Summary text distinguishes "No CI workflows detected" from "CI status unknown: no recent workflow runs".
- Before this change, `augint-tools`, `tagmania`, `augint-shell`, and `ai-cc-tools` all showed a "?" icon on a green card because their tip commit was a release bump.

## Test plan

- [x] `uv run pytest` (687 passed)
- [x] `uv run pre-commit run --all-files`
- [x] New unit tests in `test_gql.py` cover tip-null→history-success, tip-null→history-null, tip-present-ignores-history, and dev-branch walkback.
- [x] Updated `test_health.py` expects MEDIUM for unknown-with-workflows.