### PR TITLE
feat(dashboard): escalate open-issues severity by age

### DIFF
--- a/src/augint_tools/dashboard/_data.py
+++ b/src/augint_tools/dashboard/_data.py
@@ -184,8 +184,8 @@ class RepoStatus:
     # Human-filed open issues (bots + PRs filtered out).
     human_open_issues: int = 0
     # ISO-8601 UTC creation timestamp of the oldest human-filed open issue.
-    # Drives the "stale" tint on the counts line when any issue is older
-    # than three days.
+    # Drives the "stale" / "ancient" tint on the counts line and the
+    # open_issues health-check severity escalation.
     oldest_issue_created_at: str | None = None
     # Default branch name, used by checks that build links to files on GitHub.
     default_branch: str = "main"

--- a/src/augint_tools/dashboard/health/checks/open_issues.py
+++ b/src/augint_tools/dashboard/health/checks/open_issues.py
@@ -1,11 +1,20 @@
-"""Health check: high open issue count (excluding bot-created issues).
+"""Health check: open human-filed issues — count and age.
 
-Uses ``RepoStatus.human_open_issues`` which is already computed during the
-main GraphQL workspace fetch -- no duplicate REST call from this check.
+Uses ``RepoStatus.human_open_issues`` and ``RepoStatus.oldest_issue_created_at``
+(both pre-computed during the main GraphQL workspace fetch -- no extra REST
+calls from this check). The card always shows a numerical issue counter on the
+CI line, so a "quiet" (OK-severity) result here deliberately emits no info
+row. Severity only escalates when there are *too many* issues or the oldest
+issue has sat too long.
+
+Thresholds default to 7 days (stale -> MEDIUM) and 30 days (ancient ->
+CRITICAL); the widget's counts-line color tiers use the same values (see
+``repo_card._ISSUE_STALE_AGE`` / ``_ISSUE_CRITICAL_AGE``).
 """
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
 from .._models import HealthCheckResult, Severity
@@ -18,9 +27,21 @@ if TYPE_CHECKING:
     from .. import FetchContext
 
 
+def _issue_age_days(iso_ts: str | None) -> int | None:
+    if not iso_ts:
+        return None
+    try:
+        ts = datetime.fromisoformat(iso_ts)
+    except ValueError:
+        return None
+    if ts.tzinfo is None:
+        ts = ts.replace(tzinfo=UTC)
+    return max(0, (datetime.now(UTC) - ts).days)
+
+
 class OpenIssuesCheck:
     name = "open_issues"
-    description = "Flag repos with many open human-filed issues"
+    description = "Flag repos with many or long-open human-filed issues"
 
     def evaluate(
         self,
@@ -30,15 +51,45 @@ class OpenIssuesCheck:
         config: dict,
         context: FetchContext,  # noqa: ARG002
     ) -> HealthCheckResult:
-        threshold = config.get("open_issues_threshold", 10)
-        human_count = status.human_open_issues
+        count_threshold = config.get("open_issues_threshold", 10)
+        stale_days = config.get("stale_issue_days", 7)
+        critical_days = config.get("critical_issue_days", 30)
 
-        if human_count >= threshold:
+        human_count = status.human_open_issues
+        link = f"https://github.com/{status.full_name}/issues"
+        age = _issue_age_days(status.oldest_issue_created_at)
+
+        if age is not None and age >= critical_days:
             return HealthCheckResult(
                 check_name=self.name,
-                severity=Severity.LOW,
+                severity=Severity.CRITICAL,
+                summary=f"({human_count}) open issues, oldest {age}d",
+                link=link,
+            )
+
+        too_many = human_count >= count_threshold
+        too_old = age is not None and age >= stale_days
+
+        if too_many and too_old:
+            return HealthCheckResult(
+                check_name=self.name,
+                severity=Severity.MEDIUM,
+                summary=f"({human_count}) open issues, oldest {age}d",
+                link=link,
+            )
+        if too_old:
+            return HealthCheckResult(
+                check_name=self.name,
+                severity=Severity.MEDIUM,
+                summary=f"oldest issue {age}d ({human_count} open)",
+                link=link,
+            )
+        if too_many:
+            return HealthCheckResult(
+                check_name=self.name,
+                severity=Severity.MEDIUM,
                 summary=f"({human_count}) open issues (excl. bots)",
-                link=f"https://github.com/{status.full_name}/issues",
+                link=link,
             )
 
         return HealthCheckResult(

--- a/src/augint_tools/dashboard/widgets/repo_card.py
+++ b/src/augint_tools/dashboard/widgets/repo_card.py
@@ -55,9 +55,12 @@ _STATUS_ICON = {
 # flags the card and its severity styling already communicates the concern.
 _ISSUE_HINT_THRESHOLD = 10
 
-# An open issue older than this turns the issues count yellow so it stands
-# out without escalating the whole card's severity.
-_ISSUE_STALE_AGE = timedelta(days=3)
+# Age tiers for the issues counter on the counts line. Kept in lock-step with
+# the ``open_issues`` health check (see ``stale_issue_days`` /
+# ``critical_issue_days`` defaults) so the count colour and the card border
+# severity tell the same story: stale -> yellow, ancient -> red.
+_ISSUE_STALE_AGE = timedelta(days=7)
+_ISSUE_CRITICAL_AGE = timedelta(days=30)
 
 
 def _within_window(iso_ts: str | None, window_seconds: int) -> bool:
@@ -313,11 +316,14 @@ class RepoCard(Widget):
     def _issue_count_style(self, status, spec: ThemeSpec) -> str:
         """Return the inline style for the issue count number.
 
