### PR TITLE
feat(dashboard): show more findings per card and let text reflow with width

### DIFF
--- a/src/augint_tools/dashboard/widgets/repo_card.py
+++ b/src/augint_tools/dashboard/widgets/repo_card.py
@@ -84,14 +84,6 @@ def _older_than(iso_ts: str | None, age: timedelta) -> bool:
     return datetime.now(UTC) - ts > age
 
 
-def _truncate(value: str | None, width: int) -> str:
-    if not value:
-        return ""
-    if len(value) <= width:
-        return value
-    return value[: max(0, width - 3)] + "..."
-
-
 class RepoCard(Widget):
     """Reactive card for a single repository."""
 
@@ -329,8 +321,14 @@ class RepoCard(Widget):
             return spec.severity_colors[Severity.LOW]
         return ""
 
-    def _findings_lines(self, health: RepoHealth, limit: int) -> list[tuple[Text, str]]:
+    def _findings_lines(self, health: RepoHealth, limit: int | None) -> list[tuple[Text, str]]:
         """Return up to ``limit`` finding rows paired with their click-target URLs.
+
+        ``limit=None`` (or any non-positive value) means no cap -- emit every
+        finding. Per-row text is left full-length; Rich's ``no_wrap=True`` +
+        ``overflow="ellipsis"`` (set in :meth:`_finalize`) trims at render time
+        based on the card's actual width, which the user can grow or shrink
+        with ctrl + mouse-wheel.
 
         When there are no real findings we still want the slot to carry useful
         signal rather than a flat "all green" string, so we emit OK-severity
@@ -341,6 +339,10 @@ class RepoCard(Widget):
         spec = self._theme_spec
         actions_url = self._actions_url(health)
         lines: list[tuple[Text, str]] = []
+
+        def _at_cap() -> bool:
+            return limit is not None and limit > 0 and len(lines) >= limit
+
         for error_label, error in (
             ("dev", health.status.dev_error),
             ("main", health.status.main_error),
@@ -348,25 +350,23 @@ class RepoCard(Widget):
             if error:
                 t = Text()
                 t.append(f"{error_label}: ", style="bold")
-                t.append(_truncate(error, 30), style=spec.severity_colors[Severity.CRITICAL])
+                t.append(error, style=spec.severity_colors[Severity.CRITICAL])
                 lines.append((t, actions_url))
-                if len(lines) >= limit:
+                if _at_cap():
                     return lines
         for finding in health.findings:
             t = Text()
             icon = spec.severity_icons.get(finding.severity, "*")
             t.append(f"{icon} ", style=self._severity_style(finding.severity, spec))
-            t.append(
-                _truncate(finding.summary, 40), style=self._severity_style(finding.severity, spec)
-            )
+            t.append(finding.summary, style=self._severity_style(finding.severity, spec))
             lines.append((t, finding.link or self._repo_url(health)))
-            if len(lines) >= limit:
+            if _at_cap():
                 return lines
         if not lines:
             lines.extend(self._healthy_info_lines(health, limit))
         return lines
 
-    def _healthy_info_lines(self, health: RepoHealth, limit: int) -> list[tuple[Text, str]]:
+    def _healthy_info_lines(self, health: RepoHealth, limit: int | None) -> list[tuple[Text, str]]:
         """Informative OK-severity rows used when this repo has zero findings.
 
         Surfaces open issues / PRs / drafts with click targets, so a green card
@@ -415,7 +415,9 @@ class RepoCard(Widget):
                     self._repo_url(health),
                 )
             )
-        return info[:limit] if limit > 0 else info
+        if limit is None or limit <= 0:
+            return info
+        return info[:limit]
 
     def _render_packed(self, health: RepoHealth) -> Text:
         self._click_map = {}
@@ -430,7 +432,7 @@ class RepoCard(Widget):
         parts.append(self._counts_line(health))
         self._click_map[len(parts)] = self._counts_click_region(health)
 
