### PR TITLE
fix(auth): prefer gh CLI keyring over GH_TOKEN env/.env

### DIFF
--- a/src/augint_tools/dashboard/_common.py
+++ b/src/augint_tools/dashboard/_common.py
@@ -113,12 +113,19 @@ def load_env_config(filename: str = ".env") -> tuple[str, str, str]:
 
 
 def _get_gh_cli_token() -> str:
-    """Return the token from ``gh auth token`` or an empty string if unavailable."""
+    """Return the token from ``gh auth token`` (keyring/SSO) or an empty string.
+
+    Strips GH_TOKEN/GITHUB_TOKEN from the subprocess env so ``gh`` reports the
+    keyring token instead of echoing back whatever was already in the process
+    environment (which may be a narrow .env token auto-exported by direnv).
+    """
+    env = {k: v for k, v in os.environ.items() if k not in ("GH_TOKEN", "GITHUB_TOKEN")}
     try:
         result = subprocess.run(
             ["gh", "auth", "token"],
             capture_output=True,
             text=True,
+            env=env,
             check=True,
         )
     except (subprocess.CalledProcessError, FileNotFoundError):
@@ -141,29 +148,25 @@ def _resolve_token(filename: str = ".env", auth_source: str = "auto") -> str:
     if auth_source != "auto":
         raise ValueError(f"Unsupported auth_source '{auth_source}'.")
 
-    token = os.environ.get("GH_TOKEN", "").strip()
-    if token:
-        logger.debug("Using GitHub token from GH_TOKEN environment variable.")
-        return token
-
     gh_token = _get_gh_cli_token()
     if gh_token:
-        if dotenv_token:
-            logger.debug(
-                "Using GitHub token from gh auth token. Ignoring GH_TOKEN from .env; "
-                "export GH_TOKEN in the current shell to force it."
-            )
-        else:
-            logger.debug("Using GitHub token from gh auth token.")
+        logger.debug("Using GitHub token from gh auth token (keyring/SSO).")
         return gh_token
 
+    env_token = os.environ.get("GH_TOKEN", "").strip()
+    if env_token:
+        logger.debug(
+            "Using GitHub token from GH_TOKEN environment variable (gh CLI keyring unavailable)."
+        )
+        return env_token
+
     if dotenv_token:
-        logger.debug("Using GitHub token from GH_TOKEN in .env.")
+        logger.debug("Using GitHub token from GH_TOKEN in .env (keyring unavailable).")
         return dotenv_token
 
     raise RuntimeError(
-        "No GitHub token found. Set GH_TOKEN in .env / environment, "
-        "or authenticate with: gh auth login"
+        "No GitHub token found. Authenticate with 'gh auth login', "
+        "or set GH_TOKEN in .env / environment."
     )
 
 

--- a/src/augint_tools/env/auth.py
+++ b/src/augint_tools/env/auth.py
@@ -1,9 +1,14 @@
 """GitHub authentication and env config loading.
 
 Token resolution priority (auth_source="auto"):
-1. GH_TOKEN environment variable
-2. gh auth token (GitHub CLI keyring)
+1. gh auth token (GitHub CLI keyring / SSO)
+2. GH_TOKEN environment variable
 3. GH_TOKEN from .env file
+
+Keyring wins by design: users keep GH_TOKEN in .env so it syncs to GitHub
+Actions secrets, but those tokens are often narrower-scope than their SSO
+credentials. Preferring the keyring avoids silently downgrading auth when
+shells (direnv/autoenv) auto-export .env into the process environment.
 """
 
 from __future__ import annotations
@@ -34,12 +39,19 @@ def load_env_config(filename: str = ".env") -> tuple[str, str, str]:
 
 
 def _get_gh_cli_token() -> str:
-    """Return the token from ``gh auth token`` or empty string if unavailable."""
+    """Return the token from ``gh auth token`` (keyring/SSO) or empty string.
+
+    Strips GH_TOKEN/GITHUB_TOKEN from the subprocess env so ``gh`` reports the
+    keyring token instead of echoing back whatever was already in the process
+    environment (which may be a narrow .env token auto-exported by direnv).
+    """
+    env = {k: v for k, v in os.environ.items() if k not in ("GH_TOKEN", "GITHUB_TOKEN")}
     try:
         result = subprocess.run(
             ["gh", "auth", "token"],
             capture_output=True,
             text=True,
+            env=env,
             check=True,
         )
     except (subprocess.CalledProcessError, FileNotFoundError):