-        Yellow when any human-filed issue is older than three days; blue when
-        there is at least one human-filed issue but the count is still below
-        the health check's threshold. Otherwise no override -- inherit the
-        card's default text colour.
+        Red when any human-filed issue is older than the critical threshold;
+        yellow at the stale threshold; blue when there is at least one
+        human-filed issue but the count is still below the health check's
+        threshold. Otherwise no override -- inherit the card's default text
+        colour.
         """
+        if _older_than(status.oldest_issue_created_at, _ISSUE_CRITICAL_AGE):
+            return spec.severity_colors[Severity.CRITICAL]
         if _older_than(status.oldest_issue_created_at, _ISSUE_STALE_AGE):
             return spec.severity_colors[Severity.MEDIUM]
         if 0 < status.human_open_issues < _ISSUE_HINT_THRESHOLD:
@@ -372,26 +378,20 @@ class RepoCard(Widget):
     def _healthy_info_lines(self, health: RepoHealth, limit: int | None) -> list[tuple[Text, str]]:
         """Informative OK-severity rows used when this repo has zero findings.
 
-        Surfaces open issues / PRs / drafts with click targets, so a green card
-        still offers a jumping-off point. Falls back to a single "healthy"
-        line linking to the repo home when there's nothing to show at all.
+        Surfaces open PRs / drafts with click targets, so a green card still
+        offers a jumping-off point. Open issues are intentionally omitted here
+        -- the counts line already carries a numerical indicator, and the
+        open_issues health check escalates severity when issues are old or
+        numerous. Falls back to a single "healthy" line linking to the repo
+        home when there's nothing to show at all.
         """
         spec = self._theme_spec
         status = health.status
         ok_style = spec.severity_colors[Severity.OK]
         full_name = status.full_name
-        issues_url = f"https://github.com/{full_name}/issues"
         pulls_url = f"https://github.com/{full_name}/pulls"
 
         info: list[tuple[Text, str]] = []
-        if status.open_issues > 0:
-            noun = "issue" if status.open_issues == 1 else "issues"
-            info.append(
-                (
-                    Text(f"{status.open_issues} open {noun}", style=ok_style),
-                    issues_url,
-                )
-            )
         # "open PRs" here means non-draft PRs -- drafts get their own line so
         # the reader can tell at a glance which ones are actually review-ready.
         ready_prs = max(0, status.open_prs - status.draft_prs)

--- a/tests/unit/test_dashboard.py
+++ b/tests/unit/test_dashboard.py
@@ -827,7 +827,7 @@ class TestRepoCardRender:
         RepoCard, spec = self._spec()
         status = _status(open_issues=2)
         status.human_open_issues = 2
-        status.oldest_issue_created_at = (datetime.now(UTC) - timedelta(days=5)).isoformat()
+        status.oldest_issue_created_at = (datetime.now(UTC) - timedelta(days=10)).isoformat()
         health = RepoHealth(status=status)
         card = RepoCard(health, theme_spec=spec)
         line = card._counts_line(health)
@@ -837,6 +837,20 @@ class TestRepoCardRender:
         styles = [str(span.style) for span in line.spans]
         assert any(medium_color in s for s in styles)
         assert not any(low_color in s for s in styles if low_color != medium_color)
+
+    def test_counts_line_red_when_ancient(self):
+        from datetime import UTC, datetime, timedelta
+
+        RepoCard, spec = self._spec()
+        status = _status(open_issues=2)
+        status.human_open_issues = 2
+        status.oldest_issue_created_at = (datetime.now(UTC) - timedelta(days=45)).isoformat()
+        health = RepoHealth(status=status)
+        card = RepoCard(health, theme_spec=spec)
+        line = card._counts_line(health)
+        # ancient beats stale -- the count tint jumps to CRITICAL.
+        critical_color = spec.severity_colors[Severity.CRITICAL]
+        assert any(critical_color in str(span.style) for span in line.spans)
 
 
 class TestFindingsLinesHealthyInfo:
@@ -856,34 +870,29 @@ class TestFindingsLinesHealthyInfo:
         assert text.plain == "healthy"
         assert url == "https://github.com/org/quiet"
 
-    def test_no_findings_with_open_issues_returns_issues_line(self):
+    def test_no_findings_open_issues_alone_falls_back_to_healthy(self):
+        # Issues are communicated by the counts-line numerical indicator and
+        # by severity escalation in the open_issues check; they deliberately
+        # don't produce an info row, so a repo with only open issues reads as
+        # "healthy" in the findings slot.
         RepoCard, spec = self._spec()
         status = _status(full_name="org/busy", open_issues=4)
         health = RepoHealth(status=status)
         card = RepoCard(health, theme_spec=spec)
         lines = card._findings_lines(health, limit=2)
-        assert any(
-            line.plain == "4 open issues" and url == "https://github.com/org/busy/issues"
-            for line, url in lines
-        )
+        assert [(line.plain, url) for line, url in lines] == [
+            ("healthy", "https://github.com/org/busy"),
+        ]
 
-    def test_no_findings_single_issue_uses_singular_noun(self):
-        RepoCard, spec = self._spec()
-        status = _status(full_name="org/busy", open_issues=1)
-        health = RepoHealth(status=status)
-        card = RepoCard(health, theme_spec=spec)
-        lines = card._findings_lines(health, limit=2)
-        assert lines[0][0].plain == "1 open issue"
-
-    def test_no_findings_with_issues_and_prs_returns_both_lines(self):
+    def test_no_findings_with_issues_and_prs_only_pr_line_emitted(self):
         RepoCard, spec = self._spec()
         status = _status(full_name="org/busy", open_issues=2, open_prs=3)
         health = RepoHealth(status=status)
         card = RepoCard(health, theme_spec=spec)
         lines = card._findings_lines(health, limit=4)
         plain = [(line.plain, url) for line, url in lines]
-        assert ("2 open issues", "https://github.com/org/busy/issues") in plain
         assert ("3 open prs", "https://github.com/org/busy/pulls") in plain
+        assert not any(line.plain.endswith("open issues") for line, _ in lines)
 
     def test_no_findings_drafts_line_separate_from_ready_prs(self):
         RepoCard, spec = self._spec()

--- a/tests/unit/test_health.py
+++ b/tests/unit/test_health.py
@@ -36,6 +36,7 @@ def _status(
     open_prs=0,
     draft_prs=0,
     human_open_issues=0,
+    oldest_issue_created_at=None,
     default_branch="main",
     has_workflows=True,
     looks_like_service=False,
@@ -55,6 +56,7 @@ def _status(
         open_prs=open_prs,
         draft_prs=draft_prs,
         human_open_issues=human_open_issues,
+        oldest_issue_created_at=oldest_issue_created_at,
         default_branch=default_branch,
         has_workflows=has_workflows,
         looks_like_service=looks_like_service,
@@ -607,23 +609,32 @@ class TestStalePRs:
 
 
 class TestOpenIssues:
+    @staticmethod
+    def _days_ago(days: int) -> str:
+        return (datetime.now(UTC) - timedelta(days=days)).isoformat()
+
     def test_below_threshold(self):
         result = get_check("open_issues").evaluate(
             _mock_repo(),
-            _status(open_issues=5, human_open_issues=5),
+            _status(open_issues=5, human_open_issues=5, oldest_issue_created_at=self._days_ago(2)),
             config={},
             context=_ctx(),
         )
         assert result.severity == Severity.OK
 
     def test_above_threshold(self):
+        # Too many fresh issues escalates to MEDIUM so the border turns
+        # yellow -- count alone used to be LOW (border stayed green) which
+        # the numerical counter already communicated.
         result = get_check("open_issues").evaluate(
             _mock_repo(),
-            _status(open_issues=15, human_open_issues=15),
+            _status(
+                open_issues=15, human_open_issues=15, oldest_issue_created_at=self._days_ago(2)
+            ),
             config={},
             context=_ctx(),
         )
-        assert result.severity == Severity.LOW
+        assert result.severity == Severity.MEDIUM
         assert "(15) open issues" in result.summary
         assert result.link is not None
 
@@ -632,7 +643,7 @@ class TestOpenIssues:
         # excludes bots. The check reads it straight off RepoStatus.
         result = get_check("open_issues").evaluate(
             _mock_repo(),
-            _status(open_issues=12, human_open_issues=5),
+            _status(open_issues=12, human_open_issues=5, oldest_issue_created_at=self._days_ago(2)),
             config={},
             context=_ctx(),
         )
@@ -642,11 +653,40 @@ class TestOpenIssues:
     def test_custom_threshold(self):
         result = get_check("open_issues").evaluate(
             _mock_repo(),
-            _status(open_issues=3, human_open_issues=3),
+            _status(open_issues=3, human_open_issues=3, oldest_issue_created_at=self._days_ago(1)),
             config={"open_issues_threshold": 3},
             context=_ctx(),
         )
-        assert result.severity == Severity.LOW
+        assert result.severity == Severity.MEDIUM
+
+    def test_stale_issue_medium(self):
+        result = get_check("open_issues").evaluate(
+            _mock_repo(),
+            _status(open_issues=1, human_open_issues=1, oldest_issue_created_at=self._days_ago(10)),
+            config={},
+            context=_ctx(),
+        )
+        assert result.severity == Severity.MEDIUM
+        assert "10d" in result.summary
+
+    def test_ancient_issue_critical(self):
+        result = get_check("open_issues").evaluate(
+            _mock_repo(),
+            _status(open_issues=2, human_open_issues=2, oldest_issue_created_at=self._days_ago(45)),
+            config={},
+            context=_ctx(),
+        )
+        assert result.severity == Severity.CRITICAL
+        assert "45d" in result.summary
+
+    def test_quiet_when_empty(self):
+        result = get_check("open_issues").evaluate(
+            _mock_repo(),
+            _status(open_issues=0, human_open_issues=0, oldest_issue_created_at=None),
+            config={},
+            context=_ctx(),
+        )
+        assert result.severity == Severity.OK
 
 
 class TestOpenPRs:


### PR DESCRIPTION
## Summary
- Open-issues severity now escalates by age of the oldest human-filed issue: OK -> MEDIUM at 7d -> CRITICAL at 30d, on both the repo-card counts line and the `open_issues` health check.
- Count-based escalation bumps from LOW to MEDIUM so the card border actually reflects the concern (the numerical counter already carried the LOW signal).
- Drops the redundant "N open issues" healthy info row -- the counts line already surfaces the number.

## Test plan
- [x] `uv run pytest` -- 724 passed
- [x] `uv run mypy src/` -- clean
- [x] `uv run ruff check src/ tests/` -- clean
- [x] New tests cover the MEDIUM / CRITICAL age tiers and the "quiet when empty" path