### PR TITLE
fix(dashboard): lead coverage summary with threshold ratio

### DIFF
--- a/src/augint_tools/dashboard/health/checks/coverage.py
+++ b/src/augint_tools/dashboard/health/checks/coverage.py
@@ -194,8 +194,8 @@ class CoverageCheck:
                     check_name=self.name,
                     severity=Severity.LOW,
                     summary=(
-                        f"coverage threshold lowered to {lowered_threshold}% "
-                        f"(std: {_STANDARD_THRESHOLD}%)"
+                        f"({lowered_threshold}%/{_STANDARD_THRESHOLD}%) "
+                        f"code coverage reduced from standard"
                     ),
                     link=workflow_link,
                 )

--- a/tests/unit/test_health.py
+++ b/tests/unit/test_health.py
@@ -669,7 +669,7 @@ jobs:
         result = self._evaluate(self._LOWERED_PY)
         assert result.severity == Severity.LOW
         assert "60" in result.summary
-        assert "lowered" in result.summary
+        assert "reduced" in result.summary
         assert result.link is not None
         assert "pipeline.yaml" in result.link
 


### PR DESCRIPTION
Reformat the lowered-threshold summary from
"coverage threshold lowered to 50% (std: 80%)" to
"(50%/80%) code coverage reduced from standard" so the numeric ratio
is the first thing a scanning reader sees on the dashboard card.