@@ -65,29 +77,26 @@ def resolve_token(filename: str = ".env", auth_source: str = "auto") -> str:
     if auth_source != "auto":
         raise ValueError(f"Unsupported auth_source '{auth_source}'.")
 
-    token = os.environ.get("GH_TOKEN", "").strip()
-    if token:
-        logger.debug("Using GitHub token from GH_TOKEN environment variable.")
-        return token
-
     gh_token = _get_gh_cli_token()
     if gh_token:
-        if dotenv_token:
-            logger.debug(
-                "Using GitHub token from gh auth token. Ignoring GH_TOKEN from .env; "
-                "export GH_TOKEN in the current shell to force it."
-            )
-        else:
-            logger.debug("Using GitHub token from gh auth token.")
+        logger.debug("Using GitHub token from gh auth token (keyring/SSO).")
         return gh_token
 
+    env_token = os.environ.get("GH_TOKEN", "").strip()
+    if env_token:
+        logger.debug(
+            "Using GitHub token from GH_TOKEN environment variable "
+            "(gh CLI keyring unavailable)."
+        )
+        return env_token
+
     if dotenv_token:
-        logger.debug("Using GitHub token from GH_TOKEN in .env.")
+        logger.debug("Using GitHub token from GH_TOKEN in .env (keyring unavailable).")
         return dotenv_token
 
     raise RuntimeError(
-        "No GitHub token found. Set GH_TOKEN in .env / environment, "
-        "or authenticate with: gh auth login"
+        "No GitHub token found. Authenticate with 'gh auth login', "
+        "or set GH_TOKEN in .env / environment."
     )
 
 

--- a/src/augint_tools/github/cli.py
+++ b/src/augint_tools/github/cli.py
@@ -1,23 +1,58 @@
-"""GitHub CLI wrapper."""
+"""GitHub CLI wrapper.
 
+All ``gh`` subprocess calls route through :func:`run_gh`, which prefers the
+user's keyring/SSO credentials over ``GH_TOKEN`` from the process environment.
+Users keep ``GH_TOKEN`` in ``.env`` so it syncs to GitHub Actions secrets;
+direnv-style shells auto-export that into the environment. Without this
+sanitization, ``gh`` would silently use the (often narrower) .env token and
+fail on operations that the user's SSO credentials would have authorized.
+"""
+
+import os
 import subprocess
+from functools import lru_cache
+
+_GH_TOKEN_ENV_VARS = ("GH_TOKEN", "GITHUB_TOKEN")
+
+
+def _env_without_gh_tokens() -> dict[str, str]:
+    return {k: v for k, v in os.environ.items() if k not in _GH_TOKEN_ENV_VARS}
+
+
+@lru_cache(maxsize=1)
+def _keyring_works() -> bool:
+    """Return True if ``gh auth status`` succeeds using the keyring alone.
+
+    Probes with GH_TOKEN/GITHUB_TOKEN stripped so ``gh`` can't short-circuit
+    to the env var. Cached per process because ``gh auth status`` is slow
+    enough to notice if called on every subprocess.
+    """
+    try:
+        result = subprocess.run(
+            ["gh", "auth", "status"],
+            capture_output=True,
+            text=True,
+            env=_env_without_gh_tokens(),
+            check=False,
+        )
+    except (FileNotFoundError, OSError):
+        return False
+    return result.returncode == 0
+
+
+def _gh_env() -> dict[str, str]:
+    if _keyring_works():
+        return _env_without_gh_tokens()
+    return os.environ.copy()
 
 
 def run_gh(args: list[str], check: bool = True) -> subprocess.CompletedProcess:
-    """
-    Run a gh CLI command.
-
-    Args:
-        args: Command arguments
-        check: Whether to raise on non-zero exit
-
-    Returns:
-        CompletedProcess result
-    """
+    """Run a ``gh`` command with keyring-first env sanitization."""
     return subprocess.run(
         ["gh", *args],
         capture_output=True,
         text=True,
+        env=_gh_env(),
         check=check,
     )
 
@@ -34,7 +69,7 @@ def is_gh_available() -> bool:
 
 
 def is_gh_authenticated() -> bool:
