### PR TITLE
fix(dashboard): render dev-as-default repos with N/A main, not a lost dev pipeline

### DIFF
--- a/src/augint_tools/dashboard/_gql.py
+++ b/src/augint_tools/dashboard/_gql.py
@@ -328,18 +328,24 @@ def _parse_repo(data: dict) -> RepoSnapshot:
     main_head_sha = main_target.get("oid") if isinstance(main_target, dict) else None
 
     dev_ref = data.get("_dev")
-    # If the repo's default branch is already "dev" (e.g. aillc-web), the
-    # defaultBranchRef and the explicit refs/heads/dev lookup resolve to the
-    # same commit. Treating them as separate branches double-counts a single
-    # failing pipeline as both "main failing" and "dev failing" in broken_ci.
-    # In that layout there is no distinct dev branch to surface, so collapse
-    # it into the default-branch slot only.
-    if default_branch == "dev":
-        dev_ref = None
     has_dev_branch = dev_ref is not None
     dev_target = (dev_ref or {}).get("target") or {} if isinstance(dev_ref, dict) else {}
     dev_rollup_state = _resolve_rollup_state(dev_target)
     dev_head_sha = dev_target.get("oid") if isinstance(dev_target, dict) else None
+
+    # When ``dev`` is the default branch -- common on new projects that stage
+    # on dev before cutting main, and on repos like aillc-web -- the
+    # defaultBranchRef and the refs/heads/dev lookup alias the same commit.
+    # Route the rollup into the dev slot and mark main as ABSENT so the card
+    # renders "dev X  main N/A" (main styled informationally, not as a
+    # failure). Using a sentinel ABSENT state lets broken_ci / severity
+    # aggregation ignore it -- it's neither "failure" nor "unknown".
+    if default_branch == "dev":
+        dev_rollup_state = main_rollup_state
+        dev_head_sha = main_head_sha
+        main_rollup_state = "ABSENT"
+        main_head_sha = None
+        has_dev_branch = True
 
     root_tree = data.get("_rootTree")
     if isinstance(root_tree, dict):
@@ -603,6 +609,11 @@ def translate_rollup_state(state: str | None) -> str:
         return "failure"
     if state in ("PENDING", "EXPECTED"):
         return "in_progress"
+    # Parser sentinel: branch genuinely doesn't exist (e.g. no ``main`` on a
+    # new project that's still on dev). Distinct from ``unknown``, which means
+    # the branch exists but no rollup could be resolved.
+    if state in ("ABSENT",):
+        return "absent"
     # Missing rollup (e.g. no workflows) or unknown state.
     return "unknown"
 

--- a/src/augint_tools/dashboard/health/checks/service_missing_dev.py
+++ b/src/augint_tools/dashboard/health/checks/service_missing_dev.py
@@ -36,7 +36,16 @@ class ServiceMissingDevBranchCheck:
                 severity=Severity.OK,
                 summary="not a service repo",
             )