-        for line, url in self._findings_lines(health, 2):
+        for line, url in self._findings_lines(health, 3):
             parts.append(line)
             self._click_map[len(parts)] = _ClickRegion(url=url)
 
@@ -465,7 +467,9 @@ class RepoCard(Widget):
         parts.append(self._counts_line(health))
         self._click_map[len(parts)] = self._counts_click_region(health)
 
-        for line, url in self._findings_lines(health, 4):
+        # List mode is the verbose view -- no cap, every finding gets a row.
+        # Rich still ellipsises individual lines that exceed the card width.
+        for line, url in self._findings_lines(health, None):
             parts.append(line)
             self._click_map[len(parts)] = _ClickRegion(url=url)
 

--- a/tests/unit/test_dashboard.py
+++ b/tests/unit/test_dashboard.py
@@ -916,6 +916,49 @@ class TestFindingsLinesHealthyInfo:
         assert "stale" in lines[0][0].plain
         assert not any("open issues" in line.plain for line, _ in lines)
 
+    def test_limit_none_returns_all_findings(self):
+        # list-mode rendering passes limit=None: every finding should make it
+        # through. Rich handles per-line ellipsis at render time.
+        RepoCard, spec = self._spec()
+        checks = [
+            HealthCheckResult(check_name=f"chk{i}", severity=Severity.MEDIUM, summary=f"f{i}")
+            for i in range(6)
+        ]
+        status = _status(full_name="org/busy")
+        health = RepoHealth(status=status, checks=checks)
+        card = RepoCard(health, theme_spec=spec)
+        lines = card._findings_lines(health, limit=None)
+        assert len(lines) == 6
+
+    def test_limit_zero_treated_as_unlimited(self):
+        # Defensive: limit<=0 also means unlimited so callers can pass 0
+        # without accidentally suppressing every finding.
+        RepoCard, spec = self._spec()
+        checks = [
+            HealthCheckResult(check_name=f"chk{i}", severity=Severity.MEDIUM, summary=f"f{i}")
+            for i in range(3)
+        ]
+        status = _status(full_name="org/busy")
+        health = RepoHealth(status=status, checks=checks)
+        card = RepoCard(health, theme_spec=spec)
+        lines = card._findings_lines(health, limit=0)
+        assert len(lines) == 3
+
+    def test_finding_summary_is_not_pre_truncated(self):
+        # The card width controls how much text shows; the helper itself must
+        # not truncate, so resizing via ctrl+mouse-wheel can grow the visible
+        # text dynamically.
+        RepoCard, spec = self._spec()
+        long_summary = "a" * 120
+        check = HealthCheckResult(
+            check_name="renovate_enabled", severity=Severity.HIGH, summary=long_summary
+        )
+        status = _status(full_name="org/busy")
+        health = RepoHealth(status=status, checks=[check])
+        card = RepoCard(health, theme_spec=spec)
+        lines = card._findings_lines(health, limit=None)
+        assert long_summary in lines[0][0].plain
+
 
 class TestDetailDrawerHealthySummary:
     """_detail_drawer_content surfaces OK info with clickable links when green."""


### PR DESCRIPTION
## Summary

Two related card-density tweaks:

- **More findings per card**: packed mode goes from 2 to **3**, list mode goes from 4 to **unlimited**. Dense mode unchanged at 1. Findings are already sorted worst-first, so the extra rows surface real signal that was previously dropped silently.
- **Per-finding text reflows with card width**: removed the hard 30/40-char truncation from error/finding rows. Rich's existing \`no_wrap=True\` + \`overflow=ellipsis\` trims at render time using the card's actual width, so growing the card via ctrl+mouse-wheel now actually shows more text (it didn't before -- the truncate cap was independent of width).
- The unused \`_truncate\` helper in \`repo_card\` is removed.

## Test plan

- [x] \`uv run pytest\` (261 dashboard + health tests pass; three new tests cover \`limit=None\` showing all findings, \`limit=0\` treated as unlimited, and finding summaries no longer pre-truncated)
- [x] \`uv run pre-commit run --all-files\` (ruff + ruff-format + mypy + uv.lock all green)