### PR TITLE
feat(dashboard): flag service-shaped repos missing a dev branch

### DIFF
--- a/src/augint_tools/dashboard/_data.py
+++ b/src/augint_tools/dashboard/_data.py
@@ -80,6 +80,27 @@ def _detect_tags(
     return is_workspace, tuple(tags)
 
 
+# Root-tree files that mark a repo as a service rather than a library. Detected
+# independently of branch layout so the dashboard can flag a service-shaped repo
+# whose dev branch has gone missing -- the actual configuration drift, not a
+# downstream symptom in the rollup state.
+_SERVICE_MARKERS: tuple[str, ...] = (
+    "template.yaml",
+    "template.yml",
+    "samconfig.toml",
+    "serverless.yml",
+    "serverless.yaml",
+    "cdk.json",
+    "Dockerfile",
+)
+
+
+def _detect_service_markers(root_entries: tuple[str, ...]) -> tuple[str, ...]:
+    """Return the subset of canonical service-marker files present at the repo root."""
+    names = set(root_entries)
+    return tuple(marker for marker in _SERVICE_MARKERS if marker in names)
+
+
 # ---------------------------------------------------------------------------
 # Data model
 # ---------------------------------------------------------------------------
@@ -89,7 +110,10 @@ def _detect_tags(
 class RepoStatus:
     name: str
     full_name: str
-    is_service: bool
+    # Whether a ``dev`` branch exists on the repo. Drives the dev/main column
+    # rendering and the "dev pipeline failing" branch of broken_ci. Independent
+    # of whether the repo is *structurally* a service -- see ``looks_like_service``.
+    has_dev_branch: bool
     main_status: str
     main_error: str | None
     dev_status: str | None
@@ -120,6 +144,14 @@ class RepoStatus:
     # happened not to trigger any workflow" (common for semantic-release
     # chore commits that intentionally skip CI).
     has_workflows: bool = False
+    # Structural service detection: true when the repo root contains any
+    # canonical service-marker file (template.yaml, samconfig.toml,
+    # serverless.yml, cdk.json, Dockerfile, ...). Independent of branch layout
+    # so the dashboard can flag service-shaped repos whose dev branch is missing.
+    looks_like_service: bool = False
+    # Specific service-marker filenames detected at the repo root, surfaced in
+    # diagnostic output for the missing-dev-branch alert.
+    service_markers: tuple[str, ...] = ()
 
 
 # ---------------------------------------------------------------------------
@@ -172,6 +204,7 @@ def build_status_from_snapshot(
     open_issues = snapshot.issue_total_count
 
     is_workspace, tags = _detect_tags(snapshot.primary_language, snapshot.root_entries)
+    service_markers = _detect_service_markers(snapshot.root_entries)
 
     main_status = translate_rollup_state(snapshot.main_rollup_state)
     dev_status: str | None = (
@@ -181,7 +214,7 @@ def build_status_from_snapshot(
     return RepoStatus(
         name=snapshot.name,
         full_name=snapshot.full_name,
-        is_service=snapshot.has_dev_branch,
+        has_dev_branch=snapshot.has_dev_branch,
         main_status=main_status,
         main_error=main_error,
         dev_status=dev_status,
@@ -198,6 +231,8 @@ def build_status_from_snapshot(
         oldest_issue_created_at=oldest_iso,
         default_branch=snapshot.default_branch or "main",
         has_workflows=bool(snapshot.workflow_files),
+        looks_like_service=bool(service_markers),
+        service_markers=service_markers,
     )
 
 
@@ -262,6 +297,8 @@ def load_cache() -> dict[str, RepoStatus]:
             filtered = {k: v for k, v in val.items() if k in allowed}
             if "tags" in filtered and isinstance(filtered["tags"], list):
                 filtered["tags"] = tuple(filtered["tags"])
+            if "service_markers" in filtered and isinstance(filtered["service_markers"], list):
+                filtered["service_markers"] = tuple(filtered["service_markers"])
             result[key] = RepoStatus(**filtered)
         return result
     except (json.JSONDecodeError, TypeError, KeyError):

--- a/src/augint_tools/dashboard/app.py
+++ b/src/augint_tools/dashboard/app.py
@@ -550,7 +550,7 @@ class MainScreen(Screen[None]):
         t = Text()
         t.append(f"{status.full_name}\n\n", style="bold")
         t.append(f"main ci: {status.main_status}\n")
-        if status.is_service and status.dev_status:
+        if status.has_dev_branch and status.dev_status:
             t.append(f"dev ci:  {status.dev_status}\n")
         # issues + PRs counts are emitted as OSC-8 hyperlinks so clicking the
         # number opens the matching GitHub listing. Matches the card's click
@@ -773,7 +773,7 @@ class MainScreen(Screen[None]):
             t.append("  ")
             t.append(f"{name:<16}", style=f"{accent} link {link_url}")
             t.append(" ")
-            if status.is_service and status.dev_status:
+            if status.has_dev_branch and status.dev_status:
                 t.append("\u25cf", style=self._ci_dot_style(status.dev_status, spec))
                 t.append(" ")
             else:
@@ -828,8 +828,8 @@ class MainScreen(Screen[None]):
         """Split of services vs libraries and their health."""
         from .health import Severity as _Sev
 
-        services = [h for h in healths if h.status.is_service]
-        libs = [h for h in healths if not h.status.is_service]
+        services = [h for h in healths if h.status.has_dev_branch or h.status.looks_like_service]
+        libs = [h for h in healths if not (h.status.has_dev_branch or h.status.looks_like_service)]
         t.append("service / lib\n", style="bold")
 
         def _line(label: str, bucket: list) -> None:
@@ -1572,7 +1572,7 @@ class DashboardApp(App[None]):
                     status_by_name[repo.full_name] = RepoStatus(
                         name=getattr(repo, "name", "?"),
                         full_name=repo.full_name,
-                        is_service=False,
+                        has_dev_branch=False,
                         main_status="unknown",
                         main_error=None,
                         dev_status=None,
@@ -1587,7 +1587,7 @@ class DashboardApp(App[None]):
             status_by_name[repo.full_name] = status
             if status.main_status == "failure":
                 failing_targets.append((repo, status.default_branch))
-            if status.is_service and status.dev_status == "failure":
+            if status.has_dev_branch and status.dev_status == "failure":
                 failing_targets.append((repo, "dev"))
 
         # Phase 2b: populate failing-run detail. GraphQL's statusCheckRollup

--- a/src/augint_tools/dashboard/health/checks/__init__.py
+++ b/src/augint_tools/dashboard/health/checks/__init__.py
@@ -1,6 +1,15 @@
 """Built-in health checks. Importing this module triggers registration."""
 
-from . import broken_ci, coverage, open_issues, open_prs, renovate, renovate_prs, stale_prs
+from . import (
+    broken_ci,
+    coverage,
+    open_issues,
+    open_prs,
+    renovate,
+    renovate_prs,
+    service_missing_dev,
+    stale_prs,
+)
 
 __all__ = [
     "broken_ci",
@@ -9,5 +18,6 @@ __all__ = [
     "open_prs",
     "renovate",
     "renovate_prs",
+    "service_missing_dev",
     "stale_prs",
 ]

--- a/src/augint_tools/dashboard/health/checks/service_missing_dev.py
+++ b/src/augint_tools/dashboard/health/checks/service_missing_dev.py
@@ -1,0 +1,44 @@
+"""Health check: structurally a service but the ``dev`` branch is missing."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from .._models import HealthCheckResult, Severity
+from .._registry import register
+
+if TYPE_CHECKING:
+    from github.Repository import Repository
+
+    from ..._data import RepoStatus
+    from .. import FetchContext
+
+
+class ServiceMissingDevBranchCheck:
+    name = "service_missing_dev_branch"
+    description = "Detect service-shaped repos whose dev branch has gone missing"
+
+    def evaluate(
+        self,
+        repo: Repository,  # noqa: ARG002
+        status: RepoStatus,
+        *,
+        config: dict,  # noqa: ARG002
+        context: FetchContext,  # noqa: ARG002
+    ) -> HealthCheckResult:
+        if status.looks_like_service and not status.has_dev_branch:
+            markers = ", ".join(status.service_markers) or "service markers detected"
+            return HealthCheckResult(
+                check_name=self.name,
+                severity=Severity.CRITICAL,
+                summary=f"service repo missing dev branch ({markers})",
+                link=f"https://github.com/{status.full_name}/branches",
+            )
+        return HealthCheckResult(
+            check_name=self.name,
+            severity=Severity.OK,
+            summary="dev branch present",
+        )
+
+
+register(ServiceMissingDevBranchCheck())

--- a/src/augint_tools/dashboard/screens/drilldown.py
+++ b/src/augint_tools/dashboard/screens/drilldown.py
@@ -41,7 +41,7 @@ class DrillDownScreen(ModalScreen[None]):
         t.append(f"branch: {status.main_status}", style="bold")
         if status.main_error:
             t.append(f"\n  main: {status.main_error}", style="red")
-        if status.is_service and status.dev_status:
+        if status.has_dev_branch and status.dev_status:
             t.append(f"\n  dev: {status.dev_status}", style="bold")
             if status.dev_error:
                 t.append(f"\n    {status.dev_error}", style="red")

--- a/src/augint_tools/dashboard/widgets/repo_card.py
+++ b/src/augint_tools/dashboard/widgets/repo_card.py
@@ -269,7 +269,11 @@ class RepoCard(Widget):
             line.append(" > ", style=f"bold black on {self._theme_spec.status_pass}")
             line.append(" ")
         line.append(health.status.name, style="bold")
-        if health.status.is_service:
+        # "svc" is the union of both signals: a repo is service-flavoured if
+        # it either runs a dev branch (gitflow-style) or carries a structural
+        # marker like template.yaml/Dockerfile. Repos satisfying neither are
+        # libraries.
+        if health.status.has_dev_branch or health.status.looks_like_service:
             line.append("  svc", style="dim")
         if health.status.is_workspace:
             line.append("  ws", style="dim")
@@ -281,7 +285,7 @@ class RepoCard(Widget):
         spec = self._theme_spec
         status = health.status
         line = Text()
-        if status.is_service and status.dev_status is not None:
+        if status.has_dev_branch and status.dev_status is not None:
             line.append("dev ")
             line.append(
                 _STATUS_ICON.get(status.dev_status, "?"),

--- a/tests/unit/test_dashboard.py
+++ b/tests/unit/test_dashboard.py
@@ -64,7 +64,7 @@ def _status(
     return RepoStatus(
         name=name,
         full_name=full_name,
-        is_service=False,
+        has_dev_branch=False,
         main_status=main_status,
         main_error=None,
         dev_status=None,
@@ -1221,6 +1221,52 @@ class TestDetectTags:
         assert tags == ()
 
 
+class TestDetectServiceMarkers:
+    """Service-marker detection is independent of dev-branch existence so the
+    dashboard can flag service-shaped repos whose dev branch went missing."""
+
+    def test_no_markers_returns_empty(self):
+        from augint_tools.dashboard._data import _detect_service_markers
+
+        assert _detect_service_markers(()) == ()
+        assert _detect_service_markers(("README.md", "pyproject.toml", "src")) == ()
+
+    def test_sam_service(self):
+        from augint_tools.dashboard._data import _detect_service_markers
+
+        markers = _detect_service_markers(("template.yaml", "samconfig.toml", "src"))
+        assert "template.yaml" in markers
+        assert "samconfig.toml" in markers
+
+    def test_dockerfile_alone_is_a_marker(self):
+        from augint_tools.dashboard._data import _detect_service_markers
+
+        assert _detect_service_markers(("Dockerfile",)) == ("Dockerfile",)
+
+    def test_cdk_marker(self):
+        from augint_tools.dashboard._data import _detect_service_markers
+
+        assert _detect_service_markers(("cdk.json",)) == ("cdk.json",)
+
+    def test_serverless_marker(self):
+        from augint_tools.dashboard._data import _detect_service_markers
+
+        assert _detect_service_markers(("serverless.yml",)) == ("serverless.yml",)
+
+    def test_template_yml_variant(self):
+        from augint_tools.dashboard._data import _detect_service_markers
+
+        assert _detect_service_markers(("template.yml",)) == ("template.yml",)
+
+    def test_marker_detection_is_independent_of_dev_branch(self):
+        # Only the root_entries argument matters -- branch state is not consulted.
+        from augint_tools.dashboard._data import _detect_service_markers
+
+        markers = _detect_service_markers(("Dockerfile", "template.yaml"))
+        assert "Dockerfile" in markers
+        assert "template.yaml" in markers
+
+
 class TestBootstrapCache:
     def test_bootstrap_no_cache(self):
         from augint_tools.dashboard.state import bootstrap_from_cache
@@ -1358,7 +1404,7 @@ class TestAppMisc:
         status = RepoStatus(
             name="r0",
             full_name="org/r0",
-            is_service=False,
+            has_dev_branch=False,
             main_status="success",
             main_error=None,
             dev_status=None,

--- a/tests/unit/test_health.py
+++ b/tests/unit/test_health.py
@@ -27,7 +27,7 @@ from augint_tools.dashboard.health._registry import get_check
 def _status(
     name="myrepo",
     full_name="org/myrepo",
-    is_service=False,
+    has_dev_branch=False,
     main_status="success",
     main_error=None,
     dev_status=None,
@@ -38,11 +38,13 @@ def _status(
     human_open_issues=0,
     default_branch="main",
     has_workflows=True,
+    looks_like_service=False,
+    service_markers=(),
 ):
     return RepoStatus(
         name=name,
         full_name=full_name,
-        is_service=is_service,
+        has_dev_branch=has_dev_branch,
         main_status=main_status,
         main_error=main_error,
         dev_status=dev_status,
@@ -53,6 +55,8 @@ def _status(
         human_open_issues=human_open_issues,
         default_branch=default_branch,
         has_workflows=has_workflows,
+        looks_like_service=looks_like_service,
+        service_markers=service_markers,
     )
 
 
@@ -233,6 +237,7 @@ class TestRegistry:
         assert "open_issues" in names
         assert "open_prs" in names
         assert "coverage" in names
+        assert "service_missing_dev_branch" in names
 
     def test_all_checks_returns_instances(self):
         checks = all_checks()
@@ -274,7 +279,8 @@ class TestBrokenCI:
         result = get_check("broken_ci").evaluate(
             _mock_repo(),
             _status(
-                is_service=True,
+                has_dev_branch=True,
+                looks_like_service=True,
                 main_status="success",
                 dev_status="failure",
                 dev_error="deploy: Push image",
@@ -314,7 +320,8 @@ class TestBrokenCI:
         result = get_check("broken_ci").evaluate(
             _mock_repo(),
             _status(
-                is_service=True,
+                has_dev_branch=True,
+                looks_like_service=True,
                 main_status="failure",
                 main_error="err",
                 dev_status="failure",
@@ -324,6 +331,68 @@ class TestBrokenCI:
             context=_ctx(),
         )
         assert "main" in result.summary
+
+
+class TestServiceMissingDevBranch:
+    """A repo with structural service markers but no dev branch is the exact
+    drift the dashboard exists to catch -- e.g. a SAM/CDK/Dockerfile service
+    whose dev branch was deleted because the standard ruleset's deletion rule
+    wasn't in place. The check fires CRITICAL because the dev-pinned workflows
+    will start poisoning the main rollup, which is a noisy and indirect signal
+    compared to naming the actual condition."""
+
+    def test_service_with_dev_branch_is_ok(self):
+        result = get_check("service_missing_dev_branch").evaluate(
+            _mock_repo(),
+            _status(
+                has_dev_branch=True,
+                looks_like_service=True,
+                service_markers=("template.yaml",),
+            ),
+            config={},
+            context=_ctx(),
+        )
+        assert result.severity == Severity.OK
+
+    def test_service_without_dev_branch_is_critical(self):
+        result = get_check("service_missing_dev_branch").evaluate(
+            _mock_repo(),
+            _status(
+                has_dev_branch=False,
+                looks_like_service=True,
+                service_markers=("template.yaml", "Dockerfile"),
+            ),
+            config={},
+            context=_ctx(),
+        )
+        assert result.severity == Severity.CRITICAL
+        assert "service repo missing dev branch" in result.summary
+        assert "template.yaml" in result.summary
+        assert "Dockerfile" in result.summary
+        assert result.link == "https://github.com/org/myrepo/branches"
+
+    def test_library_without_dev_branch_is_ok(self):
+        # No service markers -> not a service -> dev branch absence is expected,
+        # not a problem. This is what guards the check from false positives on
+        # ordinary library repos.
+        result = get_check("service_missing_dev_branch").evaluate(
+            _mock_repo(),
+            _status(has_dev_branch=False, looks_like_service=False),
+            config={},
+            context=_ctx(),
+        )
+        assert result.severity == Severity.OK
+
+    def test_library_with_dev_branch_is_ok(self):
+        # Some library repos legitimately maintain a dev branch (long-running
+        # rewrite, doc staging, etc.). Not a service, dev exists -> nothing to flag.
+        result = get_check("service_missing_dev_branch").evaluate(
+            _mock_repo(),
+            _status(has_dev_branch=True, looks_like_service=False),
+            config={},
+            context=_ctx(),
+        )
+        assert result.severity == Severity.OK
 
 
 class TestRenovateEnabled:


### PR DESCRIPTION
## Summary

- Adds a structural service-marker signal independent of branch layout so the dashboard can name the actual root cause when a service repo loses its dev branch, instead of relying on the downstream "main pipeline failing" rollup symptom.
- Renames `RepoStatus.is_service` to `has_dev_branch` (accurate to what it stores) and adds `looks_like_service` + `service_markers` populated from root-tree files (`template.yaml`, `samconfig.toml`, `serverless.yml`, `cdk.json`, `Dockerfile`, ...).
- New `service_missing_dev_branch` health check fires CRITICAL when a repo has service markers but no dev branch.
- The user-visible "svc" tag and services-vs-libs breakdown use the **union** of both signals so repos whose service infra lives in a subdir (e.g. `infrastructure/`) don't regress.

## Why

Diagnosed against `Augmenting-Integrations/aillc-web`: it's a SAM/Docker service whose `dev` branch was deleted (the standard `service_dev` ruleset's `deletion` rule was missing on that repo). The dashboard surfaced this as `main pipeline failing` via the GraphQL rollup history lookback — which worked, but indirectly. With this change the alert names the actual condition: `service repo missing dev branch (template.yaml, Dockerfile)`.

## Live verification

Ran the new check against six real workspace repos. Only the misconfigured one fires:

| Repo | has_dev | looks_svc | check |
|---|---|---|---|
| `Augmenting-Integrations/aillc-web` | False | True | **CRITICAL** |
| `Augmenting-Integrations/ai-lls-web` | True | False | OK |
| `Augmenting-Integrations/ai-lls-api` | True | True | OK |
| `Augmenting-Integrations/landline-scrubber` | False | False | OK |
| `svange/augint-tools` | False | False | OK |
| `svange/augint-shell` | False | False | OK |

## Test plan

- [x] `uv run pytest` (698 pass)
- [x] `uv run pre-commit run --all-files` (ruff + ruff-format + mypy + uv.lock all green)
- [x] Live verification against six repos in the workspace
- [ ] Sanity check after merge: open the dashboard and confirm `aillc-web` shows the new CRITICAL alert in addition to its existing flags