### PR TITLE
fix(dashboard): suppress Renovate Dependency Dashboard + drawer/keybinding rework

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -176,7 +176,6 @@ jobs:
       - name: Run unit tests
         run: |
           uv run pytest \
-            -m "not tui" \
             --cov=src --cov-report=html --cov-report=xml --cov-fail-under=50 \
             --html=test-report.html --self-contained-html \
             -v

--- a/src/augint_tools/dashboard/_data.py
+++ b/src/augint_tools/dashboard/_data.py
@@ -29,7 +29,23 @@ if TYPE_CHECKING:
 CACHE_DIR = Path.home() / ".cache" / "ai-gh"
 CACHE_FILE = CACHE_DIR / "tui_cache.json"
 
-_BOT_LOGINS = {"renovate[bot]", "renovate-bot", "dependabot[bot]", "github-actions[bot]"}
+# Renovate's default "Dependency Dashboard" issue. Users don't treat it as a
+# real issue -- it's a persistent control panel -- so the dashboard excludes
+# it from open-issue counts. Customized titles (via dependencyDashboardTitle)
+# aren't matched; those repos fall through to the real count.
+_RENOVATE_DASHBOARD_TITLE = "Dependency Dashboard"
+
+
+def _is_renovate_dashboard(issue) -> bool:
+    """True if *issue* is Renovate's dependency-dashboard control-panel issue.
+
+    Uses GraphQL's ``__typename == "Bot"`` signal. Login allowlists don't
+    work because some Renovate installations report ``renovate`` as the
+    login (no ``[bot]`` suffix) while GraphQL still types the author as
+    ``Bot``.
+    """
+    title = (issue.title or "").strip()
+    return title == _RENOVATE_DASHBOARD_TITLE and getattr(issue, "author_is_bot", False)
 
 
 # ---------------------------------------------------------------------------