-    """Check if gh CLI is authenticated."""
+    """Check if gh CLI is authenticated by any available mechanism."""
     try:
         result = run_gh(["auth", "status"], check=False)
         return result.returncode == 0

--- a/tests/unit/test_env_auth.py
+++ b/tests/unit/test_env_auth.py
@@ -31,19 +31,10 @@ class TestLoadEnvConfig:
 
 
 class TestResolveToken:
-    def test_prefers_explicit_env_over_gh_cli(self, tmp_path, monkeypatch):
+    def test_prefers_gh_cli_over_env_var(self, tmp_path, monkeypatch):
         env_path = tmp_path / ".env"
         env_path.write_text("GH_TOKEN=file-token\n")
         monkeypatch.setenv("GH_TOKEN", "env-token")
-
-        with patch("augint_tools.env.auth.subprocess.run") as mock_run:
-            assert resolve_token(str(env_path)) == "env-token"
-            mock_run.assert_not_called()
-
-    def test_prefers_gh_cli_over_dotenv(self, tmp_path, monkeypatch):
-        env_path = tmp_path / ".env"
-        env_path.write_text("GH_TOKEN=file-token\n")
-        monkeypatch.delenv("GH_TOKEN", raising=False)
 
         with patch("augint_tools.env.auth.subprocess.run") as mock_run:
             mock_run.return_value = CompletedProcess(
@@ -53,7 +44,36 @@ class TestResolveToken:
             )
             assert resolve_token(str(env_path)) == "gh-token"
 
-    def test_uses_dotenv_when_gh_cli_unavailable(self, tmp_path, monkeypatch):
+    def test_gh_cli_probe_strips_env_token(self, tmp_path, monkeypatch):
+        """gh auth token must run with GH_TOKEN stripped so it returns the keyring value."""
+        env_path = tmp_path / ".env"
+        env_path.write_text("")
+        monkeypatch.setenv("GH_TOKEN", "env-token")
+        monkeypatch.setenv("GITHUB_TOKEN", "env-gh-token")
+
+        with patch("augint_tools.env.auth.subprocess.run") as mock_run:
+            mock_run.return_value = CompletedProcess(
+                args=["gh", "auth", "token"],
+                returncode=0,
+                stdout="keyring-token\n",
+            )
+            resolve_token(str(env_path))
+            passed_env = mock_run.call_args.kwargs["env"]
+            assert "GH_TOKEN" not in passed_env
+            assert "GITHUB_TOKEN" not in passed_env
+
+    def test_falls_back_to_env_var_when_gh_cli_unavailable(self, tmp_path, monkeypatch):
+        env_path = tmp_path / ".env"
+        env_path.write_text("GH_TOKEN=file-token\n")
+        monkeypatch.setenv("GH_TOKEN", "env-token")
+
+        with patch(
+            "augint_tools.env.auth.subprocess.run",
+            side_effect=FileNotFoundError,
+        ):
+            assert resolve_token(str(env_path)) == "env-token"
+
+    def test_falls_back_to_dotenv_when_no_keyring_and_no_env_var(self, tmp_path, monkeypatch):
         env_path = tmp_path / ".env"
         env_path.write_text("GH_TOKEN=file-token\n")
         monkeypatch.delenv("GH_TOKEN", raising=False)
@@ -92,3 +112,17 @@ class TestResolveToken:
         ):
             with pytest.raises(RuntimeError, match="No GitHub token found"):
                 resolve_token(str(env_path))
+
+    def test_gh_cli_empty_output_falls_back(self, tmp_path, monkeypatch):
+        """gh auth token exiting 0 with empty stdout (no keyring) should fall back."""
+        env_path = tmp_path / ".env"
+        env_path.write_text("GH_TOKEN=file-token\n")
+        monkeypatch.setenv("GH_TOKEN", "env-token")
+
+        with patch("augint_tools.env.auth.subprocess.run") as mock_run:
+            mock_run.return_value = CompletedProcess(
+                args=["gh", "auth", "token"],
+                returncode=0,
+                stdout="\n",
+            )
+            assert resolve_token(str(env_path)) == "env-token"

