### PR TITLE
feat(dashboard): refine service detection to suppress false positives

### DIFF
--- a/src/augint_tools/dashboard/_data.py
+++ b/src/augint_tools/dashboard/_data.py
@@ -80,10 +80,15 @@ def _detect_tags(
     return is_workspace, tuple(tags)
 
 
-# Root-tree files that mark a repo as a service rather than a library. Detected
+# Root-tree files that mark a repo as a deployable service. Detected
 # independently of branch layout so the dashboard can flag a service-shaped repo
 # whose dev branch has gone missing -- the actual configuration drift, not a
 # downstream symptom in the rollup state.
+#
+# ``Dockerfile`` is intentionally absent: many Python libraries ship a
+# Dockerfile for the dev container or CI runner without ever being deployed.
+# A SAM/CDK/Serverless config or a JS/web build are the unambiguous "this gets
+# deployed somewhere" signals.
 _SERVICE_MARKERS: tuple[str, ...] = (
     "template.yaml",
     "template.yml",
@@ -91,13 +96,42 @@ _SERVICE_MARKERS: tuple[str, ...] = (
     "serverless.yml",
     "serverless.yaml",
     "cdk.json",
-    "Dockerfile",
 )
 
 
-def _detect_service_markers(root_entries: tuple[str, ...]) -> tuple[str, ...]:
-    """Return the subset of canonical service-marker files present at the repo root."""
+def _is_org_repo(name: str) -> bool:
+    """AWS Organization IaC repos: name ends with ``-org``.
+
+    Org repos hold CloudFormation/SAM templates that manage the AWS Organization
+    itself (accounts, OUs, SCPs, StackSets). They are deployed to a single
+    account, never run a dev/main split, and may also publish convenience
+    Python packages off main. They are neither services nor libraries in the
+    standard sense and should be excluded from both classifications.
+    """
+    return name.endswith("-org")
+
+
+def _detect_service_markers(name: str, root_entries: tuple[str, ...]) -> tuple[str, ...]:
+    """Return the subset of service-marker files indicating a deployable service.
+
+    Returns an empty tuple for repos that look like *something other than* a
+    deployable service even when service markers are present:
+
+    - **Org repos** (``*-org``): IaC for an AWS Organization, no dev/main split.
+    - **Workspace repos** (``workspace.yaml``): meta-repos that coordinate other
+      repos, never deployed themselves.
+    - **Python packages** (``pyproject.toml`` without ``package.json``):
+      libraries published to PyPI that frequently ship a SAM template purely
+      for ephemeral test environments or CI infrastructure, not production
+      deploys.
+    """
+    if _is_org_repo(name):
+        return ()
     names = set(root_entries)
+    if "workspace.yaml" in names:
+        return ()
+    if "pyproject.toml" in names and "package.json" not in names:
+        return ()
     return tuple(marker for marker in _SERVICE_MARKERS if marker in names)
 
 
@@ -152,6 +186,10 @@ class RepoStatus:
     # Specific service-marker filenames detected at the repo root, surfaced in
     # diagnostic output for the missing-dev-branch alert.
     service_markers: tuple[str, ...] = ()
+    # AWS Organization IaC repo (name ends with ``-org``). Holds templates for
+    # the org itself and may publish convenience packages, but never runs a
+    # dev/main split -- excluded from the service-missing-dev alert.
+    is_org: bool = False
 
 
 # ---------------------------------------------------------------------------
@@ -204,7 +242,8 @@ def build_status_from_snapshot(
     open_issues = snapshot.issue_total_count
 
     is_workspace, tags = _detect_tags(snapshot.primary_language, snapshot.root_entries)
-    service_markers = _detect_service_markers(snapshot.root_entries)
+    service_markers = _detect_service_markers(snapshot.name, snapshot.root_entries)
+    is_org = _is_org_repo(snapshot.name)
 
     main_status = translate_rollup_state(snapshot.main_rollup_state)
     dev_status: str | None = (
@@ -233,6 +272,7 @@ def build_status_from_snapshot(
         has_workflows=bool(snapshot.workflow_files),
         looks_like_service=bool(service_markers),
         service_markers=service_markers,
+        is_org=is_org,
     )
 
 

--- a/src/augint_tools/dashboard/health/checks/service_missing_dev.py
+++ b/src/augint_tools/dashboard/health/checks/service_missing_dev.py
@@ -26,6 +26,16 @@ class ServiceMissingDevBranchCheck:
         config: dict,  # noqa: ARG002
         context: FetchContext,  # noqa: ARG002
     ) -> HealthCheckResult:
+        # Org repos and workspace repos legitimately don't run a dev/main
+        # split; ``looks_like_service`` already excludes them at the marker
+        # level, but guard here too so a future signal change can't accidentally
+        # start firing CRITICAL on them.
+        if status.is_org or status.is_workspace:
+            return HealthCheckResult(
+                check_name=self.name,
+                severity=Severity.OK,
+                summary="not a service repo",
+            )
         if status.looks_like_service and not status.has_dev_branch:
             markers = ", ".join(status.service_markers) or "service markers detected"
             return HealthCheckResult(

--- a/tests/unit/test_dashboard.py
+++ b/tests/unit/test_dashboard.py
@@ -1223,48 +1223,109 @@ class TestDetectTags:
 
 class TestDetectServiceMarkers:
     """Service-marker detection is independent of dev-branch existence so the
-    dashboard can flag service-shaped repos whose dev branch went missing."""
+    dashboard can flag service-shaped repos whose dev branch went missing.
+
+    Discriminators in priority order:
+      - ``-org`` repos are AWS Organization IaC, never services.
+      - workspace.yaml repos are meta-repos, never services.
+      - Python packages (pyproject.toml without package.json) frequently ship a
+        SAM template purely for ephemeral test environments / CI infra.
+      - Dockerfile alone is too noisy: many libraries ship a dev-container or
+        CI-runner Dockerfile without ever being deployed.
+    """
 
     def test_no_markers_returns_empty(self):
         from augint_tools.dashboard._data import _detect_service_markers
 
-        assert _detect_service_markers(()) == ()
-        assert _detect_service_markers(("README.md", "pyproject.toml", "src")) == ()
+        assert _detect_service_markers("repo", ()) == ()
+        assert _detect_service_markers("repo", ("README.md", "src")) == ()
 
-    def test_sam_service(self):
+    def test_web_service_with_sam(self):
         from augint_tools.dashboard._data import _detect_service_markers
 
-        markers = _detect_service_markers(("template.yaml", "samconfig.toml", "src"))
+        # package.json + SAM is the unambiguous "deployable web service" shape.
+        markers = _detect_service_markers(
+            "aillc-web", ("package.json", "template.yaml", "Dockerfile", "src")
+        )
         assert "template.yaml" in markers
-        assert "samconfig.toml" in markers
 
-    def test_dockerfile_alone_is_a_marker(self):
+    def test_dockerfile_alone_is_not_a_marker(self):
+        # Many Python libs ship a dev-container Dockerfile. Without a deploy
+        # signal alongside it, refuse to classify as a service.
         from augint_tools.dashboard._data import _detect_service_markers
 
-        assert _detect_service_markers(("Dockerfile",)) == ("Dockerfile",)
+        assert _detect_service_markers("somelib", ("Dockerfile",)) == ()
 
-    def test_cdk_marker(self):
+    def test_cdk_marker_in_node_app(self):
         from augint_tools.dashboard._data import _detect_service_markers
 
-        assert _detect_service_markers(("cdk.json",)) == ("cdk.json",)
+        assert _detect_service_markers("infra", ("cdk.json", "package.json")) == ("cdk.json",)
 
-    def test_serverless_marker(self):
+    def test_serverless_marker_in_node_app(self):
         from augint_tools.dashboard._data import _detect_service_markers
 
-        assert _detect_service_markers(("serverless.yml",)) == ("serverless.yml",)
+        assert _detect_service_markers("api", ("serverless.yml", "package.json")) == (
+            "serverless.yml",
+        )
 
-    def test_template_yml_variant(self):
+    def test_python_package_with_sam_for_testing_is_not_a_service(self):
+        # tagmania / ai-lls-lib pattern: a Python package that uses SAM only
+        # for ephemeral test environments. pyproject.toml without package.json
+        # outweighs the SAM signal.
         from augint_tools.dashboard._data import _detect_service_markers
 
-        assert _detect_service_markers(("template.yml",)) == ("template.yml",)
+        assert (
+            _detect_service_markers("tagmania", ("pyproject.toml", "template.yaml", "src", "tests"))
+            == ()
+        )
+        assert (
+            _detect_service_markers(
+                "ai-lls-lib", ("pyproject.toml", "template.yaml", "Dockerfile", "src")
+            )
+            == ()
+        )
 
-    def test_marker_detection_is_independent_of_dev_branch(self):
-        # Only the root_entries argument matters -- branch state is not consulted.
+    def test_python_with_package_json_is_a_service(self):
+        # pyproject.toml + package.json is rare but means there's a deployable
+        # frontend alongside Python infra automation -- treat as a service.
         from augint_tools.dashboard._data import _detect_service_markers
 
-        markers = _detect_service_markers(("Dockerfile", "template.yaml"))
-        assert "Dockerfile" in markers
+        markers = _detect_service_markers(
+            "fullstack", ("pyproject.toml", "package.json", "template.yaml")
+        )
         assert "template.yaml" in markers
+
+    def test_org_repo_is_never_a_service(self):
+        # augint-org pattern: AWS Organization IaC. The -org suffix flips it
+        # out of the service classification regardless of templates present.
+        from augint_tools.dashboard._data import _detect_service_markers
+
+        assert (
+            _detect_service_markers(
+                "augint-org", ("template.yaml", "stacks", "stacksets", "pyproject.toml")
+            )
+            == ()
+        )
+
+    def test_workspace_repo_is_never_a_service(self):
+        from augint_tools.dashboard._data import _detect_service_markers
+
+        assert _detect_service_markers("ws", ("workspace.yaml", "template.yaml")) == ()
+
+
+class TestIsOrgRepo:
+    def test_org_suffix(self):
+        from augint_tools.dashboard._data import _is_org_repo
+
+        assert _is_org_repo("augint-org")
+        assert _is_org_repo("woxom-org")
+
+    def test_non_org(self):
+        from augint_tools.dashboard._data import _is_org_repo
+
+        assert not _is_org_repo("aillc-web")
+        assert not _is_org_repo("augint-tools")
+        assert not _is_org_repo("org-helper")  # only the suffix counts
 
 
 class TestBootstrapCache:

--- a/tests/unit/test_health.py
+++ b/tests/unit/test_health.py
@@ -40,6 +40,8 @@ def _status(
     has_workflows=True,
     looks_like_service=False,
     service_markers=(),
+    is_org=False,
+    is_workspace=False,
 ):
     return RepoStatus(
         name=name,
@@ -57,6 +59,8 @@ def _status(
         has_workflows=has_workflows,
         looks_like_service=looks_like_service,
         service_markers=service_markers,
+        is_org=is_org,
+        is_workspace=is_workspace,
     )
 
 
@@ -389,6 +393,33 @@ class TestServiceMissingDevBranch:
         result = get_check("service_missing_dev_branch").evaluate(
             _mock_repo(),
             _status(has_dev_branch=True, looks_like_service=False),
+            config={},
+            context=_ctx(),
+        )
+        assert result.severity == Severity.OK
+
+    def test_org_repo_is_never_flagged(self):
+        # ``-org`` repos hold AWS Organization IaC, never run a dev split,
+        # and may publish convenience packages off main. Even if some future
+        # signal change set looks_like_service=True on one, the check must
+        # not fire.
+        result = get_check("service_missing_dev_branch").evaluate(
+            _mock_repo(),
+            _status(
+                is_org=True,
+                has_dev_branch=False,
+                looks_like_service=True,
+                service_markers=("template.yaml",),
+            ),
+            config={},
+            context=_ctx(),
+        )
+        assert result.severity == Severity.OK
+
+    def test_workspace_repo_is_never_flagged(self):
+        result = get_check("service_missing_dev_branch").evaluate(
+            _mock_repo(),
+            _status(is_workspace=True, has_dev_branch=False, looks_like_service=False),
             config={},
             context=_ctx(),
         )


### PR DESCRIPTION
## Summary

Tightens the structural-service heuristic introduced in #78 so it stops false-positiving on three classes of repo that aren't actually services.

- **\`-org\` repos** (e.g. \`augint-org\`): new \`is_org: bool\` on \`RepoStatus\`, set when the repo name ends with \`-org\`. AWS Organization IaC, no dev/main split. Always OK on the missing-dev check.
- **Python packages with SAM templates** (e.g. \`tagmania\`, \`ai-lls-lib\`): \`pyproject.toml\` without \`package.json\` is taken as strong evidence the repo is a publishable Python package; any SAM/CDK template is then assumed to be for ephemeral test envs / CI infra, not a production deploy.
- **Drop \`Dockerfile\` from the marker list**: too noisy on its own, lots of libs ship a dev-container Dockerfile without a deploy story. \`aillc-web\` still trips via \`template.yaml\` + \`package.json\`.
- The check itself also short-circuits to OK on org and workspace repos as a defensive guard, in case a future signal change accidentally sets \`looks_like_service=True\` on one.

## Live verification

| Repo | has_dev | looks_svc | is_org | check |
|---|---|---|---|---|
| \`Augmenting-Integrations/aillc-web\` | True | True | False | OK |
| \`Augmenting-Integrations/ai-lls-web\` | True | False | False | OK |
| \`Augmenting-Integrations/ai-lls-api\` | True | False | False | OK |
| \`Augmenting-Integrations/ai-lls-lib\` | False | False | False | OK |
| \`Augmenting-Integrations/landline-scrubber\` | False | False | False | OK |
| \`Augmenting-Integrations/augint-org\` | False | False | True | OK |
| \`svange/tagmania\` | False | False | False | OK |
| \`svange/augint-tools\` | False | False | False | OK |
| \`svange/augint-shell\` | False | False | False | OK |

\`aillc-web\` is OK because the dev branch was recreated since #78 merged, which is the exact behaviour the new check exists to incentivise.

## Test plan

- [x] \`uv run pytest\` (258 dashboard + health tests pass)
- [x] \`uv run pre-commit run --all-files\` (ruff + ruff-format + mypy + uv.lock all green)
- [x] Live verification across nine workspace repos -- zero false positives, zero false negatives