@@ -232,14 +248,17 @@ def build_status_from_snapshot(
     # full total as open_issues but only the first 100 contribute to the
     # human-filtered count. The warning threshold (default 10) is comfortably
     # below that cap.
-    human_issues = [i for i in snapshot.issues if (i.author_login or "") not in _BOT_LOGINS]
+    human_issues = [i for i in snapshot.issues if not getattr(i, "author_is_bot", False)]
     human_open_issues = len(human_issues)
     oldest = min((i.created_at for i in human_issues), default=None)
     oldest_iso = _to_iso_utc(oldest)
 
     # Total open issues (including bots) -- prefer the GraphQL totalCount
     # since it's authoritative even when the node list was truncated.
-    open_issues = snapshot.issue_total_count
+    # Subtract Renovate's Dependency Dashboard (at most one per repo) so a
+    # repo with only that control-panel issue open displays as zero.
+    dashboard_count = sum(1 for i in snapshot.issues if _is_renovate_dashboard(i))
+    open_issues = max(0, snapshot.issue_total_count - dashboard_count)
 
     is_workspace, tags = _detect_tags(snapshot.primary_language, snapshot.root_entries)
     service_markers = _detect_service_markers(snapshot.name, snapshot.root_entries)

--- a/src/augint_tools/dashboard/_gql.py
+++ b/src/augint_tools/dashboard/_gql.py
@@ -91,6 +91,12 @@ class IssueSnapshot:
     number: int
     created_at: datetime
     author_login: str | None
+    title: str | None = None
+    # True when GraphQL resolved ``author`` to the ``Bot`` type. This covers
+    # both canonical GitHub Apps (login ending in ``[bot]``) and self-hosted
+    # Renovate setups whose author login is just ``renovate`` -- the
+    # ``__typename`` is ``Bot`` in both cases.
+    author_is_bot: bool = False
 
 
 @dataclass
@@ -211,8 +217,9 @@ fragment RepoFields on Repository {{
     totalCount
     nodes {{
       number
+      title
       createdAt
-      author {{ login }}
+      author {{ __typename login }}
     }}
   }}
 {renovate_fields}
@@ -321,6 +328,14 @@ def _parse_repo(data: dict) -> RepoSnapshot:
     main_head_sha = main_target.get("oid") if isinstance(main_target, dict) else None
 
     dev_ref = data.get("_dev")
+    # If the repo's default branch is already "dev" (e.g. aillc-web), the
+    # defaultBranchRef and the explicit refs/heads/dev lookup resolve to the
+    # same commit. Treating them as separate branches double-counts a single
+    # failing pipeline as both "main failing" and "dev failing" in broken_ci.
+    # In that layout there is no distinct dev branch to surface, so collapse
+    # it into the default-branch slot only.
+    if default_branch == "dev":
+        dev_ref = None
     has_dev_branch = dev_ref is not None
     dev_target = (dev_ref or {}).get("target") or {} if isinstance(dev_ref, dict) else {}
     dev_rollup_state = _resolve_rollup_state(dev_target)
@@ -379,13 +394,21 @@ def _parse_repo(data: dict) -> RepoSnapshot:
         if not isinstance(issue, dict):
             continue
         author = issue.get("author") or {}
-        author_login = author.get("login") if isinstance(author, dict) else None
+        if isinstance(author, dict):
+            author_login = author.get("login")
+            author_is_bot = author.get("__typename") == "Bot"
+        else:
+            author_login = None
+            author_is_bot = False
         ts = _parse_ts(issue.get("createdAt")) or datetime.now(UTC)
+        title = issue.get("title")
         issues.append(
             IssueSnapshot(
                 number=int(issue.get("number") or 0),
                 created_at=ts,
                 author_login=author_login,
+                title=title if isinstance(title, str) else None,
+                author_is_bot=author_is_bot,
             )
         )
 

--- a/src/augint_tools/dashboard/app.py
+++ b/src/augint_tools/dashboard/app.py
@@ -505,8 +505,20 @@ class MainScreen(Screen[None]):
             self._aws_drawer.open()
 
     def cycle_top_drawer(self) -> None:
-        """Alias for toggle_org_drawer (SHIFT+W)."""
+        """Alias for toggle_org_drawer (w key)."""
         self.toggle_org_drawer()
+
+    def toggle_system_drawer(self) -> None:
+        """Direct open/close for the system drawer (``s`` key)."""
+        if self._system_drawer.is_open:
+            self._system_drawer.close()
+            return
+        # Close the detail drawer if it happens to be open; the two share
+        # the right side and can't both be visible.
+        if self._drawer.is_open:
+            self._drawer.close()
+        self._system_drawer.refresh_content(self._state)
+        self._system_drawer.open()
 
     def refresh_system_drawer(self) -> None:
         """Update the system drawer content if it is open."""
@@ -1225,20 +1237,23 @@ class DashboardApp(App[None]):
 
     BINDINGS = [
         Binding("q", "quit", "Quit"),
+        Binding("ctrl+c", "quit", show=False),
         Binding("r", "refresh_now", "Refresh"),
-        Binding("s", "cycle_sort", "Sort"),
-        Binding("f", "open_filter_panel", "Filter"),
-        Binding("g", "cycle_layout", "Layout"),
-        Binding("t", "cycle_theme", "Theme"),
-        Binding("b", "toggle_flash", "Blink"),
-        Binding("d", "toggle_drawer", "Detail"),
-        Binding("i", "toggle_org", "Org"),
+        Binding("1", "open_filter_panel", "Filter"),
+        Binding("2", "cycle_sort", "Sort"),
+        Binding("3", "cycle_layout", "Layout"),
+        Binding("4", "cycle_theme", "Theme"),
+        Binding("5", "toggle_flash", "Blink"),
         Binding("e", "toggle_errors", "Errors"),
+        Binding("a", "cycle_left_drawer", "AWS"),
+        Binding("w", "cycle_top_drawer", "Org"),
+        Binding("s", "toggle_system_drawer", "System"),
+        Binding("d", "cycle_right_drawer", "Drawer"),
+        # Displaced from lowercase `w` when the org drawer claimed it; keep
+        # a hidden alias so the workspace-hide toggle doesn't disappear.
+        Binding("W", "toggle_hide_workspace", "Workspace", show=False),
+        Binding("i", "toggle_org", "Org", show=False),
         Binding("E", "clear_errors", "Clear Errors", show=False),
-        Binding("D", "cycle_right_drawer", "Drawer", show=False),
-        Binding("A", "cycle_left_drawer", "AWS", show=False),
-        Binding("W", "cycle_top_drawer", "Org", show=False),
-        Binding("w", "toggle_hide_workspace", "Workspace"),
         Binding("m", "manage_repos", "Repos"),
         Binding("O", "manage_orgs", "Orgs"),
         Binding("question_mark", "show_help", "Help"),
@@ -1246,13 +1261,6 @@ class DashboardApp(App[None]):
         Binding("plus", "widen_card", "Wider", show=False),
         Binding("equals_sign", "widen_card", show=False),
         Binding("minus", "narrow_card", "Narrower", show=False),
-        Binding("1", "quit", show=False),
-        Binding("2", "refresh_now", show=False),
-        Binding("3", "cycle_sort", show=False),
-        Binding("4", "open_filter_panel", show=False),
-        Binding("5", "cycle_layout", show=False),
-        Binding("6", "cycle_theme", show=False),
-        Binding("7", "toggle_flash", show=False),
         Binding("enter", "open_selected", show=False, priority=True),
         Binding("o", "open_selected_browser", show=False, priority=True),
         Binding("down", "move_down", show=False, priority=True),
@@ -1369,6 +1377,14 @@ class DashboardApp(App[None]):
         bootstrap_from_cache(self.state, restrict_to=restrict)
         apply_open_source_team(self.state)
 
+        # Seed the AWS drawer from the on-disk cache so opening it doesn't
+        # stare at "loading..." while subprocesses fan out.
+        from .awsprobe import load_aws_cache
+
+        cached_aws = load_aws_cache()
+        if cached_aws is not None:
+            self.state.aws_state = cached_aws
+
         self._main = MainScreen(
             self.state,
             self._org_name,
@@ -1397,8 +1413,10 @@ class DashboardApp(App[None]):
         self.set_interval(_FLASH_TICK_SECONDS, self._tick_flash)
         # Probe host RAM / GPU in the background: once at startup so the
         # first org-drawer open already shows numbers, then every 3s while
-        # the drawer is visible (see ``_tick_sysmeter``).
-        self._refresh_sysmeter()
+        # the drawer is visible (see ``_tick_sysmeter``). Suppressed when
+        # ``skip_refresh`` is set so Pilot tests don't spawn the worker.
+        if not self._skip_refresh:
+            self._refresh_sysmeter()
         self.set_interval(3.0, self._tick_sysmeter)
 
         # System probe (CPU, docker, network): refresh every 5s while the
@@ -1907,19 +1925,29 @@ class DashboardApp(App[None]):
     # ---- AWS probe worker ----
 
     def _refresh_aws_probe(self) -> None:
-        """Kick a background AWS probe."""
-        self.run_worker(self._refresh_aws_probe_sync, thread=True, exit_on_error=False)
+        """Refresh AWS profile status from on-disk state.
 
-    def _refresh_aws_probe_sync(self) -> None:
-        from .awsprobe import probe_aws
+        Runs synchronously on the UI thread: the local probe reads
+        ``~/.aws/config`` and ``~/.aws/sso/cache`` only and finishes in
+        well under one frame, so there's no reason to hand off to a
+        worker. The previous worker-based path was firing per-profile
+        ``aws sts`` subprocesses, which is what made opening the drawer
+        feel like the UI had frozen.
+        """
+        from .awsprobe import probe_aws_local, save_aws_cache
 
         try:
-            aws_state = probe_aws()
+            aws_state = probe_aws_local(previous_state=self.state.aws_state)
         except Exception as exc:
             self.state.log_error("awsprobe", f"{exc.__class__.__name__}: {exc}")
+            self._update_aws_drawer()
             return
         self.state.aws_state = aws_state
-        self.call_from_thread(self._update_aws_drawer)
+        try:
+            save_aws_cache(aws_state)
+        except OSError as exc:
+            self.state.log_error("awsprobe", f"cache save failed: {exc}")
+        self._update_aws_drawer()
 
     def _update_aws_drawer(self) -> None:
         if self._main is not None:
@@ -2080,8 +2108,16 @@ class DashboardApp(App[None]):
             self._refresh_aws_probe()
 
     def action_cycle_top_drawer(self) -> None:
-        """SHIFT+W alias for toggle_org."""
+        """``w`` alias for toggle_org."""
         self.action_toggle_org()
+
+    def action_toggle_system_drawer(self) -> None:
+        """``s`` key: open/close the system drawer directly."""
+        if self._main is None:
+            return
+        self._main.toggle_system_drawer()
+        if self._main._system_drawer.is_open:
+            self._refresh_system_probe()
 
     def action_widen_card(self) -> None:
         self._resize_card(+PANEL_WIDTH_STEP)

--- a/src/augint_tools/dashboard/awsprobe.py
+++ b/src/augint_tools/dashboard/awsprobe.py
@@ -10,11 +10,14 @@ import json
 import re
 import shutil
 import subprocess
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 
 _PROFILE_NAME_RE = re.compile(r"^[a-zA-Z0-9._-]+$")
+
+_CACHE_DIR = Path.home() / ".cache" / "ai-gh"
+_CACHE_FILE = _CACHE_DIR / "aws_cache.json"
 
 
 @dataclass(frozen=True)
@@ -59,7 +62,11 @@ def _is_safe_profile_name(name: str) -> bool:
 def _parse_config_for_profile(
     config: configparser.ConfigParser, profile_name: str
 ) -> dict[str, str | None]:
-    """Extract SSO and region fields from the parsed config for a profile."""
+    """Extract SSO and region fields from the parsed config for a profile.
+
+    Resolves ``sso_session`` indirection used by newer AWS CLI v2 configs,
+    where the start URL lives in a ``[sso-session NAME]`` section.
+    """
     section = "default" if profile_name == "default" else f"profile {profile_name}"
     result: dict[str, str | None] = {
         "region": None,
@@ -72,7 +79,66 @@ def _parse_config_for_profile(
         result["sso_start_url"] = config.get(section, "sso_start_url", fallback=None)
         result["sso_account_id"] = config.get(section, "sso_account_id", fallback=None)
         result["sso_role_name"] = config.get(section, "sso_role_name", fallback=None)
+        if result["sso_start_url"] is None:
+            sso_session = config.get(section, "sso_session", fallback=None)
+            if sso_session:
+                session_section = f"sso-session {sso_session}"
+                if config.has_section(session_section):
+                    result["sso_start_url"] = config.get(
+                        session_section, "sso_start_url", fallback=None
+                    )
     return result
+
+
+def _load_sso_token_cache() -> dict[str, str]:
+    """Return ``startUrl -> expiresAt`` from ``~/.aws/sso/cache``.
+
+    Used to short-circuit the sts round-trip for profiles whose SSO token
+    is already expired locally. The expiresAt is kept as the raw string
+    from AWS so parsing errors stay isolated to :func:`_sso_token_expired`.
+    """
+    cache_dir = Path.home() / ".aws" / "sso" / "cache"
+    result: dict[str, str] = {}
+    if not cache_dir.is_dir():
+        return result
+    for path in cache_dir.glob("*.json"):
+        try:
+            data = json.loads(path.read_text())
+        except (OSError, json.JSONDecodeError):
+            continue
+        start_url = data.get("startUrl")
+        expires_at = data.get("expiresAt")
+        if isinstance(start_url, str) and isinstance(expires_at, str):
+            result[start_url] = expires_at
+    return result
+
+
+def _sso_token_expired(expires_at_iso: str) -> bool:
+    """Return True if the ISO timestamp is already in the past (or unparseable)."""
+    try:
+        s = expires_at_iso.replace("UTC", "+00:00").replace("Z", "+00:00")
+        expires = datetime.fromisoformat(s)
+    except (ValueError, TypeError):
+        return True
+    if expires.tzinfo is None:
+        expires = expires.replace(tzinfo=UTC)
+    return expires <= datetime.now(UTC)
+
+
+def _make_profile(
+    name: str, cfg: dict[str, str | None], status: str, error: str | None
+) -> AwsProfile:
+    return AwsProfile(
+        name=name,
+        region=cfg["region"],
+        sso_start_url=cfg["sso_start_url"],
+        sso_account_id=cfg["sso_account_id"],
+        sso_role_name=cfg["sso_role_name"],
+        account_id=None,
+        user_arn=None,
+        status=status,
+        error=error,
+    )
 
 
 def list_aws_profiles() -> list[str]:
@@ -102,169 +168,117 @@ def list_aws_profiles() -> list[str]:
     return sorted(profiles)
 
 
-def check_profile_status(profile_name: str) -> AwsProfile:
-    """Check the session status of a single AWS profile.
+def probe_aws_local(previous_state: AwsState | None = None) -> AwsState:
+    """Resolve AWS profile statuses purely from on-disk state.
 
-    Runs ``aws sts get-caller-identity`` with a 5-second timeout.
+    Fires zero subprocesses, so this finishes in single-digit milliseconds
+    regardless of profile count. Status is derived entirely from
+    ``~/.aws/config`` and ``~/.aws/sso/cache``:
+
+    * SSO profile + no local token        -> ``expired``
+    * SSO profile + token past expiresAt  -> ``expired``
+    * SSO profile + token still valid     -> ``active``
+    * Non-SSO profile                     -> carry previous status forward,
+                                             or ``unknown`` if we've never
+                                             successfully verified it
+
+    ``account_id`` / ``user_arn`` are carried forward from *previous_state*
+    when available (they can only be populated by a prior sts call, but
+    they rarely change so cached values are fine for display).
     """
-    # Read config metadata regardless of CLI availability
+    cli_available = _is_aws_cli_available()
+    profile_names = list_aws_profiles()
+
     config_path = _aws_config_path()
     config = configparser.ConfigParser()
     try:
         config.read(str(config_path))
     except configparser.Error:
         pass
-    cfg = _parse_config_for_profile(config, profile_name)
 
-    # Validate profile name before passing to subprocess
-    if not _is_safe_profile_name(profile_name):
-        return AwsProfile(
-            name=profile_name,
-            region=cfg["region"],
-            sso_start_url=cfg["sso_start_url"],
-            sso_account_id=cfg["sso_account_id"],
-            sso_role_name=cfg["sso_role_name"],
-            account_id=None,
-            user_arn=None,
-            status="error",
-            error=f"Invalid profile name: {profile_name}",
-        )
+    sso_tokens = _load_sso_token_cache() if cli_available else {}
+    previous_map: dict[str, AwsProfile] = {}
+    if previous_state is not None:
+        previous_map = {p.name: p for p in previous_state.profiles}
 
-    if not _is_aws_cli_available():
-        return AwsProfile(
-            name=profile_name,
-            region=cfg["region"],
-            sso_start_url=cfg["sso_start_url"],
-            sso_account_id=cfg["sso_account_id"],
-            sso_role_name=cfg["sso_role_name"],
-            account_id=None,
-            user_arn=None,
-            status="unknown",
-            error="aws CLI not found",
-        )
+    results: list[AwsProfile] = []
+    for name in profile_names:
+        cfg = _parse_config_for_profile(config, name)
+        prev = previous_map.get(name)
 
-    try:
-        result = subprocess.run(  # noqa: S603
-            [
-                "aws",
-                "sts",
-                "get-caller-identity",
-                "--profile",
-                profile_name,
-                "--output",
-                "json",
-            ],
-            capture_output=True,
-            text=True,
-            timeout=5,
-        )
-    except subprocess.TimeoutExpired:
-        return AwsProfile(
-            name=profile_name,
-            region=cfg["region"],
-            sso_start_url=cfg["sso_start_url"],
-            sso_account_id=cfg["sso_account_id"],
-            sso_role_name=cfg["sso_role_name"],
-            account_id=None,
-            user_arn=None,
-            status="error",
-            error="Timed out after 5s",
-        )
+        if not cli_available:
+            results.append(_make_profile(name, cfg, "unknown", "aws CLI not found"))
+            continue
 
-    if result.returncode == 0:
-        try:
-            data = json.loads(result.stdout)
-        except json.JSONDecodeError:
-            return AwsProfile(
-                name=profile_name,
+        sso_url = cfg["sso_start_url"]
+        if sso_url is None:
+            # Non-SSO profile: local state can't tell us anything. Preserve
+            # the previous probe's result so the drawer doesn't regress to
+            # "unknown" just because we stopped hitting sts.
+            if prev is not None:
+                results.append(prev)
+            else:
+                results.append(_make_profile(name, cfg, "unknown", "not verified"))
+            continue
+
+        token_expiry = sso_tokens.get(sso_url)
+        if token_expiry is None:
+            results.append(_make_profile(name, cfg, "expired", "no SSO token cached"))
+            continue
+        if _sso_token_expired(token_expiry):
+            results.append(_make_profile(name, cfg, "expired", "SSO token expired"))
+            continue
+
+        # Token is valid. Carry forward any previously verified identity
+        # fields so the drawer can still show account/arn next to the name.
+        account_id = prev.account_id if prev is not None else None
+        user_arn = prev.user_arn if prev is not None else None
+        results.append(
+            AwsProfile(
+                name=name,
                 region=cfg["region"],
-                sso_start_url=cfg["sso_start_url"],
+                sso_start_url=sso_url,
                 sso_account_id=cfg["sso_account_id"],
                 sso_role_name=cfg["sso_role_name"],
-                account_id=None,
-                user_arn=None,
-                status="error",
-                error="Failed to parse sts response",
+                account_id=account_id,
+                user_arn=user_arn,
+                status="active",
+                error=None,
             )
-        return AwsProfile(
-            name=profile_name,
-            region=cfg["region"],
-            sso_start_url=cfg["sso_start_url"],
-            sso_account_id=cfg["sso_account_id"],
-            sso_role_name=cfg["sso_role_name"],
-            account_id=data.get("Account"),
-            user_arn=data.get("Arn"),
-            status="active",
-            error=None,
         )
 
-    # Determine whether it's an expired token or some other error
-    stderr = result.stderr or ""
-    if "expired" in stderr.lower() or "sso session" in stderr.lower():
-        status = "expired"
-    else:
-        status = "error"
-
-    return AwsProfile(
-        name=profile_name,
-        region=cfg["region"],
-        sso_start_url=cfg["sso_start_url"],
-        sso_account_id=cfg["sso_account_id"],
-        sso_role_name=cfg["sso_role_name"],
-        account_id=None,
-        user_arn=None,
-        status=status,
-        error=stderr.strip() or "Unknown error",
-    )
-
-
-def probe_aws(profiles: list[str] | None = None) -> AwsState:
-    """Probe AWS profiles and return aggregate state.
-
-    If *profiles* is None, discovers them via :func:`list_aws_profiles`.
-    """
-    cli_available = _is_aws_cli_available()
-
-    if profiles is None:
-        profiles = list_aws_profiles()
-
-    if not cli_available:
-        # Still parse config metadata but mark everything unknown
-        config_path = _aws_config_path()
-        config = configparser.ConfigParser()
-        try:
-            config.read(str(config_path))
-        except configparser.Error:
-            pass
-
-        aws_profiles: list[AwsProfile] = []
-        for name in profiles:
-            cfg = _parse_config_for_profile(config, name)
-            aws_profiles.append(
-                AwsProfile(
-                    name=name,
-                    region=cfg["region"],
-                    sso_start_url=cfg["sso_start_url"],
-                    sso_account_id=cfg["sso_account_id"],
-                    sso_role_name=cfg["sso_role_name"],
-                    account_id=None,
-                    user_arn=None,
-                    status="unknown",
-                    error="aws CLI not found",
-                )
-            )
-        return AwsState(
-            profiles=tuple(aws_profiles),
-            aws_cli_available=False,
-            last_check_at=datetime.now(UTC).isoformat(),
-        )
-
-    checked = [check_profile_status(name) for name in profiles]
     return AwsState(
-        profiles=tuple(checked),
-        aws_cli_available=True,
+        profiles=tuple(results),
+        aws_cli_available=cli_available,
         last_check_at=datetime.now(UTC).isoformat(),
     )
+
+
+def save_aws_cache(state: AwsState) -> None:
+    """Persist AwsState to disk so the drawer paints instantly on next start."""
+    _CACHE_DIR.mkdir(parents=True, exist_ok=True)
+    data = {
+        "profiles": [asdict(p) for p in state.profiles],
+        "aws_cli_available": state.aws_cli_available,
+        "last_check_at": state.last_check_at,
+    }
+    _CACHE_FILE.write_text(json.dumps(data, indent=2))
+
+
+def load_aws_cache() -> AwsState | None:
+    """Return the last persisted AwsState, or ``None`` if unavailable."""
+    if not _CACHE_FILE.exists():
+        return None
+    try:
+        data = json.loads(_CACHE_FILE.read_text())
+        profiles = tuple(AwsProfile(**p) for p in data.get("profiles", []))
+        return AwsState(
+            profiles=profiles,
+            aws_cli_available=bool(data.get("aws_cli_available", False)),
+            last_check_at=data.get("last_check_at"),
+        )
+    except (json.JSONDecodeError, TypeError, KeyError):
+        return None
 
 
 def launch_sso_login(profile_name: str) -> bool:

--- a/src/augint_tools/dashboard/health/checks/coverage.py
+++ b/src/augint_tools/dashboard/health/checks/coverage.py
@@ -10,13 +10,15 @@ for signals that the coverage gate has been **actively weakened**:
   or shell suffixes such as ``|| true``, ``|| :``, ``|| echo ...``. Severity MEDIUM.
 - Python ``pytest --cov`` with no ``--cov-fail-under`` gate at all. Severity LOW
   (equivalent to a 0% threshold).
+- ``unit-tests`` job present but no coverage command inside it. Severity LOW --
+  the repo adopted the standardized job name but the gate is missing, which
+  is a regression from standard, not non-adoption.
 
-**Non-adoption is benign.** Repos that haven't adopted the
-ai-standardize-pipeline convention (no pipeline.yaml, or pipeline.yaml with
-no ``unit-tests`` job, or unit-tests job with no coverage command) return
-OK severity with an informative summary. This is observational, not a
-warning -- a repo is not "unhealthy" just because it doesn't follow the
-standard naming convention for its workflow files.
+**True non-adoption is benign.** Repos with no ``pipeline.yaml`` at all, or
+with a ``pipeline.yaml`` that has no ``unit-tests`` job, return OK severity
+with an informative summary. This is observational, not a warning -- a repo
+is not "unhealthy" just because it doesn't follow the standard naming
+convention for its workflow files.
 
 For Node repos using ``vitest``/``jest --coverage`` the threshold lives in
 ``vitest.config.*``/``jest.config.*`` rather than the workflow, so this check
@@ -122,10 +124,13 @@ class CoverageCheck:
 
         steps = unit_tests.get("steps")
         if not isinstance(steps, list):
+            # unit-tests job exists but is empty/malformed -- the standard was
+            # adopted in name but no gate is actually running.
             return HealthCheckResult(
                 check_name=self.name,
-                severity=Severity.OK,
-                summary="unit-tests has no steps",
+                severity=Severity.LOW,
+                summary="unit-tests job has no steps",
+                link=workflow_link,
             )
 
         return self._evaluate_steps(steps, workflow_link)
@@ -171,10 +176,16 @@ class CoverageCheck:
                 has_node_coverage = True
 
         if not coverage_seen:
+            # unit-tests job exists but runs no coverage command. Either a
+            # wrapper hides the real invocation (make/tox/nox/script) or the
+            # gate was stripped. Either way, from the dashboard's vantage
+            # point the coverage posture is unverifiable -- flag as LOW so
+            # the repo surfaces for inspection.
             return HealthCheckResult(
                 check_name=self.name,
-                severity=Severity.OK,
-                summary="no coverage command in unit-tests",
+                severity=Severity.LOW,
+                summary="unit-tests job has no coverage command",
+                link=workflow_link,
             )
 
         # Ignoring failures is worse than lowering the bar: still run tests,

--- a/src/augint_tools/dashboard/health/checks/renovate_prs.py
+++ b/src/augint_tools/dashboard/health/checks/renovate_prs.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
     from ..._data import RepoStatus
     from .. import FetchContext
 
-_RENOVATE_LOGINS = {"renovate[bot]", "renovate-bot"}
+_RENOVATE_LOGINS = {"renovate[bot]", "renovate-bot", "renovate"}
 
 
 class RenovatePRsPilingCheck:

--- a/src/augint_tools/dashboard/health/checks/stale_prs.py
+++ b/src/augint_tools/dashboard/health/checks/stale_prs.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
     from ..._data import RepoStatus
     from .. import FetchContext
 
-_RENOVATE_LOGINS = {"renovate[bot]", "renovate-bot"}
+_RENOVATE_LOGINS = {"renovate[bot]", "renovate-bot", "renovate"}
 
 
 class StalePRsCheck:

--- a/src/augint_tools/dashboard/screens/help.py
+++ b/src/augint_tools/dashboard/screens/help.py
@@ -17,25 +17,32 @@ Navigation
 
 Data
   r                   Refresh now
-  s                   Cycle sort (health, alpha, problem)
-  f                   Open filter panel (multi-select)
+  1                   Open filter panel (multi-select)
+  2                   Cycle sort (health, alpha, problem)
   m                   Manage repos (enable/disable)
   O                   Manage organizations (add/remove)
-  w                   Hide/show workspace repos
+  W                   Hide/show workspace repos
 
 Layouts and themes
-  g                   Cycle layout (packed, grouped, severity, dense, list)
-  t                   Cycle theme
+  3                   Cycle layout (packed, grouped, severity, dense, list)
+  4                   Cycle theme
+  5                   Toggle flash/blink
   ctrl + scroll       Resize card width
 
 Overlays
-  d                   Repo detail drawer
-  u                   Usage breakdown drawer
+  a                   AWS profile drawer
+  w                   Org drawer
+  s                   System drawer (CPU, docker, network)
+  d                   Repo detail / system drawer (cycle)
   e                   Toggle error drawer
   E                   Clear errors
   ?                   This help
   /                   Command palette
   esc                 Dismiss
+
+Quit
+  q                   Quit
+  ctrl+c              Quit
 
 Development
   F5                  Full restart (re-exec process)

--- a/src/augint_tools/dashboard/widgets/aws_drawer.py
+++ b/src/augint_tools/dashboard/widgets/aws_drawer.py
@@ -89,8 +89,7 @@ class AwsDrawer(Container):
             self._body.update(t)
             return
 
-        # Track which line each profile is on for click handling
-        line_index = 2  # After "AWS Profiles\n\n"
+        line_index = 2
         for profile in aws_state.profiles:
             self._profile_lines.append((line_index, profile.name))
             self._append_profile_line(t, profile)
@@ -100,7 +99,7 @@ class AwsDrawer(Container):
         if aws_state.last_check_at:
             t.append(f"  checked: {aws_state.last_check_at[:19]}\n", style="dim")
         t.append("\n  click expired profiles to launch SSO login.\n", style="dim")
-        t.append("  press A to close.", style="dim")
+        t.append("  press a to close.", style="dim")
         self._body.update(t)
 
     def _append_profile_line(self, t: Text, profile: AwsProfile) -> None:

--- a/src/augint_tools/dashboard/widgets/dashboard_footer.py
+++ b/src/augint_tools/dashboard/widgets/dashboard_footer.py
@@ -11,24 +11,25 @@ from textual.containers import Horizontal
 from textual.events import Click
 from textual.widgets import Static
 
-# Functional keys shown on the left with [N] numbering.
+# Functional keys shown on the left.
 # (key_char, label, action_name)
 _LEFT_KEYS: list[tuple[str, str, str]] = [
     ("q", "Quit", "quit"),
     ("r", "Refresh", "refresh_now"),
-    ("s", "Sort", "cycle_sort"),
-    ("f", "Filter", "open_filter_panel"),
-    ("g", "Layout", "cycle_layout"),
-    ("t", "Theme", "cycle_theme"),
-    ("b", "Blink", "toggle_flash"),
+    ("1", "Filter", "open_filter_panel"),
+    ("2", "Sort", "cycle_sort"),
+    ("3", "Layout", "cycle_layout"),
+    ("4", "Theme", "cycle_theme"),
+    ("5", "Blink", "toggle_flash"),
 ]
 
-# Drawer/panel keys shown on the right without numbering.
+# Drawer/panel keys shown on the right.
 # (key_char, label, action_name)
 _RIGHT_KEYS: list[tuple[str, str, str]] = [
-    ("W", "Org", "cycle_top_drawer"),
-    ("A", "AWS", "cycle_left_drawer"),
-    ("D", "Drawer", "cycle_right_drawer"),
+    ("w", "Org", "cycle_top_drawer"),
+    ("a", "AWS", "cycle_left_drawer"),
+    ("s", "System", "toggle_system_drawer"),
+    ("d", "Drawer", "cycle_right_drawer"),
     ("e", "Errors", "toggle_errors"),
     ("?", "Help", "show_help"),
 ]
@@ -58,14 +59,12 @@ class _FooterItem(Static):
 
 
 def _build_left_items() -> list[_FooterItem]:
-    """Create clickable items for the left (numbered) section."""
+    """Create clickable items for the left section."""
     items: list[_FooterItem] = []
-    for i, (key, label, action) in enumerate(_LEFT_KEYS, 1):
+    for i, (key, label, action) in enumerate(_LEFT_KEYS):
         txt = Text()
-        if i > 1:
+        if i > 0:
             txt.append(" ")
-        txt.append(f"[{i}]", style="dim")
-        txt.append(" ")
         txt.append(key, style="bold")
         txt.append(f" {label}")
         items.append(_FooterItem(txt, action))

--- a/src/augint_tools/dashboard/widgets/system_drawer.py
+++ b/src/augint_tools/dashboard/widgets/system_drawer.py
@@ -80,7 +80,7 @@ class SystemDrawer(Container):
         self._append_gpu(t, state)
         self._append_docker(t, state)
         self._append_network(t, state)
-        t.append("\npress D to close, click Docker to filter.", style="dim")
+        t.append("\npress s to close, click Docker to filter.", style="dim")
         self._body.update(t)
 
     def _append_cpu(self, t: Text, state: AppState) -> None:

--- a/tests/unit/test_dashboard.py
+++ b/tests/unit/test_dashboard.py
@@ -506,7 +506,7 @@ class TestDashboardPilot:
             async with app.run_test() as pilot:
                 await pilot.pause()
                 start = app.state.layout_name
-                await pilot.press("g")
+                await pilot.press("3")
                 await pilot.pause()
                 assert app.state.layout_name != start
                 assert app.state.layout_name in list_layouts()
@@ -520,7 +520,7 @@ class TestDashboardPilot:
             async with app.run_test() as pilot:
                 await pilot.pause()
                 start = app.state.theme_name
-                await pilot.press("t")
+                await pilot.press("4")
                 await pilot.pause()
                 assert app.state.theme_name != start
 
@@ -533,26 +533,36 @@ class TestDashboardPilot:
             async with app.run_test() as pilot:
                 await pilot.pause()
                 start = app.state.sort_mode
-                await pilot.press("s")
+                await pilot.press("2")
                 await pilot.pause()
                 assert app.state.sort_mode != start
 
         asyncio.run(run())
 
     def test_drawer_toggle(self):
+        # `d` now cycles through the right-side drawers: none -> detail ->
+        # system -> none. This test exercises the full cycle.
         async def run():
             app = DashboardApp(repos=[], skip_refresh=True)
             _seed_state(app)
             async with app.run_test() as pilot:
                 await pilot.pause()
                 drawer = app.query_one("#drawer")
+                system_drawer = app.query_one("#system-drawer")
                 assert not drawer.has_class("open")
+                assert not system_drawer.has_class("open")
                 await pilot.press("d")
                 await pilot.pause()
                 assert drawer.has_class("open")
+                assert not system_drawer.has_class("open")
                 await pilot.press("d")
                 await pilot.pause()
                 assert not drawer.has_class("open")
+                assert system_drawer.has_class("open")
+                await pilot.press("d")
+                await pilot.pause()
+                assert not drawer.has_class("open")
+                assert not system_drawer.has_class("open")
 
         asyncio.run(run())
 
@@ -622,7 +632,7 @@ class TestDashboardActions:
             async with app.run_test() as pilot:
                 await pilot.pause()
                 assert not app.state.active_filters
-                await pilot.press("f")
+                await pilot.press("1")
                 await pilot.pause()
                 # Panel is now open -- dismiss it
                 await pilot.press("escape")

--- a/tests/unit/test_gql.py
+++ b/tests/unit/test_gql.py
@@ -195,6 +195,100 @@ class TestParseResponse:
         assert snap.has_dev_branch
         assert snap.dev_rollup_state == "FAILURE"
 
+    def test_dev_as_default_branch_not_double_counted(self):
+        # aillc-web-style layout: dev IS the default branch and a separate
+        # refs/heads/dev lookup aliases the same commit. Surfacing both would
+        # make broken_ci fire twice on a single failing pipeline.
+        payload = _graphql_repo_payload(
+            full_name="org/web",
+            has_dev=True,
+            main_state="FAILURE",
+            dev_state="FAILURE",
+        )
+        payload["defaultBranchRef"]["name"] = "dev"
+        response = {"data": {"r0": payload}}
+        snapshots, _, _ = parse_response(response, [_mock_repo("org/web")])
+        snap = snapshots["org/web"]
+        assert snap.default_branch == "dev"
+        assert snap.main_rollup_state == "FAILURE"
+        assert snap.has_dev_branch is False
+        assert snap.dev_rollup_state is None
+
+    def test_renovate_dependency_dashboard_excluded_from_open_issues(self):
+        # A repo whose only open issue is Renovate's "Dependency Dashboard"
+        # control-panel issue should display as having zero open issues.
+        # Real GraphQL returns author.__typename == "Bot" for the bot App.
+        from augint_tools.dashboard._data import build_status_from_snapshot
+
+        payload = _graphql_repo_payload(
+            full_name="org/a",
+            issue_nodes=[
+                {
+                    "number": 1,
+                    "title": "Dependency Dashboard",
+                    "createdAt": "2026-04-01T10:00:00Z",
+                    "author": {"__typename": "Bot", "login": "renovate[bot]"},
+                }
+            ],
+            issue_total=1,
+        )
+        response = {"data": {"r0": payload}}
+        snapshots, _, _ = parse_response(response, [_mock_repo("org/a")])
+        snap = snapshots["org/a"]
+        assert snap.issue_total_count == 1
+        assert snap.issues[0].title == "Dependency Dashboard"
+        assert snap.issues[0].author_is_bot is True
+        status = build_status_from_snapshot(snap)
+        assert status.open_issues == 0
+        assert status.human_open_issues == 0
+
+    def test_dependency_dashboard_from_bare_login_renovate_excluded(self):
+        # Real data from svange/augint-shell issue #3: author __typename is
+        # "Bot" but login is just "renovate" (no [bot] suffix). Earlier
+        # login-based filtering missed this.
+        from augint_tools.dashboard._data import build_status_from_snapshot
+
+        payload = _graphql_repo_payload(
+            full_name="org/a",
+            issue_nodes=[
+                {
+                    "number": 3,
+                    "title": "Dependency Dashboard",
+                    "createdAt": "2026-04-01T10:00:00Z",
+                    "author": {"__typename": "Bot", "login": "renovate"},
+                }
+            ],
+            issue_total=1,
+        )
+        response = {"data": {"r0": payload}}
+        snapshots, _, _ = parse_response(response, [_mock_repo("org/a")])
+        status = build_status_from_snapshot(snapshots["org/a"])
+        assert status.open_issues == 0
+        assert status.human_open_issues == 0
+
+    def test_dependency_dashboard_only_suppressed_when_authored_by_bot(self):
+        # A human-authored issue titled "Dependency Dashboard" still counts,
+        # so a real issue with that title is never silently hidden.
+        from augint_tools.dashboard._data import build_status_from_snapshot
+
+        payload = _graphql_repo_payload(
+            full_name="org/a",
+            issue_nodes=[
+                {
+                    "number": 2,
+                    "title": "Dependency Dashboard",
+                    "createdAt": "2026-04-01T10:00:00Z",
+                    "author": {"__typename": "User", "login": "alice"},
+                }
+            ],
+            issue_total=1,
+        )
+        response = {"data": {"r0": payload}}
+        snapshots, _, _ = parse_response(response, [_mock_repo("org/a")])
+        status = build_status_from_snapshot(snapshots["org/a"])
+        assert status.open_issues == 1
+        assert status.human_open_issues == 1
+
     def test_pr_fields_parsed(self):
         payload = _graphql_repo_payload(
             full_name="org/a",

--- a/tests/unit/test_health.py
+++ b/tests/unit/test_health.py
@@ -806,10 +806,27 @@ jobs:
         assert "not standardized" in result.summary
         assert "unit-tests" in result.summary
 
-    def test_missing_coverage_command_is_ok(self):
+    def test_missing_coverage_command_is_low(self):
+        # unit-tests job adopted in name but runs no coverage command --
+        # either a wrapper hides it or the gate was stripped. Either way,
+        # unverifiable from the dashboard's vantage point -> LOW.
         result = self._evaluate(self._NO_COVERAGE_COMMAND)
-        assert result.severity == Severity.OK
+        assert result.severity == Severity.LOW
         assert "coverage" in result.summary
+        assert result.link is not None
+
+    def test_unit_tests_job_without_steps_is_low(self):
+        # unit-tests job exists but has no steps -- standard adopted in name
+        # only, no gate actually running.
+        yaml_text = """\
+jobs:
+  unit-tests:
+    name: Unit tests
+"""
+        result = self._evaluate(yaml_text)
+        assert result.severity == Severity.LOW
+        assert "no steps" in result.summary
+        assert result.link is not None
 
     def test_yml_fallback(self):
         result = self._evaluate(self._STANDARD_PY, path=".github/workflows/pipeline.yml")


### PR DESCRIPTION
## Summary

- **fix**: Renovate's *Dependency Dashboard* is no longer counted in `open_issues` / `human_open_issues`. Filter keys off GraphQL `author.__typename == "Bot"` so it works for self-hosted Renovate (login `renovate`) as well as the GitHub App (`renovate[bot]`). Fixes the case where `augint-shell` and others reported 1 issue but the only one was the Renovate control panel.
- **fix**: when a repo's default branch is `dev` (aillc-web), the snapshot parser no longer also records `dev_rollup_state` from a separate `refs/heads/dev` lookup. One failing pipeline no longer lights up as both "main failing" and "dev failing".
- **fix**: `renovate_prs` and `stale_prs` now recognise the bare `renovate` login (self-hosted), so those checks actually run for these repos.
- **perf**: AWS drawer switches to `probe_aws_local` — zero subprocesses, runs synchronously on open using `~/.aws/sso/cache` for status and the on-disk `aws_cache.json` for account/ARN carry-forward. Removes the 30-second "frozen UI" on drawer open.
- **feat**: keybindings reworked — `1-5` for Filter/Sort/Layout/Theme/Blink, `q` / `ctrl+c` for Quit, `w a s d` for Org / AWS / System / Detail-cycle drawers. Workspace-hide moved to `W`.
- **feat**: `s` opens the System drawer directly instead of requiring a double-`d` through the cycle.
- **ci**: TUI tests re-enabled; `skip_refresh` gates the mount-time sysmeter worker so Pilot tests don't spawn it. `pytest-timeout=30` is the safety net.
- **feat**: coverage health check flags adopted-but-gateless `unit-tests` jobs as LOW (previously OK).

## Test plan

- [x] `uv run pytest` — full suite incl. 33 @tui tests passes locally (~30s)
- [x] `uv run pre-commit run --all-files` — clean
- [x] Live verification: `parse_response` + `build_status_from_snapshot` against `svange/augint-shell` returns `open_issues=0`, `human_open_issues=0` (1 Dependency Dashboard issue suppressed)
- [ ] Restart the running dashboard and confirm `augint-shell` no longer shows 1 issue
- [ ] CI passes with TUI tests enabled