--- a/tests/unit/test_github_cli.py
+++ b/tests/unit/test_github_cli.py
@@ -1,0 +1,74 @@
+"""Tests for the gh CLI subprocess wrapper."""
+
+from subprocess import CompletedProcess
+from unittest.mock import patch
+
+import pytest
+
+from augint_tools.github import cli as gh_cli
+
+
+@pytest.fixture(autouse=True)
+def _clear_keyring_cache():
+    gh_cli._keyring_works.cache_clear()
+    yield
+    gh_cli._keyring_works.cache_clear()
+
+
+class TestRunGh:
+    def test_strips_gh_token_when_keyring_works(self, monkeypatch):
+        monkeypatch.setenv("GH_TOKEN", "dotenv-token")
+        monkeypatch.setenv("GITHUB_TOKEN", "dotenv-github-token")
+        monkeypatch.setenv("KEEP_ME", "yes")
+
+        calls = []
+
+        def fake_run(cmd, **kwargs):
+            calls.append((cmd, kwargs.get("env")))
+            if cmd == ["gh", "auth", "status"] and kwargs.get("env", {}).get("GH_TOKEN") is None:
+                return CompletedProcess(args=cmd, returncode=0, stdout="")
+            return CompletedProcess(args=cmd, returncode=0, stdout="ok")
+
+        with patch("augint_tools.github.cli.subprocess.run", side_effect=fake_run):
+            result = gh_cli.run_gh(["pr", "list"])
+
+        assert result.returncode == 0
+        pr_list_env = calls[-1][1]
+        assert "GH_TOKEN" not in pr_list_env
+        assert "GITHUB_TOKEN" not in pr_list_env
+        assert pr_list_env.get("KEEP_ME") == "yes"
+
+    def test_passes_through_gh_token_when_keyring_unavailable(self, monkeypatch):
+        monkeypatch.setenv("GH_TOKEN", "dotenv-token")
+
+        def fake_run(cmd, **kwargs):
+            if cmd == ["gh", "auth", "status"]:
+                return CompletedProcess(args=cmd, returncode=1, stdout="", stderr="not logged in")
+            return CompletedProcess(args=cmd, returncode=0, stdout="ok")
+
+        with patch("augint_tools.github.cli.subprocess.run", side_effect=fake_run) as mock_run:
+            gh_cli.run_gh(["pr", "list"])
+
+        pr_list_env = mock_run.call_args_list[-1].kwargs["env"]
+        assert pr_list_env.get("GH_TOKEN") == "dotenv-token"
+
+    def test_keyring_probe_is_cached(self, monkeypatch):
+        monkeypatch.delenv("GH_TOKEN", raising=False)
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+
+        with patch("augint_tools.github.cli.subprocess.run") as mock_run:
+            mock_run.return_value = CompletedProcess(args=[], returncode=0, stdout="")
+            gh_cli.run_gh(["pr", "list"])
+            gh_cli.run_gh(["pr", "view", "1"])
+
+        status_calls = [c for c in mock_run.call_args_list if c.args[0] == ["gh", "auth", "status"]]
+        assert len(status_calls) == 1
+
+    def test_keyring_probe_tolerates_missing_gh(self, monkeypatch):
+        monkeypatch.setenv("GH_TOKEN", "dotenv-token")
+
+        with patch(
+            "augint_tools.github.cli.subprocess.run",
+            side_effect=FileNotFoundError,
+        ):
+            assert gh_cli._keyring_works() is False


### PR DESCRIPTION
## Summary

- `GH_TOKEN` in `.env` is needed so it syncs to GitHub Actions secrets, but direnv-style shells auto-export it into the process env, which causes `gh` (and PyGithub via `resolve_token`) to short-circuit to that often-narrower token instead of the user's SSO keyring credentials.
- Flip resolution priority to **keyring -> env var -> .env** in `env/auth.py` and the dashboard's mirror in `dashboard/_common.py`.
- `github/cli.py:run_gh` now probes `gh auth status` once per process with `GH_TOKEN`/`GITHUB_TOKEN` stripped; if the keyring works, those vars are stripped from every subsequent `gh` subprocess env so `gh` uses the keyring.
- `.env`-based auth still works unchanged when no keyring is configured.

## Test plan

- [x] `uv run pytest` — 724 passing (new `test_github_cli.py`, updated `test_env_auth.py` priority + probe-env-stripping coverage).
- [x] `uv run pre-commit run --all-files` — clean.
- [ ] Manual: with a valid `gh auth login` plus a stale `GH_TOKEN` in `./.env`, confirm `ai-tools` gh-backed commands succeed.