-        if status.looks_like_service and not status.has_dev_branch:
+        # ``has_dev_branch`` is False in two different situations:
+        #   1. No refs/heads/dev exists (real drift -- fire CRITICAL).
+        #   2. refs/heads/dev *is* the default branch, so _parse_repo collapses
+        #      it into the default-branch slot to avoid double-counting in
+        #      broken_ci (e.g. aillc-web). Not drift -- stay OK.
+        if (
+            status.looks_like_service
+            and not status.has_dev_branch
+            and status.default_branch != "dev"
+        ):
             markers = ", ".join(status.service_markers) or "service markers detected"
             return HealthCheckResult(
                 check_name=self.name,

--- a/src/augint_tools/dashboard/widgets/repo_card.py
+++ b/src/augint_tools/dashboard/widgets/repo_card.py
@@ -45,6 +45,9 @@ _STATUS_ICON = {
     "failure": "FAIL",
     "in_progress": "RUN",
     "unknown": "? ",
+    # Branch doesn't exist yet (e.g. main hasn't been cut off dev on a new
+    # project). Shown in yellow so it stands out without reading as failure.
+    "absent": "N/A",
 }
 
 # Upper bound for the subtle blue hint on the counts line. Matches the default
@@ -523,6 +526,9 @@ class RepoCard(Widget):
             return f"bold {spec.status_fail}"
         if status == "in_progress":
             return f"bold {spec.status_running}"
+        if status == "absent":
+            # Branch not yet created -- informational yellow, not alerting.
+            return "bold yellow"
         return f"bold {spec.status_unknown}"
 
     # ---- mouse + focus ----

--- a/tests/unit/test_gql.py
+++ b/tests/unit/test_gql.py
@@ -195,10 +195,12 @@ class TestParseResponse:
         assert snap.has_dev_branch
         assert snap.dev_rollup_state == "FAILURE"
 
-    def test_dev_as_default_branch_not_double_counted(self):
-        # aillc-web-style layout: dev IS the default branch and a separate
-        # refs/heads/dev lookup aliases the same commit. Surfacing both would
-        # make broken_ci fire twice on a single failing pipeline.
+    def test_dev_as_default_branch_routes_to_dev_slot(self):
+        # aillc-web-style layout (also: new projects that stage on dev before
+        # cutting main). defaultBranchRef and refs/heads/dev alias the same
+        # commit; the parser must route the rollup into the dev slot and
+        # mark main as ABSENT so the card shows "dev X  main N/A" without
+        # double-counting a single failing pipeline in broken_ci.
         payload = _graphql_repo_payload(
             full_name="org/web",
             has_dev=True,
@@ -210,9 +212,18 @@ class TestParseResponse:
         snapshots, _, _ = parse_response(response, [_mock_repo("org/web")])
         snap = snapshots["org/web"]
         assert snap.default_branch == "dev"
-        assert snap.main_rollup_state == "FAILURE"
-        assert snap.has_dev_branch is False
-        assert snap.dev_rollup_state is None
+        assert snap.has_dev_branch is True
+        # Main slot marked absent, no SHA -- nothing to fetch a failing run for.
+        assert snap.main_rollup_state == "ABSENT"
+        assert snap.main_head_sha is None
+        # Dev slot carries the default-branch rollup + SHA (routed from main).
+        assert snap.dev_rollup_state == "FAILURE"
+        assert snap.dev_head_sha == "abc123"
+
+    def test_absent_translates_to_absent(self):
+        from augint_tools.dashboard._gql import translate_rollup_state
+
+        assert translate_rollup_state("ABSENT") == "absent"
 
     def test_renovate_dependency_dashboard_excluded_from_open_issues(self):
         # A repo whose only open issue is Renovate's "Dependency Dashboard"

--- a/tests/unit/test_health.py
+++ b/tests/unit/test_health.py
@@ -336,6 +336,23 @@ class TestBrokenCI:
         )
         assert "main" in result.summary
 
+    def test_absent_main_with_passing_dev_is_ok(self):
+        # New-project layout: dev is the default branch, main doesn't exist
+        # yet. Parser emits main_status="absent". broken_ci must not flag
+        # this -- there's no failing pipeline, just no prod branch yet.
+        result = get_check("broken_ci").evaluate(
+            _mock_repo(),
+            _status(
+                has_dev_branch=True,
+                main_status="absent",
+                dev_status="success",
+                default_branch="dev",
+            ),
+            config={},
+            context=_ctx(),
+        )
+        assert result.severity == Severity.OK
+
 
 class TestServiceMissingDevBranch:
     """A repo with structural service markers but no dev branch is the exact
@@ -374,6 +391,23 @@ class TestServiceMissingDevBranch:
         assert "template.yaml" in result.summary
         assert "Dockerfile" in result.summary
         assert result.link == "https://github.com/org/myrepo/branches"
+
+    def test_service_with_dev_as_default_branch_is_ok(self):
+        # aillc-web layout: ``dev`` IS the default branch, so the GraphQL
+        # parser collapses has_dev_branch to False to avoid double-counting
+        # broken CI. The dev branch still exists -- must not flag as drift.
+        result = get_check("service_missing_dev_branch").evaluate(
+            _mock_repo(),
+            _status(
+                has_dev_branch=False,
+                looks_like_service=True,
+                service_markers=("template.yaml",),
+                default_branch="dev",
+            ),
+            config={},
+            context=_ctx(),
+        )
+        assert result.severity == Severity.OK
 
     def test_library_without_dev_branch_is_ok(self):
         # No service markers -> not a service -> dev branch absence is expected,


### PR DESCRIPTION
PR #81 fixed the double-count bug by nulling the separate refs/heads/dev
lookup when defaultBranchRef.name == "dev", but the rollup then stayed
in the main slot and has_dev_branch went False. For an entire workspace
that standardised on dev-as-default (aillc-web and every sibling that
staged on dev before cutting main), the result was that no repo showed
a dev pipeline anymore and service_missing_dev_branch fired CRITICAL
on all of them.

- _parse_repo now routes the defaultBranchRef rollup into the dev slot
  when default_branch == "dev", sets main_rollup_state to a new ABSENT
  sentinel, clears main_head_sha, and keeps has_dev_branch True. One
  lookup, one rollup, correct slot.
- translate_rollup_state maps ABSENT to "absent". Distinct from
  "unknown" so broken_ci doesn't fire MEDIUM on missing-main.
- repo_card renders "absent" as "N/A" in yellow via _STATUS_ICON and
  _status_style. Informational, not alerting -- card severity stays
  green because existing severity aggregators (app.py, severity.py,
  repo_card lines 215/232) all gate on == "failure".
- service_missing_dev_branch now exempts default_branch == "dev"
  explicitly, as a belt-and-suspenders guard in case a future parser
  change leaves has_dev_branch False on this layout.

Tests: updated test_dev_as_default_branch_not_double_counted (renamed
to ..._routes_to_dev_slot) to assert the new routing + ABSENT main,
added test_absent_translates_to_absent, test_absent_main_with_passing_dev_is_ok
in broken_ci, and test_service_with_dev_as_default_branch_is_ok.
