### PR TITLE
test: raise coverage from 74% to 80%

### DIFF
--- a/src/augint_tools/dashboard/_data.py
+++ b/src/augint_tools/dashboard/_data.py
@@ -184,8 +184,8 @@ class RepoStatus:
     # Human-filed open issues (bots + PRs filtered out).
     human_open_issues: int = 0
     # ISO-8601 UTC creation timestamp of the oldest human-filed open issue.
-    # Drives the "stale" tint on the counts line when any issue is older
-    # than three days.
+    # Drives the "stale" / "ancient" tint on the counts line and the
+    # open_issues health-check severity escalation.
     oldest_issue_created_at: str | None = None
     # Default branch name, used by checks that build links to files on GitHub.
     default_branch: str = "main"

--- a/src/augint_tools/dashboard/health/checks/open_issues.py
+++ b/src/augint_tools/dashboard/health/checks/open_issues.py
@@ -1,11 +1,20 @@
-"""Health check: high open issue count (excluding bot-created issues).
+"""Health check: open human-filed issues — count and age.
 
-Uses ``RepoStatus.human_open_issues`` which is already computed during the
-main GraphQL workspace fetch -- no duplicate REST call from this check.
+Uses ``RepoStatus.human_open_issues`` and ``RepoStatus.oldest_issue_created_at``
+(both pre-computed during the main GraphQL workspace fetch -- no extra REST
+calls from this check). The card always shows a numerical issue counter on the
+CI line, so a "quiet" (OK-severity) result here deliberately emits no info
+row. Severity only escalates when there are *too many* issues or the oldest
+issue has sat too long.
+
+Thresholds default to 7 days (stale -> MEDIUM) and 30 days (ancient ->
+CRITICAL); the widget's counts-line color tiers use the same values (see
+``repo_card._ISSUE_STALE_AGE`` / ``_ISSUE_CRITICAL_AGE``).
 """
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
 from .._models import HealthCheckResult, Severity
@@ -18,9 +27,21 @@ if TYPE_CHECKING:
     from .. import FetchContext
 
 
+def _issue_age_days(iso_ts: str | None) -> int | None:
+    if not iso_ts:
+        return None
+    try:
+        ts = datetime.fromisoformat(iso_ts)
+    except ValueError:
+        return None
+    if ts.tzinfo is None:
+        ts = ts.replace(tzinfo=UTC)
+    return max(0, (datetime.now(UTC) - ts).days)
+
+
 class OpenIssuesCheck:
     name = "open_issues"
-    description = "Flag repos with many open human-filed issues"
+    description = "Flag repos with many or long-open human-filed issues"
 
     def evaluate(
         self,
@@ -30,15 +51,45 @@ class OpenIssuesCheck:
         config: dict,
         context: FetchContext,  # noqa: ARG002
     ) -> HealthCheckResult:
-        threshold = config.get("open_issues_threshold", 10)
-        human_count = status.human_open_issues
+        count_threshold = config.get("open_issues_threshold", 10)
+        stale_days = config.get("stale_issue_days", 7)
+        critical_days = config.get("critical_issue_days", 30)
 
-        if human_count >= threshold:
+        human_count = status.human_open_issues
+        link = f"https://github.com/{status.full_name}/issues"
+        age = _issue_age_days(status.oldest_issue_created_at)
+
+        if age is not None and age >= critical_days:
             return HealthCheckResult(
                 check_name=self.name,
-                severity=Severity.LOW,
+                severity=Severity.CRITICAL,
+                summary=f"({human_count}) open issues, oldest {age}d",
+                link=link,
+            )
+
+        too_many = human_count >= count_threshold
+        too_old = age is not None and age >= stale_days
+
+        if too_many and too_old:
+            return HealthCheckResult(
+                check_name=self.name,
+                severity=Severity.MEDIUM,
+                summary=f"({human_count}) open issues, oldest {age}d",
+                link=link,
+            )
+        if too_old:
+            return HealthCheckResult(
+                check_name=self.name,
+                severity=Severity.MEDIUM,
+                summary=f"oldest issue {age}d ({human_count} open)",
+                link=link,
+            )
+        if too_many:
+            return HealthCheckResult(
+                check_name=self.name,
+                severity=Severity.MEDIUM,
                 summary=f"({human_count}) open issues (excl. bots)",
-                link=f"https://github.com/{status.full_name}/issues",
+                link=link,
             )
 
         return HealthCheckResult(

--- a/src/augint_tools/dashboard/widgets/repo_card.py
+++ b/src/augint_tools/dashboard/widgets/repo_card.py
@@ -55,9 +55,12 @@ _STATUS_ICON = {
 # flags the card and its severity styling already communicates the concern.
 _ISSUE_HINT_THRESHOLD = 10
 
-# An open issue older than this turns the issues count yellow so it stands
-# out without escalating the whole card's severity.
-_ISSUE_STALE_AGE = timedelta(days=3)
+# Age tiers for the issues counter on the counts line. Kept in lock-step with
+# the ``open_issues`` health check (see ``stale_issue_days`` /
+# ``critical_issue_days`` defaults) so the count colour and the card border
+# severity tell the same story: stale -> yellow, ancient -> red.
+_ISSUE_STALE_AGE = timedelta(days=7)
+_ISSUE_CRITICAL_AGE = timedelta(days=30)
 
 
 def _within_window(iso_ts: str | None, window_seconds: int) -> bool:
@@ -313,11 +316,14 @@ class RepoCard(Widget):
     def _issue_count_style(self, status, spec: ThemeSpec) -> str:
         """Return the inline style for the issue count number.
 
-        Yellow when any human-filed issue is older than three days; blue when
-        there is at least one human-filed issue but the count is still below
-        the health check's threshold. Otherwise no override -- inherit the
-        card's default text colour.
+        Red when any human-filed issue is older than the critical threshold;
+        yellow at the stale threshold; blue when there is at least one
+        human-filed issue but the count is still below the health check's
+        threshold. Otherwise no override -- inherit the card's default text
+        colour.
         """
+        if _older_than(status.oldest_issue_created_at, _ISSUE_CRITICAL_AGE):
+            return spec.severity_colors[Severity.CRITICAL]
         if _older_than(status.oldest_issue_created_at, _ISSUE_STALE_AGE):
             return spec.severity_colors[Severity.MEDIUM]
         if 0 < status.human_open_issues < _ISSUE_HINT_THRESHOLD:
@@ -372,26 +378,20 @@ class RepoCard(Widget):
     def _healthy_info_lines(self, health: RepoHealth, limit: int | None) -> list[tuple[Text, str]]:
         """Informative OK-severity rows used when this repo has zero findings.
 
-        Surfaces open issues / PRs / drafts with click targets, so a green card
-        still offers a jumping-off point. Falls back to a single "healthy"
-        line linking to the repo home when there's nothing to show at all.
+        Surfaces open PRs / drafts with click targets, so a green card still
+        offers a jumping-off point. Open issues are intentionally omitted here
+        -- the counts line already carries a numerical indicator, and the
+        open_issues health check escalates severity when issues are old or
+        numerous. Falls back to a single "healthy" line linking to the repo
+        home when there's nothing to show at all.
         """
         spec = self._theme_spec
         status = health.status
         ok_style = spec.severity_colors[Severity.OK]
         full_name = status.full_name
-        issues_url = f"https://github.com/{full_name}/issues"
         pulls_url = f"https://github.com/{full_name}/pulls"
 
         info: list[tuple[Text, str]] = []
-        if status.open_issues > 0:
-            noun = "issue" if status.open_issues == 1 else "issues"
-            info.append(
-                (
-                    Text(f"{status.open_issues} open {noun}", style=ok_style),
-                    issues_url,
-                )
-            )
         # "open PRs" here means non-draft PRs -- drafts get their own line so
         # the reader can tell at a glance which ones are actually review-ready.
         ready_prs = max(0, status.open_prs - status.draft_prs)

--- a/tests/unit/test_checks.py
+++ b/tests/unit/test_checks.py
@@ -1,7 +1,12 @@
 """Tests for check system."""
 
-from augint_tools.checks import Phase, resolve_plan
+from pathlib import Path
+from unittest.mock import patch
+
+from augint_tools.checks import Phase, PhaseResult, resolve_plan, run_plan
+from augint_tools.checks.runner import _apply_fix_flag, _extract_failures
 from augint_tools.detection.commands import CommandPlan
+from augint_tools.execution.runner import CommandResult
 
 
 class TestPhases:
@@ -68,3 +73,102 @@ class TestPlanResolution:
         assert len(d["phases"]) == 1
         assert d["phases"][0]["name"] == "quality"
         assert d["phases"][0]["command"] == "ruff check ."
+
+    def test_ci_preset_mirrors_full(self):
+        plan_ci = resolve_plan(self._sample_plan(), preset="ci")
+        plan_full = resolve_plan(self._sample_plan(), preset="full")
+        assert [p.name for p in plan_ci.phases] == [p.name for p in plan_full.phases]
+        assert plan_ci.preset == "ci"
+
+    def test_unknown_preset_falls_back_to_default(self):
+        plan = resolve_plan(self._sample_plan(), preset="bogus")
+        # Unknown preset silently uses default -> quality + tests.
+        assert [p.name for p in plan.phases] == ["quality", "tests"]
+
+
+class TestApplyFixFlag:
+    def test_adds_fix_to_ruff(self):
+        assert _apply_fix_flag("ruff check src/") == "ruff check --fix src/"
+
+    def test_pre_commit_unchanged(self):
+        # pre-commit auto-fixes already; command stays identical.
+        assert _apply_fix_flag("pre-commit run --all-files") == "pre-commit run --all-files"
+
+    def test_biome_check_gets_apply(self):
+        assert _apply_fix_flag("biome check src/") == "biome check --apply src/"
+
+    def test_unknown_tool_returns_unchanged(self):
+        assert _apply_fix_flag("mypy src/") == "mypy src/"
+
+
+class TestExtractFailures:
+    def test_keeps_error_lines_only(self):
+        output = "  starting build\nerror: something broke\nok: fine\nTask failed horribly\n"
+        assert _extract_failures(output) == [
+            "error: something broke",
+            "Task failed horribly",
+        ]
+
+    def test_ignores_blank_lines(self):
+        assert _extract_failures("\n\n  \n") == []
+
+    def test_caps_at_twenty(self):
+        spam = "\n".join([f"error line {i}" for i in range(50)])
+        assert len(_extract_failures(spam)) == 20
+
+
+class TestRunPlan:
+    def _plan(self, *, fixable: bool = False) -> CommandPlan:
+        return CommandPlan(quality="ruff check .", tests="pytest -v")
+
+    def test_successful_run_marks_phases_passed(self):
+        plan = resolve_plan(self._plan(), preset="default")
+        with patch(
+            "augint_tools.checks.runner.run_command",
+            return_value=CommandResult(
+                success=True, exit_code=0, stdout="ok", stderr="", command="x"
+            ),
+        ):
+            results = run_plan(plan, cwd=Path("."))
+        assert [r.status for r in results] == ["passed", "passed"]
+        assert all(isinstance(r, PhaseResult) for r in results)
+        assert results[0].to_dict()["status"] == "passed"
+
+    def test_failure_extracts_failures_and_sets_status(self):
+        plan = resolve_plan(self._plan(), preset="quick")
+        failing = CommandResult(
+            success=False,
+            exit_code=1,
+            stdout="",
+            stderr="error: broken\nbuild failed\n",
+            command="x",
+        )
+        with patch("augint_tools.checks.runner.run_command", return_value=failing):
+            results = run_plan(plan, cwd=Path("."))
+        assert results[0].status == "failed"
+        assert "error: broken" in results[0].failures
+        assert results[0].exit_code == 1
+
+    def test_fix_mode_rewrites_command_and_marks_fixed(self):
+        plan = resolve_plan(self._plan(), preset="quick")
+        with patch(
+            "augint_tools.checks.runner.run_command",
+            return_value=CommandResult(
+                success=True, exit_code=0, stdout="", stderr="", command="x"
+            ),
+        ) as mock_run:
+            results = run_plan(plan, cwd=Path("."), fix=True)
+        # The resolved phase for "quality" is fixable -> command gets --fix.
+        assert mock_run.call_args.args[0] == "ruff check --fix ."
+        assert results[0].status == "fixed"
+        # The PhaseResult records the original command, not the fix-mutated one.
+        assert results[0].command == "ruff check ."
+
+    def test_failure_uses_stdout_when_stderr_empty(self):
+        plan = resolve_plan(self._plan(), preset="quick")
+        failing = CommandResult(
+            success=False, exit_code=2, stdout="error: boom", stderr="", command="x"
+        )
+        with patch("augint_tools.checks.runner.run_command", return_value=failing):
+            results = run_plan(plan, cwd=Path("."))
+        assert "error: boom" in results[0].failures

--- a/tests/unit/test_dashboard.py
+++ b/tests/unit/test_dashboard.py
@@ -827,7 +827,7 @@ class TestRepoCardRender:
         RepoCard, spec = self._spec()
         status = _status(open_issues=2)
         status.human_open_issues = 2
-        status.oldest_issue_created_at = (datetime.now(UTC) - timedelta(days=5)).isoformat()
+        status.oldest_issue_created_at = (datetime.now(UTC) - timedelta(days=10)).isoformat()
         health = RepoHealth(status=status)
         card = RepoCard(health, theme_spec=spec)
         line = card._counts_line(health)
@@ -837,6 +837,20 @@ class TestRepoCardRender:
         styles = [str(span.style) for span in line.spans]
         assert any(medium_color in s for s in styles)
         assert not any(low_color in s for s in styles if low_color != medium_color)
+
+    def test_counts_line_red_when_ancient(self):
+        from datetime import UTC, datetime, timedelta
+
+        RepoCard, spec = self._spec()
+        status = _status(open_issues=2)
+        status.human_open_issues = 2
+        status.oldest_issue_created_at = (datetime.now(UTC) - timedelta(days=45)).isoformat()
+        health = RepoHealth(status=status)
+        card = RepoCard(health, theme_spec=spec)
+        line = card._counts_line(health)
+        # ancient beats stale -- the count tint jumps to CRITICAL.
+        critical_color = spec.severity_colors[Severity.CRITICAL]
+        assert any(critical_color in str(span.style) for span in line.spans)
 
 
 class TestFindingsLinesHealthyInfo:
@@ -856,34 +870,29 @@ class TestFindingsLinesHealthyInfo:
         assert text.plain == "healthy"
         assert url == "https://github.com/org/quiet"
 
-    def test_no_findings_with_open_issues_returns_issues_line(self):
+    def test_no_findings_open_issues_alone_falls_back_to_healthy(self):
+        # Issues are communicated by the counts-line numerical indicator and
+        # by severity escalation in the open_issues check; they deliberately
+        # don't produce an info row, so a repo with only open issues reads as
+        # "healthy" in the findings slot.
         RepoCard, spec = self._spec()
         status = _status(full_name="org/busy", open_issues=4)
         health = RepoHealth(status=status)
         card = RepoCard(health, theme_spec=spec)
         lines = card._findings_lines(health, limit=2)
-        assert any(
-            line.plain == "4 open issues" and url == "https://github.com/org/busy/issues"
-            for line, url in lines
-        )
+        assert [(line.plain, url) for line, url in lines] == [
+            ("healthy", "https://github.com/org/busy"),
+        ]
 
-    def test_no_findings_single_issue_uses_singular_noun(self):
-        RepoCard, spec = self._spec()
-        status = _status(full_name="org/busy", open_issues=1)
-        health = RepoHealth(status=status)
-        card = RepoCard(health, theme_spec=spec)
-        lines = card._findings_lines(health, limit=2)
-        assert lines[0][0].plain == "1 open issue"
-
-    def test_no_findings_with_issues_and_prs_returns_both_lines(self):
+    def test_no_findings_with_issues_and_prs_only_pr_line_emitted(self):
         RepoCard, spec = self._spec()
         status = _status(full_name="org/busy", open_issues=2, open_prs=3)
         health = RepoHealth(status=status)
         card = RepoCard(health, theme_spec=spec)
         lines = card._findings_lines(health, limit=4)
         plain = [(line.plain, url) for line, url in lines]
-        assert ("2 open issues", "https://github.com/org/busy/issues") in plain
         assert ("3 open prs", "https://github.com/org/busy/pulls") in plain
+        assert not any(line.plain.endswith("open issues") for line, _ in lines)
 
     def test_no_findings_drafts_line_separate_from_ready_prs(self):
         RepoCard, spec = self._spec()

--- a/tests/unit/test_dashboard_common.py
+++ b/tests/unit/test_dashboard_common.py
@@ -1,0 +1,200 @@
+"""Tests for dashboard._common env/auth helpers."""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+from subprocess import CompletedProcess
+from unittest.mock import MagicMock, patch
+
+import pytest
+from github.GithubException import UnknownObjectException
+from loguru import logger
+
+from augint_tools.dashboard._common import (
+    _get_gh_cli_token,
+    _load_dotenv_values,
+    _resolve_token,
+    configure_logging,
+    get_github_client,
+    get_github_repo,
+    load_env_config,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_logging():
+    # Keep loguru sinks from leaking across tests.
+    yield
+    logger.remove()
+    logger.add(lambda _msg: None)
+
+
+class TestLoadDotenvValues:
+    def test_reads_values(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / ".env").write_text("FOO=bar\nBAZ=qux\n")
+        values = _load_dotenv_values(".env")
+        assert values == {"FOO": "bar", "BAZ": "qux"}
+
+    def test_filters_none_values(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        # An empty (no "=") line yields None as a value in python-dotenv.
+        (tmp_path / ".env").write_text("FOO=bar\nNAKED\n")
+        values = _load_dotenv_values(".env")
+        assert values == {"FOO": "bar"}
+
+
+class TestLoadEnvConfig:
+    def test_environment_overrides_dotenv(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / ".env").write_text("GH_REPO=from-env\nGH_ACCOUNT=acct-env\nGH_TOKEN=tok-env\n")
+        monkeypatch.setenv("GH_REPO", "from-os")
+        monkeypatch.delenv("GH_ACCOUNT", raising=False)
+        monkeypatch.delenv("GH_TOKEN", raising=False)
+        repo, account, token = load_env_config(".env")
+        assert repo == "from-os"
+        assert account == "acct-env"
+        assert token == "tok-env"
+
+    def test_empty_fallbacks(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        # No .env file and no env vars -> empty strings.
+        monkeypatch.delenv("GH_REPO", raising=False)
+        monkeypatch.delenv("GH_ACCOUNT", raising=False)
+        monkeypatch.delenv("GH_TOKEN", raising=False)
+        assert load_env_config(".env") == ("", "", "")
+
+
+class TestGetGhCliToken:
+    def test_strips_gh_tokens_from_env(self, monkeypatch):
+        monkeypatch.setenv("GH_TOKEN", "narrow")
+        monkeypatch.setenv("GITHUB_TOKEN", "narrow2")
+        monkeypatch.setenv("KEEP_ME", "yes")
+        captured_env = {}
+
+        def fake_run(cmd, **kwargs):
+            captured_env.update(kwargs.get("env") or {})
+            return CompletedProcess(args=cmd, returncode=0, stdout="kr-token\n")
+
+        with patch("augint_tools.dashboard._common.subprocess.run", side_effect=fake_run):
+            assert _get_gh_cli_token() == "kr-token"
+        assert "GH_TOKEN" not in captured_env
+        assert "GITHUB_TOKEN" not in captured_env
+        assert captured_env.get("KEEP_ME") == "yes"
+
+    def test_returns_empty_on_called_process_error(self):
+        with patch(
+            "augint_tools.dashboard._common.subprocess.run",
+            side_effect=subprocess.CalledProcessError(1, "gh"),
+        ):
+            assert _get_gh_cli_token() == ""
+
+    def test_returns_empty_when_gh_missing(self):
+        with patch("augint_tools.dashboard._common.subprocess.run", side_effect=FileNotFoundError):
+            assert _get_gh_cli_token() == ""
+
+
+class TestResolveToken:
+    def test_dotenv_mode_returns_dotenv_token(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / ".env").write_text("GH_TOKEN=from-dotenv\n")
+        assert _resolve_token(".env", auth_source="dotenv") == "from-dotenv"
+
+    def test_dotenv_mode_raises_when_missing(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / ".env").write_text("FOO=bar\n")
+        with pytest.raises(RuntimeError, match="No GitHub token"):
+            _resolve_token(".env", auth_source="dotenv")
+
+    def test_unknown_auth_source_raises(self):
+        with pytest.raises(ValueError, match="Unsupported"):
+            _resolve_token(auth_source="bogus")
+
+    def test_auto_prefers_gh_cli(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / ".env").write_text("GH_TOKEN=dotenv-tok\n")
+        monkeypatch.setenv("GH_TOKEN", "env-tok")
+        with patch("augint_tools.dashboard._common._get_gh_cli_token", return_value="kr-tok"):
+            assert _resolve_token(".env") == "kr-tok"
+
+    def test_auto_falls_back_to_env(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / ".env").write_text("GH_TOKEN=dotenv-tok\n")
+        monkeypatch.setenv("GH_TOKEN", "env-tok")
+        with patch("augint_tools.dashboard._common._get_gh_cli_token", return_value=""):
+            assert _resolve_token(".env") == "env-tok"
+
+    def test_auto_falls_back_to_dotenv(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / ".env").write_text("GH_TOKEN=dotenv-tok\n")
+        monkeypatch.delenv("GH_TOKEN", raising=False)
+        with patch("augint_tools.dashboard._common._get_gh_cli_token", return_value=""):
+            assert _resolve_token(".env") == "dotenv-tok"
+
+    def test_auto_raises_when_nothing_configured(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("GH_TOKEN", raising=False)
+        with patch("augint_tools.dashboard._common._get_gh_cli_token", return_value=""):
+            with pytest.raises(RuntimeError, match="No GitHub token"):
+                _resolve_token(".env")
+
+
+class TestGithubFactories:
+    def test_get_github_client(self):
+        with (
+            patch("augint_tools.dashboard._common._resolve_token", return_value="tok"),
+            patch("augint_tools.dashboard._common.Github") as mock_github,
+        ):
+            mock_github.return_value = "client"
+            assert get_github_client() == "client"
+        assert mock_github.called
+
+    def test_get_github_repo_user_lookup(self):
+        user_repo = MagicMock(name="user-repo")
+        client = MagicMock()
+        client.get_user.return_value.get_repo.return_value = user_repo
+        with (
+            patch("augint_tools.dashboard._common._resolve_token", return_value="tok"),
+            patch("augint_tools.dashboard._common.Github", return_value=client),
+        ):
+            result = get_github_repo("owner", "repo")
+        assert result is user_repo
+        client.get_user.assert_called_with("owner")
+        client.get_organization.assert_not_called()
+
+    def test_get_github_repo_falls_back_to_org(self):
+        org_repo = MagicMock(name="org-repo")
+        client = MagicMock()
+        client.get_user.return_value.get_repo.side_effect = UnknownObjectException(
+            404, "nope", None
+        )
+        client.get_organization.return_value.get_repo.return_value = org_repo
+        with (
+            patch("augint_tools.dashboard._common._resolve_token", return_value="tok"),
+            patch("augint_tools.dashboard._common.Github", return_value=client),
+        ):
+            result = get_github_repo("owner", "repo")
+        assert result is org_repo
+        client.get_organization.assert_called_with("owner")
+
+
+class TestConfigureLogging:
+    def test_verbose_without_log_file(self):
+        # Smoke test: just ensure it runs without raising and installs the
+        # stdlib InterceptHandler at level 0.
+        configure_logging(verbose=True)
+        assert logging.getLogger().level == 0
+
+    def test_log_file_sink(self, tmp_path):
+        log_file = tmp_path / "app.log"
+        configure_logging(verbose=False, log_file=str(log_file))
+        logger.info("hello-from-test")
+        # Flush by removing sinks.
+        logger.remove()
+        assert log_file.exists()
+
+    def test_chatty_stdlib_loggers_silenced(self):
+        configure_logging(verbose=False)
+        for name in ("github", "urllib3", "textual"):
+            assert logging.getLogger(name).level == logging.WARNING

--- a/tests/unit/test_dashboard_data.py
+++ b/tests/unit/test_dashboard_data.py
@@ -1,0 +1,321 @@
+"""Tests for dashboard._data cache + REST fallback helpers."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+from github.GithubException import GithubException
+
+from augint_tools.dashboard import _data
+from augint_tools.dashboard._data import (
+    RepoStatus,
+    _detect_service_markers,
+    _detect_tags,
+    _get_failed_step,
+    _is_org_repo,
+    _to_iso_utc,
+    fetch_failing_run_detail,
+    load_cache,
+    load_cache_timestamp,
+    load_health_cache,
+    save_cache,
+)
+
+
+def _status(name: str = "r", full_name: str | None = None) -> RepoStatus:
+    return RepoStatus(
+        name=name,
+        full_name=full_name or f"org/{name}",
+        has_dev_branch=False,
+        main_status="ok",
+        main_error=None,
+        dev_status=None,
+        dev_error=None,
+        open_issues=0,
+        open_prs=0,
+        draft_prs=0,
+    )
+
+
+class TestDetectTags:
+    def test_vite_branch(self):
+        is_ws, tags = _detect_tags("TypeScript", ("vite.config.ts",))
+        assert is_ws is False
+        assert "ts" in tags and "vite" in tags
+
+    def test_next_wins_over_vite(self):
+        is_ws, tags = _detect_tags("JavaScript", ("next.config.js", "vite.config.js"))
+        assert "next" in tags
+        # elif chain means vite not added when next present.
+        assert "vite" not in tags
+
+    def test_terraform_folder_detected(self):
+        _, tags = _detect_tags(None, ("terraform",))
+        assert "tf" in tags
+
+    def test_workspace_flag(self):
+        is_ws, _ = _detect_tags("Python", ("workspace.yaml", "pyproject.toml"))
+        assert is_ws is True
+
+
+class TestServiceMarkers:
+    def test_org_repo_excluded(self):
+        assert _is_org_repo("my-org") is True
+        assert _detect_service_markers("my-org", ("cdk.json",)) == ()
+
+    def test_workspace_excluded(self):
+        assert _detect_service_markers("anything", ("workspace.yaml", "cdk.json")) == ()
+
+    def test_python_library_excluded(self):
+        assert _detect_service_markers("lib", ("pyproject.toml", "template.yaml")) == ()
+
+    def test_python_plus_package_json_counts_as_service(self):
+        markers = _detect_service_markers(
+            "svc", ("pyproject.toml", "package.json", "template.yaml")
+        )
+        assert markers == ("template.yaml",)
+
+    def test_multiple_markers_preserved(self):
+        markers = _detect_service_markers("svc", ("template.yaml", "cdk.json"))
+        assert set(markers) == {"template.yaml", "cdk.json"}
+
+
+class TestToIsoUtc:
+    def test_none_passthrough(self):
+        assert _to_iso_utc(None) is None
+
+    def test_naive_datetime_gets_utc_tz(self):
+        naive = datetime(2026, 1, 2, 3, 4, 5)  # noqa: DTZ001 - exercising the tz-less path
+        result = _to_iso_utc(naive)
+        assert result is not None and result.endswith("+00:00")
+
+    def test_aware_datetime_converted_to_utc(self):
+        eastern = datetime(
+            2026,
+            1,
+            2,
+            12,
+            0,
+            0,
+            tzinfo=timezone(_offset := __import__("datetime").timedelta(hours=-5)),
+        )
+        out = _to_iso_utc(eastern)
+        # 12:00 EST -> 17:00 UTC.
+        assert out is not None and "17:00:00" in out
+
+    def test_non_datetime_returns_none(self):
+        # Objects without tzinfo/astimezone fall through the except path.
+        assert _to_iso_utc("not a datetime") is None
+
+
+class TestGetFailedStep:
+    def test_returns_job_and_step(self):
+        job = MagicMock()
+        job.name = "build"
+        job.conclusion = "failure"
+        failing_step = MagicMock(name="lint", conclusion="failure")
+        failing_step.name = "lint"
+        ok_step = MagicMock(name="setup", conclusion="success")
+        job.steps = [ok_step, failing_step]
+        run = MagicMock()
+        run.jobs.return_value = [job]
+        assert _get_failed_step(run) == "build: lint"
+
+    def test_failing_job_without_failing_step_returns_job_name(self):
+        job = MagicMock()
+        job.name = "deploy"
+        job.conclusion = "failure"
+        job.steps = []  # no failing step -> fall back to job name
+        run = MagicMock()
+        run.jobs.return_value = [job]
+        assert _get_failed_step(run) == "deploy"
+
+    def test_no_failing_jobs_returns_none(self):
+        job = MagicMock(conclusion="success")
+        run = MagicMock()
+        run.jobs.return_value = [job]
+        assert _get_failed_step(run) is None
+
+    def test_jobs_raises_github_exception(self):
+        run = MagicMock()
+        run.jobs.side_effect = GithubException(500, "boom", None)
+        assert _get_failed_step(run) is None
+
+    def test_jobs_missing_attribute(self):
+        run = MagicMock()
+        # AttributeError path via side_effect.
+        run.jobs.side_effect = AttributeError("no jobs")
+        assert _get_failed_step(run) is None
+
+
+class TestFetchFailingRunDetail:
+    def test_returns_error_and_timestamp(self):
+        repo = MagicMock()
+        run = MagicMock()
+        run.conclusion = "failure"
+        run.updated_at = datetime(2026, 1, 1, tzinfo=UTC)
+        runs = MagicMock()
+        runs.__getitem__ = lambda self, i: run if i == 0 else (_ for _ in ()).throw(IndexError())
+        repo.get_workflow_runs.return_value = runs
+        with patch("augint_tools.dashboard._data._get_failed_step", return_value="build: lint"):
+            error, when = fetch_failing_run_detail(repo, "main")
+        assert error == "build: lint"
+        assert when is not None and when.startswith("2026-01-01")
+
+    def test_falls_back_to_run_started_at(self):
+        repo = MagicMock()
+        run = MagicMock()
+        run.conclusion = "timed_out"
+        run.updated_at = None
+        run.run_started_at = datetime(2026, 2, 2, tzinfo=UTC)
+        runs = MagicMock()
+        runs.__getitem__ = lambda self, i: run
+        repo.get_workflow_runs.return_value = runs
+        with patch("augint_tools.dashboard._data._get_failed_step", return_value=None):
+            error, when = fetch_failing_run_detail(repo, "main")
+        assert error is None
+        assert when is not None and when.startswith("2026-02-02")
+
+    def test_no_runs(self):
+        repo = MagicMock()
+        runs = MagicMock()
+        runs.__getitem__ = MagicMock(side_effect=IndexError)
+        repo.get_workflow_runs.return_value = runs
+        assert fetch_failing_run_detail(repo, "main") == (None, None)
+
+    def test_successful_run_ignored(self):
+        repo = MagicMock()
+        run = MagicMock(conclusion="success")
+        runs = MagicMock()
+        runs.__getitem__ = lambda self, i: run
+        repo.get_workflow_runs.return_value = runs
+        assert fetch_failing_run_detail(repo, "main") == (None, None)
+
+    def test_github_exception_from_list_call(self):
+        repo = MagicMock()
+        repo.get_workflow_runs.side_effect = GithubException(500, "boom", None)
+        assert fetch_failing_run_detail(repo, "main") == (None, None)
+
+    def test_github_exception_on_index(self):
+        repo = MagicMock()
+        runs = MagicMock()
+        runs.__getitem__ = MagicMock(side_effect=GithubException(500, "boom", None))
+        repo.get_workflow_runs.return_value = runs
+        assert fetch_failing_run_detail(repo, "main") == (None, None)
+
+
+@pytest.fixture
+def isolated_cache(tmp_path, monkeypatch):
+    cache_file = tmp_path / "tui_cache.json"
+    monkeypatch.setattr(_data, "CACHE_DIR", tmp_path)
+    monkeypatch.setattr(_data, "CACHE_FILE", cache_file)
+    return cache_file
+
+
+class TestCache:
+    def test_load_cache_missing_file(self, isolated_cache):
+        assert load_cache() == {}
+
+    def test_save_then_load_roundtrip(self, isolated_cache):
+        save_cache([_status("a"), _status("b")])
+        loaded = load_cache()
+        assert set(loaded.keys()) == {"org/a", "org/b"}
+        assert isinstance(loaded["org/a"], RepoStatus)
+
+    def test_load_cache_ignores_unknown_fields(self, isolated_cache):
+        isolated_cache.write_text(
+            json.dumps(
+                {
+                    "repos": {
+                        "org/x": {
+                            "name": "x",
+                            "full_name": "org/x",
+                            "has_dev_branch": False,
+                            "main_status": "ok",
+                            "main_error": None,
+                            "dev_status": None,
+                            "dev_error": None,
+                            "open_issues": 0,
+                            "open_prs": 0,
+                            "draft_prs": 0,
+                            "tags": ["py"],
+                            "service_markers": ["cdk.json"],
+                            "invented_future_field": "ignore me",
+                        }
+                    }
+                }
+            )
+        )
+        loaded = load_cache()
+        assert "org/x" in loaded
+        # list -> tuple coercion applied on known fields.
+        assert loaded["org/x"].tags == ("py",)
+        assert loaded["org/x"].service_markers == ("cdk.json",)
+
+    def test_load_cache_malformed_json(self, isolated_cache):
+        isolated_cache.write_text("not json")
+        assert load_cache() == {}
+
+    def test_save_cache_preserves_existing_health(self, isolated_cache):
+        isolated_cache.parent.mkdir(parents=True, exist_ok=True)
+        isolated_cache.write_text(
+            json.dumps(
+                {
+                    "repos": {},
+                    "health": {"org/a": {"findings": []}},
+                    "health_ts": "2026-04-22T00:00:00+00:00",
+                }
+            )
+        )
+        save_cache([_status("a")])
+        data = json.loads(isolated_cache.read_text())
+        assert data["health"] == {"org/a": {"findings": []}}
+        assert data["health_ts"] == "2026-04-22T00:00:00+00:00"
+
+    def test_save_cache_with_fresh_health(self, isolated_cache):
+        health = MagicMock()
+        health.status.full_name = "org/a"
+        health.to_dict.return_value = {"findings": ["x"]}
+        save_cache([_status("a")], healths=[health])
+        data = json.loads(isolated_cache.read_text())
+        assert data["health"]["org/a"] == {"findings": ["x"]}
+        assert "health_ts" in data
+
+    def test_load_health_cache_missing(self, isolated_cache):
+        assert load_health_cache({}) == {}
+
+    def test_load_health_cache_no_health_section(self, isolated_cache):
+        isolated_cache.write_text(json.dumps({"repos": {}}))
+        assert load_health_cache({"org/a": _status("a")}) == {}
+
+    def test_load_health_cache_malformed(self, isolated_cache):
+        isolated_cache.write_text("broken")
+        assert load_health_cache({"org/a": _status("a")}) == {}
+
+    def test_load_cache_timestamp_missing_file(self, isolated_cache):
+        assert load_cache_timestamp() is None
+
+    def test_load_cache_timestamp_missing_field(self, isolated_cache):
+        isolated_cache.write_text(json.dumps({"repos": {}}))
+        assert load_cache_timestamp() is None
+
+    def test_load_cache_timestamp_aware(self, isolated_cache):
+        isolated_cache.write_text(
+            json.dumps({"repos": {}, "health_ts": "2026-04-22T12:00:00+00:00"})
+        )
+        ts = load_cache_timestamp()
+        assert ts is not None
+        assert ts.tzinfo is UTC
+        assert ts.hour == 12
+
+    def test_load_cache_timestamp_naive_assumed_utc(self, isolated_cache):
+        isolated_cache.write_text(json.dumps({"repos": {}, "health_ts": "2026-04-22T12:00:00"}))
+        ts = load_cache_timestamp()
+        assert ts is not None and ts.tzinfo is UTC
+
+    def test_load_cache_timestamp_invalid(self, isolated_cache):
+        isolated_cache.write_text(json.dumps({"repos": {}, "health_ts": "garbage"}))
+        assert load_cache_timestamp() is None

--- a/tests/unit/test_dashboard_helpers.py
+++ b/tests/unit/test_dashboard_helpers.py
@@ -1,0 +1,223 @@
+"""Tests for dashboard._helpers repo-selection + rate-limit helpers."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import click
+import pytest
+from github.GithubException import GithubException, UnknownObjectException
+
+from augint_tools.dashboard._helpers import (
+    get_viewer_login,
+    list_repos,
+    list_repos_multi,
+    list_user_orgs,
+    select_org_interactive,
+    select_repos_interactive,
+    strip_dotfile_repos,
+    warn_rate_limit,
+)
+
+
+def _repo(name: str, archived: bool = False, private: bool = False) -> MagicMock:
+    r = MagicMock()
+    r.name = name
+    r.full_name = f"org/{name}"
+    r.archived = archived
+    r.private = private
+    return r
+
+
+class TestStripDotfileRepos:
+    def test_drops_dotfile_repos(self):
+        repos = [_repo("a"), _repo(".github"), _repo(".discussions"), _repo("b")]
+        kept = strip_dotfile_repos(repos)
+        assert [r.name for r in kept] == ["a", "b"]
+
+    def test_handles_missing_name(self):
+        weird = MagicMock(spec=[])  # no .name attribute
+        assert strip_dotfile_repos([weird]) == [weird]
+
+
+class TestListRepos:
+    def test_organization_path(self):
+        g = MagicMock()
+        g.get_user.return_value.login = "viewer"
+        g.get_organization.return_value.get_repos.return_value = [
+            _repo("a"),
+            _repo("archived", archived=True),
+            _repo("b", private=True),
+        ]
+        repos = list_repos(g, "org")
+        assert [r.name for r in repos] == ["a", "b"]
+        g.get_organization.assert_called_with("org")
+
+    def test_user_fallback_when_not_org(self):
+        g = MagicMock()
+        g.get_user.return_value.login = "viewer"
+        g.get_organization.side_effect = UnknownObjectException(404, "nope", None)
+        user = MagicMock()
+        user.get_repos.return_value = [_repo("u1")]
+        # Second get_user call takes the owner string.
+        g.get_user.side_effect = [MagicMock(login="viewer"), user]
+        repos = list_repos(g, "someuser")
+        assert [r.name for r in repos] == ["u1"]
+
+    def test_viewer_lookup_failure_swallowed(self):
+        g = MagicMock()
+        # First get_user() (for viewer) fails; second (for owner) succeeds.
+        g.get_user.side_effect = [GithubException(500, "boom", None), MagicMock()]
+        g.get_organization.return_value.get_repos.return_value = [_repo("a")]
+        repos = list_repos(g, "org")
+        assert [r.name for r in repos] == ["a"]
+
+    def test_github_exception_on_org_lookup_falls_back_to_user(self):
+        g = MagicMock()
+        g.get_user.return_value.login = "viewer"
+        g.get_organization.side_effect = GithubException(500, "boom", None)
+        user = MagicMock()
+        user.get_repos.return_value = [_repo("u1")]
+        g.get_user.side_effect = [MagicMock(login="viewer"), user]
+        repos = list_repos(g, "x")
+        assert [r.name for r in repos] == ["u1"]
+
+
+class TestSelectOrgInteractive:
+    def test_no_orgs_returns_login(self):
+        g = MagicMock()
+        user = MagicMock()
+        user.login = "me"
+        user.get_orgs.return_value = []
+        g.get_user.return_value = user
+        assert select_org_interactive(g) == "me"
+
+    def test_selects_org(self):
+        g = MagicMock()
+        user = MagicMock()
+        user.login = "me"
+        org_a = MagicMock()
+        org_a.login = "acme"
+        org_b = MagicMock()
+        org_b.login = "beta"
+        user.get_orgs.return_value = [org_a, org_b]
+        g.get_user.return_value = user
+        with patch("augint_tools.dashboard._helpers.click.prompt", return_value=1):
+            assert select_org_interactive(g) == "acme"
+
+    def test_selects_personal(self):
+        g = MagicMock()
+        user = MagicMock()
+        user.login = "me"
+        org = MagicMock()
+        org.login = "acme"
+        user.get_orgs.return_value = [org]
+        g.get_user.return_value = user
+        # Index 2 is the personal entry when one org is present.
+        with patch("augint_tools.dashboard._helpers.click.prompt", return_value=2):
+            assert select_org_interactive(g) == "me"
+
+    def test_invalid_then_valid(self):
+        g = MagicMock()
+        user = MagicMock()
+        user.login = "me"
+        org = MagicMock()
+        org.login = "acme"
+        user.get_orgs.return_value = [org]
+        g.get_user.return_value = user
+        with patch("augint_tools.dashboard._helpers.click.prompt", side_effect=[9, 1]):
+            assert select_org_interactive(g) == "acme"
+
+
+class TestSelectReposInteractive:
+    def test_empty_raises(self):
+        with pytest.raises(click.ClickException):
+            select_repos_interactive([])
+
+    def test_valid_selection(self):
+        repos = [_repo("a"), _repo("b"), _repo("c")]
+        with patch("augint_tools.dashboard._helpers.click.prompt", return_value="1,3"):
+            picked = select_repos_interactive(repos)
+        assert [r.name for r in picked] == ["a", "c"]
+
+    def test_invalid_then_valid(self):
+        repos = [_repo("a"), _repo("b")]
+        # First "99" yields nothing in range -> reprompt; then "1" returns one.
+        with patch(
+            "augint_tools.dashboard._helpers.click.prompt",
+            side_effect=["99", "1"],
+        ):
+            picked = select_repos_interactive(repos)
+        assert [r.name for r in picked] == ["a"]
+
+    def test_non_integer_reprompted(self):
+        repos = [_repo("a"), _repo("b")]
+        with patch(
+            "augint_tools.dashboard._helpers.click.prompt",
+            side_effect=["bad", "2"],
+        ):
+            picked = select_repos_interactive(repos)
+        assert [r.name for r in picked] == ["b"]
+
+
+class TestViewerAndOrgHelpers:
+    def test_get_viewer_login_success(self):
+        g = MagicMock()
+        g.get_user.return_value.login = "me"
+        assert get_viewer_login(g) == "me"
+
+    def test_get_viewer_login_failure(self):
+        g = MagicMock()
+        g.get_user.side_effect = GithubException(500, "boom", None)
+        assert get_viewer_login(g) == ""
+
+    def test_list_user_orgs_success(self):
+        g = MagicMock()
+        a = MagicMock()
+        a.login = "a"
+        b = MagicMock()
+        b.login = "b"
+        g.get_user.return_value.get_orgs.return_value = [a, b]
+        assert list_user_orgs(g) == ["a", "b"]
+
+    def test_list_user_orgs_failure(self):
+        g = MagicMock()
+        g.get_user.side_effect = GithubException(500, "boom", None)
+        assert list_user_orgs(g) == []
+
+
+class TestListReposMulti:
+    def test_deduplicates_and_skips_errors(self):
+        r_a = _repo("a")
+        r_b = _repo("b")
+        call_results = {
+            "good": [r_a, r_b],
+            "also_good": [r_a],  # duplicate full_name -> deduped
+        }
+
+        def fake_list(_g, owner):
+            if owner == "bad":
+                raise RuntimeError("boom")
+            return call_results[owner]
+
+        with patch("augint_tools.dashboard._helpers.list_repos", side_effect=fake_list):
+            repos = list_repos_multi(MagicMock(), ["good", "bad", "also_good"])
+        assert [r.full_name for r in repos] == ["org/a", "org/b"]
+
+
+class TestWarnRateLimit:
+    def test_zero_refresh_does_nothing(self, capsys):
+        warn_rate_limit(repo_count=50, refresh_seconds=0)
+        assert capsys.readouterr().out == ""
+
+    def test_under_threshold_quiet(self, capsys):
+        # 60s refresh with 10 repos: 60 refreshes/hr * 1 query = 60, quiet.
+        warn_rate_limit(repo_count=10, refresh_seconds=60)
+        assert "Warning" not in capsys.readouterr().out
+
+    def test_over_threshold_warns(self, capsys):
+        # 10s refresh * ~14 queries/refresh (350 repos) = 5040, very loud.
+        warn_rate_limit(repo_count=350, refresh_seconds=10)
+        out = capsys.readouterr().out
+        assert "Warning" in out
+        assert "GraphQL queries/hour" in out

--- a/tests/unit/test_detection.py
+++ b/tests/unit/test_detection.py
@@ -1,6 +1,10 @@
 """Tests for detection engine."""
 
-from augint_tools.detection.commands import resolve_command_plan
+from pathlib import Path
+from unittest.mock import patch
+
+from augint_tools.detection.commands import CommandPlan, resolve_command_plan
+from augint_tools.detection.engine import GitHubState, RepoContext, detect
 from augint_tools.detection.framework import detect_framework
 from augint_tools.detection.language import detect_language
 from augint_tools.detection.toolchain import ToolchainInfo, detect_toolchain
@@ -112,3 +116,103 @@ class TestCommandPlanResolution:
         assert plan.quality == "npx next lint"
         assert plan.tests == "npm test"
         assert plan.build == "npx next build"
+
+
+class TestDetectEngine:
+    def _toolchain(self) -> ToolchainInfo:
+        return ToolchainInfo(
+            package_manager="uv",
+            has_pre_commit=True,
+            has_pytest=True,
+            has_ruff=True,
+            has_mypy=True,
+        )
+
+    def _plan(self) -> CommandPlan:
+        return CommandPlan(quality="q", tests="t", security="s", licenses="l", build="b")
+
+    def test_detect_not_a_git_repo_defaults(self, tmp_path):
+        with (
+            patch("augint_tools.detection.engine.detect_language", return_value="python"),
+            patch("augint_tools.detection.engine.detect_framework", return_value="plain"),
+            patch("augint_tools.detection.engine.detect_toolchain", return_value=self._toolchain()),
+            patch("augint_tools.detection.engine.resolve_command_plan", return_value=self._plan()),
+            patch("augint_tools.detection.engine.is_git_repo", return_value=False),
+            patch("augint_tools.detection.engine.is_gh_available", return_value=False),
+        ):
+            ctx = detect(tmp_path)
+        assert isinstance(ctx, RepoContext)
+        assert ctx.language == "python"
+        assert ctx.default_branch == "main"
+        assert ctx.current_branch is None
+        assert ctx.target_pr_branch == "main"
+        assert ctx.github == GitHubState()
+
+    def test_detect_git_without_gh(self, tmp_path):
+        with (
+            patch("augint_tools.detection.engine.detect_language", return_value="python"),
+            patch("augint_tools.detection.engine.detect_framework", return_value="plain"),
+            patch("augint_tools.detection.engine.detect_toolchain", return_value=self._toolchain()),
+            patch("augint_tools.detection.engine.resolve_command_plan", return_value=self._plan()),
+            patch("augint_tools.detection.engine.is_git_repo", return_value=True),
+            patch("augint_tools.detection.engine.detect_base_branch", return_value="dev"),
+            patch("augint_tools.detection.engine.get_current_branch", return_value="feat/x"),
+            patch("augint_tools.detection.engine.is_gh_available", return_value=False),
+        ):
+            ctx = detect(tmp_path)
+        assert ctx.default_branch == "dev"
+        assert ctx.current_branch == "feat/x"
+        assert ctx.github.available is False
+        assert ctx.github.repo_slug is None
+
+    def test_detect_full_gh_path(self, tmp_path):
+        with (
+            patch("augint_tools.detection.engine.detect_language", return_value="python"),
+            patch("augint_tools.detection.engine.detect_framework", return_value="plain"),
+            patch("augint_tools.detection.engine.detect_toolchain", return_value=self._toolchain()),
+            patch("augint_tools.detection.engine.resolve_command_plan", return_value=self._plan()),
+            patch("augint_tools.detection.engine.is_git_repo", return_value=True),
+            patch("augint_tools.detection.engine.detect_base_branch", return_value="main"),
+            patch("augint_tools.detection.engine.get_current_branch", return_value="main"),
+            patch("augint_tools.detection.engine.is_gh_available", return_value=True),
+            patch("augint_tools.detection.engine.is_gh_authenticated", return_value=True),
+            patch(
+                "augint_tools.detection.engine.get_remote_url",
+                return_value="https://github.com/org/repo.git",
+            ),
+        ):
+            ctx = detect(tmp_path)
+        assert ctx.github.available is True
+        assert ctx.github.authenticated is True
+        assert ctx.github.repo_slug == "org/repo"
+
+    def test_detect_defaults_to_cwd(self):
+        with (
+            patch("augint_tools.detection.engine.detect_language", return_value="unknown"),
+            patch("augint_tools.detection.engine.detect_framework", return_value="plain"),
+            patch("augint_tools.detection.engine.detect_toolchain", return_value=self._toolchain()),
+            patch("augint_tools.detection.engine.resolve_command_plan", return_value=self._plan()),
+            patch("augint_tools.detection.engine.is_git_repo", return_value=False),
+            patch("augint_tools.detection.engine.is_gh_available", return_value=False),
+        ):
+            ctx = detect()
+        assert ctx.path == Path.cwd()
+
+    def test_to_dict_round_trip(self, tmp_path):
+        ctx = RepoContext(
+            language="python",
+            framework="sam",
+            default_branch="main",
+            current_branch="feat/x",
+            target_pr_branch="main",
+            toolchain=self._toolchain(),
+            command_plan=self._plan(),
+            github=GitHubState(available=True, authenticated=True, repo_slug="org/r"),
+            path=tmp_path,
+        )
+        d = ctx.to_dict()
+        assert d["language"] == "python"
+        assert d["toolchain"]["package_manager"] == "uv"
+        assert d["command_plan"]["quality"] == "q"
+        assert d["github"] == {"available": True, "authenticated": True, "repo_slug": "org/r"}
+        assert d["path"] == str(tmp_path)

--- a/tests/unit/test_execution.py
+++ b/tests/unit/test_execution.py
@@ -1,5 +1,6 @@
 """Tests for execution module."""
 
+import subprocess
 from unittest.mock import Mock, patch
 
 from augint_tools.execution import run_command
@@ -71,3 +72,53 @@ class TestCommandDiscovery:
         """Test when no lint command found."""
         cmd = discover_lint_command(tmp_path)
         assert cmd is None
+
+    def test_discover_test_command_pyproject(self, tmp_path):
+        (tmp_path / "pyproject.toml").touch()
+        assert discover_test_command(tmp_path) == "pytest -v"
+
+    def test_discover_test_command_npm(self, tmp_path):
+        (tmp_path / "package.json").touch()
+        assert discover_test_command(tmp_path) == "npm test"
+
+    def test_discover_test_command_make(self, tmp_path):
+        (tmp_path / "Makefile").touch()
+        assert discover_test_command(tmp_path) == "make test"
+
+    def test_discover_test_command_defaults_to_cwd(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        assert discover_test_command() is None
+
+    def test_discover_lint_command_npm(self, tmp_path):
+        (tmp_path / "package.json").touch()
+        assert discover_lint_command(tmp_path) == "npm run lint"
+
+    def test_discover_lint_command_make(self, tmp_path):
+        (tmp_path / "Makefile").touch()
+        assert discover_lint_command(tmp_path) == "make lint"
+
+    def test_discover_lint_command_defaults_to_cwd(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        assert discover_lint_command() is None
+
+
+class TestRunCommandFailurePaths:
+    def test_timeout_returns_failure_with_message(self):
+        with patch(
+            "augint_tools.execution.runner.subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd="x", timeout=5),
+        ):
+            result = run_command("sleep 10", timeout=5)
+        assert result.success is False
+        assert result.exit_code == -1
+        assert "timed out" in result.stderr
+
+    def test_generic_exception_returns_failure(self):
+        with patch(
+            "augint_tools.execution.runner.subprocess.run",
+            side_effect=OSError("permission denied"),
+        ):
+            result = run_command("x")
+        assert result.success is False
+        assert result.exit_code == -1
+        assert "permission denied" in result.stderr

--- a/tests/unit/test_git.py
+++ b/tests/unit/test_git.py
@@ -3,12 +3,19 @@
 from unittest.mock import Mock, patch
 
 from augint_tools.git import (
+    branch_exists,
+    create_branch,
     detect_base_branch,
     extract_repo_slug,
     get_ahead_behind,
     get_current_branch,
     get_dirty_files,
+    get_remote_url,
+    get_repo_status,
     is_git_repo,
+    push_branch,
+    run_git,
+    switch_branch,
 )
 
 
@@ -127,3 +134,190 @@ class TestGitStatus:
         ahead, behind = get_ahead_behind()
         assert ahead == 0
         assert behind == 0
+
+    @patch("augint_tools.git.status.run_git")
+    def test_get_ahead_behind_explicit_remote(self, mock_run_git):
+        mock_run_git.return_value = Mock(returncode=0, stdout="1\t4\n")
+        ahead, behind = get_ahead_behind(remote_branch="origin/dev")
+        assert (ahead, behind) == (1, 4)
+        # No upstream lookup when explicit remote provided.
+        assert mock_run_git.call_count == 1
+
+    @patch("augint_tools.git.status.run_git")
+    def test_get_ahead_behind_malformed_output(self, mock_run_git):
+        # Single field instead of two -> defaults to (0, 0) without blowing up.
+        mock_run_git.return_value = Mock(returncode=0, stdout="oops\n")
+        assert get_ahead_behind(remote_branch="origin/main") == (0, 0)
+
+    @patch("augint_tools.git.status.run_git")
+    def test_get_ahead_behind_compare_fails(self, mock_run_git):
+        mock_run_git.side_effect = [
+            Mock(returncode=0, stdout="origin/main\n"),
+            Mock(returncode=128, stdout=""),
+        ]
+        assert get_ahead_behind() == (0, 0)
+
+    @patch("augint_tools.git.status.run_git")
+    def test_get_dirty_files_error(self, mock_run_git):
+        mock_run_git.return_value = Mock(returncode=128, stdout="")
+        assert get_dirty_files() == []
+
+    @patch("augint_tools.git.status.get_dirty_files")
+    @patch("augint_tools.git.status.get_ahead_behind")
+    @patch("augint_tools.git.repo.get_current_branch")
+    def test_get_repo_status_detects_branch(self, mock_branch, mock_ahead, mock_dirty):
+        mock_branch.return_value = "feat/x"
+        mock_ahead.return_value = (2, 1)
+        mock_dirty.return_value = ["a.py", "b.py"]
+        status = get_repo_status()
+        assert status.branch == "feat/x"
+        assert status.dirty is True
+        assert status.dirty_files == ["a.py", "b.py"]
+        assert (status.ahead, status.behind) == (2, 1)
+
+    @patch("augint_tools.git.status.get_dirty_files")
+    @patch("augint_tools.git.status.get_ahead_behind")
+    def test_get_repo_status_clean_with_explicit_branch(self, mock_ahead, mock_dirty):
+        mock_ahead.return_value = (0, 0)
+        mock_dirty.return_value = []
+        status = get_repo_status(branch="main")
+        assert status.branch == "main"
+        assert status.dirty is False
+        assert status.dirty_files == []
+
+
+class TestGitRepoExtras:
+    @patch("augint_tools.git.repo.subprocess.run")
+    def test_run_git_invokes_subprocess(self, mock_run):
+        mock_run.return_value = Mock(returncode=0, stdout="", stderr="")
+        run_git(["status"], check=False)
+        args, kwargs = mock_run.call_args
+        assert args[0][0] == "git"
+        assert kwargs["capture_output"] is True
+        assert kwargs["text"] is True
+        assert kwargs["check"] is False
+
+    @patch("augint_tools.git.repo.run_git")
+    def test_get_remote_url_found(self, mock_run_git):
+        mock_run_git.return_value = Mock(returncode=0, stdout="https://github.com/org/repo.git\n")
+        assert get_remote_url() == "https://github.com/org/repo.git"
+
+    @patch("augint_tools.git.repo.run_git")
+    def test_get_remote_url_missing(self, mock_run_git):
+        mock_run_git.return_value = Mock(returncode=2, stdout="")
+        assert get_remote_url(remote="upstream") is None
+
+    @patch("augint_tools.git.repo.run_git")
+    def test_detect_base_branch_remote_only(self, mock_run_git):
+        # No local candidate, but remote has main -> returns main.
+        mock_run_git.return_value = Mock(returncode=0, stdout="* feat/x\n  remotes/origin/main\n")
+        assert detect_base_branch() == "main"
+
+    @patch("augint_tools.git.repo.run_git")
+    def test_detect_base_branch_falls_back_to_main(self, mock_run_git):
+        # No candidate anywhere.
+        mock_run_git.return_value = Mock(returncode=0, stdout="* feat/x\n")
+        assert detect_base_branch() == "main"
+
+    @patch("augint_tools.git.repo.run_git")
+    def test_detect_base_branch_error_defaults_main(self, mock_run_git):
+        mock_run_git.return_value = Mock(returncode=128, stdout="")
+        assert detect_base_branch() == "main"
+
+    def test_extract_repo_slug_proxy_without_enough_parts(self):
+        # Proxy path missing the repo segment returns None instead of a partial.
+        assert extract_repo_slug("http://local_proxy@127.0.0.1:8080/git/onlyowner") is None
+
+    def test_extract_repo_slug_ssh_malformed(self):
+        # Two colons means we can't cleanly split into "host:slug".
+        assert extract_repo_slug("git@github.com:a:b") is None
+
+
+class TestBranchOps:
+    @patch("augint_tools.git.branch.run_git")
+    def test_create_branch_success(self, mock_run_git):
+        mock_run_git.return_value = Mock(returncode=0)
+        assert create_branch(name="feat/x", base="main") is True
+        args = mock_run_git.call_args[0][0]
+        assert args == ["checkout", "-b", "feat/x", "main"]
+
+    @patch("augint_tools.git.branch.run_git")
+    def test_create_branch_failure(self, mock_run_git):
+        mock_run_git.return_value = Mock(returncode=1)
+        assert create_branch(name="feat/x") is False
+
+    @patch("augint_tools.git.branch.run_git")
+    def test_create_branch_exception(self, mock_run_git):
+        mock_run_git.side_effect = RuntimeError("boom")
+        assert create_branch(name="feat/x") is False
+
+    @patch("augint_tools.git.branch.run_git")
+    def test_switch_branch_success(self, mock_run_git):
+        mock_run_git.return_value = Mock(returncode=0)
+        assert switch_branch(name="main") is True
+        assert mock_run_git.call_args[0][0] == ["checkout", "main"]
+
+    @patch("augint_tools.git.branch.run_git")
+    def test_switch_branch_failure(self, mock_run_git):
+        mock_run_git.return_value = Mock(returncode=1)
+        assert switch_branch(name="missing") is False
+
+    @patch("augint_tools.git.branch.run_git")
+    def test_switch_branch_exception(self, mock_run_git):
+        mock_run_git.side_effect = RuntimeError("boom")
+        assert switch_branch(name="main") is False
+
+    @patch("augint_tools.git.branch.run_git")
+    def test_push_branch_with_upstream(self, mock_run_git):
+        mock_run_git.return_value = Mock(returncode=0)
+        assert push_branch(branch="feat/x") is True
+        assert mock_run_git.call_args[0][0] == ["push", "-u", "origin", "feat/x"]
+
+    @patch("augint_tools.git.branch.run_git")
+    def test_push_branch_without_upstream(self, mock_run_git):
+        mock_run_git.return_value = Mock(returncode=0)
+        assert push_branch(branch="feat/x", set_upstream=False) is True
+        assert mock_run_git.call_args[0][0] == ["push", "origin", "feat/x"]
+
+    @patch("augint_tools.git.branch.run_git")
+    def test_push_branch_without_upstream_no_branch(self, mock_run_git):
+        mock_run_git.return_value = Mock(returncode=0)
+        assert push_branch(set_upstream=False) is True
+        assert mock_run_git.call_args[0][0] == ["push", "origin"]
+
+    @patch("augint_tools.git.branch.run_git")
+    def test_push_branch_failure(self, mock_run_git):
+        mock_run_git.return_value = Mock(returncode=1)
+        assert push_branch(branch="feat/x") is False
+
+    @patch("augint_tools.git.branch.run_git")
+    def test_push_branch_exception(self, mock_run_git):
+        mock_run_git.side_effect = RuntimeError("boom")
+        assert push_branch(branch="feat/x") is False
+
+    @patch("augint_tools.git.branch.run_git")
+    def test_branch_exists_true(self, mock_run_git):
+        mock_run_git.return_value = Mock(returncode=0)
+        assert branch_exists(name="main") is True
+
+    @patch("augint_tools.git.branch.run_git")
+    def test_branch_exists_false(self, mock_run_git):
+        mock_run_git.return_value = Mock(returncode=128)
+        assert branch_exists(name="nope") is False
+
+    @patch("augint_tools.git.branch.run_git")
+    def test_branch_exists_exception(self, mock_run_git):
+        mock_run_git.side_effect = RuntimeError("boom")
+        assert branch_exists(name="x") is False
+
+
+class TestIsGitRepoException:
+    @patch("augint_tools.git.repo.run_git")
+    def test_is_git_repo_exception_swallowed(self, mock_run_git):
+        mock_run_git.side_effect = RuntimeError("boom")
+        assert is_git_repo() is False
+
+    @patch("augint_tools.git.repo.run_git")
+    def test_get_current_branch_exception(self, mock_run_git):
+        mock_run_git.side_effect = RuntimeError("boom")
+        assert get_current_branch() is None

--- a/tests/unit/test_github_cli.py
+++ b/tests/unit/test_github_cli.py
@@ -72,3 +72,37 @@ class TestRunGh:
             side_effect=FileNotFoundError,
         ):
             assert gh_cli._keyring_works() is False
+
+
+class TestAvailability:
+    def test_is_gh_available_true(self):
+        with patch("augint_tools.github.cli.run_gh") as mock_run:
+            mock_run.return_value = CompletedProcess(args=[], returncode=0, stdout="gh 2.0")
+            assert gh_cli.is_gh_available() is True
+
+    def test_is_gh_available_nonzero(self):
+        with patch("augint_tools.github.cli.run_gh") as mock_run:
+            mock_run.return_value = CompletedProcess(args=[], returncode=1, stdout="")
+            assert gh_cli.is_gh_available() is False
+
+    def test_is_gh_available_missing_binary(self):
+        with patch("augint_tools.github.cli.run_gh", side_effect=FileNotFoundError):
+            assert gh_cli.is_gh_available() is False
+
+    def test_is_gh_available_generic_exception(self):
+        with patch("augint_tools.github.cli.run_gh", side_effect=RuntimeError("boom")):
+            assert gh_cli.is_gh_available() is False
+
+    def test_is_gh_authenticated_true(self):
+        with patch("augint_tools.github.cli.run_gh") as mock_run:
+            mock_run.return_value = CompletedProcess(args=[], returncode=0, stdout="")
+            assert gh_cli.is_gh_authenticated() is True
+
+    def test_is_gh_authenticated_false(self):
+        with patch("augint_tools.github.cli.run_gh") as mock_run:
+            mock_run.return_value = CompletedProcess(args=[], returncode=1, stdout="")
+            assert gh_cli.is_gh_authenticated() is False
+
+    def test_is_gh_authenticated_exception(self):
+        with patch("augint_tools.github.cli.run_gh", side_effect=RuntimeError("boom")):
+            assert gh_cli.is_gh_authenticated() is False

--- a/tests/unit/test_github_ops.py
+++ b/tests/unit/test_github_ops.py
@@ -1,0 +1,187 @@
+"""Tests for GitHub PR and issue helpers."""
+
+import json
+from subprocess import CompletedProcess
+from unittest.mock import patch
+
+from augint_tools.github.issues import Issue, list_issues
+from augint_tools.github.prs import PullRequest, create_pr, enable_automerge, get_open_prs
+
+
+def _ok(stdout: str = "") -> CompletedProcess:
+    return CompletedProcess(args=[], returncode=0, stdout=stdout)
+
+
+def _fail(stdout: str = "") -> CompletedProcess:
+    return CompletedProcess(args=[], returncode=1, stdout=stdout)
+
+
+class TestGetOpenPrs:
+    def test_returns_parsed_prs(self):
+        payload = json.dumps(
+            [
+                {
+                    "number": 1,
+                    "title": "one",
+                    "state": "OPEN",
+                    "url": "u1",
+                    "headRefName": "feat/a",
+                },
+                {
+                    "number": 2,
+                    "title": "two",
+                    "state": "OPEN",
+                    "url": "u2",
+                    "headRefName": "feat/b",
+                },
+            ]
+        )
+        with patch("augint_tools.github.prs.run_gh", return_value=_ok(payload)) as mock_run:
+            prs = get_open_prs()
+        assert [p.number for p in prs] == [1, 2]
+        assert prs[0] == PullRequest(
+            number=1, title="one", state="OPEN", url="u1", head_ref="feat/a"
+        )
+        # Default call carries no --repo / --head.
+        cmd = mock_run.call_args[0][0]
+        assert "--repo" not in cmd
+        assert "--head" not in cmd
+
+    def test_passes_repo_and_branch_filters(self):
+        with patch("augint_tools.github.prs.run_gh", return_value=_ok("[]")) as mock_run:
+            get_open_prs(branch="feat/x", repo="org/repo")
+        cmd = mock_run.call_args[0][0]
+        assert cmd[-4:] == ["--repo", "org/repo", "--head", "feat/x"]
+
+    def test_nonzero_returns_empty(self):
+        with patch("augint_tools.github.prs.run_gh", return_value=_fail()):
+            assert get_open_prs() == []
+
+    def test_invalid_json_returns_empty(self):
+        with patch("augint_tools.github.prs.run_gh", return_value=_ok("not-json")):
+            assert get_open_prs() == []
+
+    def test_exception_returns_empty(self):
+        with patch("augint_tools.github.prs.run_gh", side_effect=RuntimeError("boom")):
+            assert get_open_prs() == []
+
+
+class TestCreatePr:
+    def test_returns_url_on_success(self):
+        with patch(
+            "augint_tools.github.prs.run_gh",
+            return_value=_ok("https://github.com/org/repo/pull/9\n"),
+        ) as mock_run:
+            url = create_pr(title="t", base="main", head="feat/x", body="b", repo="org/repo")
+        assert url == "https://github.com/org/repo/pull/9"
+        cmd = mock_run.call_args[0][0]
+        # Title/base/body always present; repo and head appended when given.
+        assert cmd[:7] == ["pr", "create", "--title", "t", "--base", "main", "--body"]
+        assert "--repo" in cmd and "org/repo" in cmd
+        assert "--head" in cmd and "feat/x" in cmd
+
+    def test_omits_optional_flags(self):
+        with patch("augint_tools.github.prs.run_gh", return_value=_ok("url\n")) as mock_run:
+            create_pr(title="t", base="main")
+        cmd = mock_run.call_args[0][0]
+        assert "--repo" not in cmd
+        assert "--head" not in cmd
+
+    def test_returns_none_on_failure(self):
+        with patch("augint_tools.github.prs.run_gh", return_value=_fail()):
+            assert create_pr(title="t", base="main") is None
+
+    def test_returns_none_on_exception(self):
+        with patch("augint_tools.github.prs.run_gh", side_effect=RuntimeError("boom")):
+            assert create_pr(title="t", base="main") is None
+
+
+class TestEnableAutomerge:
+    def test_success_default_method(self):
+        with patch("augint_tools.github.prs.run_gh", return_value=_ok()) as mock_run:
+            assert enable_automerge(42) is True
+        cmd = mock_run.call_args[0][0]
+        assert cmd == ["pr", "merge", "42", "--auto", "--merge"]
+
+    def test_method_and_repo(self):
+        with patch("augint_tools.github.prs.run_gh", return_value=_ok()) as mock_run:
+            assert enable_automerge(7, repo="org/repo", method="squash") is True
+        cmd = mock_run.call_args[0][0]
+        assert cmd == ["pr", "merge", "7", "--auto", "--squash", "--repo", "org/repo"]
+
+    def test_failure(self):
+        with patch("augint_tools.github.prs.run_gh", return_value=_fail()):
+            assert enable_automerge(1) is False
+
+    def test_exception(self):
+        with patch("augint_tools.github.prs.run_gh", side_effect=RuntimeError("boom")):
+            assert enable_automerge(1) is False
+
+
+class TestListIssues:
+    def _payload(self) -> str:
+        return json.dumps(
+            [
+                {
+                    "number": 1,
+                    "title": "one",
+                    "state": "OPEN",
+                    "url": "u1",
+                    "labels": [{"name": "bug"}, {"name": "p1"}],
+                },
+                {
+                    "number": 2,
+                    "title": "two",
+                    "state": "CLOSED",
+                    "url": "u2",
+                    "labels": [],
+                },
+            ]
+        )
+
+    def test_returns_parsed_issues(self):
+        with patch("augint_tools.github.issues.run_gh", return_value=_ok(self._payload())):
+            issues = list_issues()
+        assert issues[0] == Issue(
+            number=1, title="one", state="OPEN", labels=["bug", "p1"], url="u1"
+        )
+        assert issues[1].labels == []
+
+    def test_label_query_uses_label_flag(self):
+        with patch("augint_tools.github.issues.run_gh", return_value=_ok("[]")) as mock_run:
+            list_issues(query="bug")
+        cmd = mock_run.call_args[0][0]
+        assert "--label" in cmd and "bug" in cmd
+        assert "--search" not in cmd
+
+    def test_search_query_uses_search_flag(self):
+        with patch("augint_tools.github.issues.run_gh", return_value=_ok("[]")) as mock_run:
+            list_issues(query="is:open needs triage")
+        cmd = mock_run.call_args[0][0]
+        assert "--search" in cmd and "is:open needs triage" in cmd
+        assert "--label" not in cmd
+
+    def test_explicit_label_prefix_uses_search(self):
+        # A "label:" prefixed query is treated as a raw search, not as --label.
+        with patch("augint_tools.github.issues.run_gh", return_value=_ok("[]")) as mock_run:
+            list_issues(query="label:bug")
+        cmd = mock_run.call_args[0][0]
+        assert "--search" in cmd and "label:bug" in cmd
+
+    def test_repo_passed_through(self):
+        with patch("augint_tools.github.issues.run_gh", return_value=_ok("[]")) as mock_run:
+            list_issues(repo="org/repo")
+        cmd = mock_run.call_args[0][0]
+        assert "--repo" in cmd and "org/repo" in cmd
+
+    def test_nonzero_returns_empty(self):
+        with patch("augint_tools.github.issues.run_gh", return_value=_fail()):
+            assert list_issues() == []
+
+    def test_invalid_json_returns_empty(self):
+        with patch("augint_tools.github.issues.run_gh", return_value=_ok("nope")):
+            assert list_issues() == []
+
+    def test_exception_returns_empty(self):
+        with patch("augint_tools.github.issues.run_gh", side_effect=RuntimeError("boom")):
+            assert list_issues() == []

--- a/tests/unit/test_health.py
+++ b/tests/unit/test_health.py
@@ -36,6 +36,7 @@ def _status(
     open_prs=0,
     draft_prs=0,
     human_open_issues=0,
+    oldest_issue_created_at=None,
     default_branch="main",
     has_workflows=True,
     looks_like_service=False,
@@ -55,6 +56,7 @@ def _status(
         open_prs=open_prs,
         draft_prs=draft_prs,
         human_open_issues=human_open_issues,
+        oldest_issue_created_at=oldest_issue_created_at,
         default_branch=default_branch,
         has_workflows=has_workflows,
         looks_like_service=looks_like_service,
@@ -607,23 +609,32 @@ class TestStalePRs:
 
 
 class TestOpenIssues:
+    @staticmethod
+    def _days_ago(days: int) -> str:
+        return (datetime.now(UTC) - timedelta(days=days)).isoformat()
+
     def test_below_threshold(self):
         result = get_check("open_issues").evaluate(
             _mock_repo(),
-            _status(open_issues=5, human_open_issues=5),
+            _status(open_issues=5, human_open_issues=5, oldest_issue_created_at=self._days_ago(2)),
             config={},
             context=_ctx(),
         )
         assert result.severity == Severity.OK
 
     def test_above_threshold(self):
+        # Too many fresh issues escalates to MEDIUM so the border turns
+        # yellow -- count alone used to be LOW (border stayed green) which
+        # the numerical counter already communicated.
         result = get_check("open_issues").evaluate(
             _mock_repo(),
-            _status(open_issues=15, human_open_issues=15),
+            _status(
+                open_issues=15, human_open_issues=15, oldest_issue_created_at=self._days_ago(2)
+            ),
             config={},
             context=_ctx(),
         )
-        assert result.severity == Severity.LOW
+        assert result.severity == Severity.MEDIUM
         assert "(15) open issues" in result.summary
         assert result.link is not None
 
@@ -632,7 +643,7 @@ class TestOpenIssues:
         # excludes bots. The check reads it straight off RepoStatus.
         result = get_check("open_issues").evaluate(
             _mock_repo(),
-            _status(open_issues=12, human_open_issues=5),
+            _status(open_issues=12, human_open_issues=5, oldest_issue_created_at=self._days_ago(2)),
             config={},
             context=_ctx(),
         )
@@ -642,11 +653,40 @@ class TestOpenIssues:
     def test_custom_threshold(self):
         result = get_check("open_issues").evaluate(
             _mock_repo(),
-            _status(open_issues=3, human_open_issues=3),
+            _status(open_issues=3, human_open_issues=3, oldest_issue_created_at=self._days_ago(1)),
             config={"open_issues_threshold": 3},
             context=_ctx(),
         )
-        assert result.severity == Severity.LOW
+        assert result.severity == Severity.MEDIUM
+
+    def test_stale_issue_medium(self):
+        result = get_check("open_issues").evaluate(
+            _mock_repo(),
+            _status(open_issues=1, human_open_issues=1, oldest_issue_created_at=self._days_ago(10)),
+            config={},
+            context=_ctx(),
+        )
+        assert result.severity == Severity.MEDIUM
+        assert "10d" in result.summary
+
+    def test_ancient_issue_critical(self):
+        result = get_check("open_issues").evaluate(
+            _mock_repo(),
+            _status(open_issues=2, human_open_issues=2, oldest_issue_created_at=self._days_ago(45)),
+            config={},
+            context=_ctx(),
+        )
+        assert result.severity == Severity.CRITICAL
+        assert "45d" in result.summary
+
+    def test_quiet_when_empty(self):
+        result = get_check("open_issues").evaluate(
+            _mock_repo(),
+            _status(open_issues=0, human_open_issues=0, oldest_issue_created_at=None),
+            config={},
+            context=_ctx(),
+        )
+        assert result.severity == Severity.OK
 
 
 class TestOpenPRs:

--- a/tests/unit/test_output.py
+++ b/tests/unit/test_output.py
@@ -2,7 +2,10 @@
 
 import json
 
+import pytest
+
 from augint_tools.output import CommandResponse, ExitCode, emit_response
+from augint_tools.output.formatter import emit_error, emit_warning
 
 
 class TestExitCode:
@@ -108,3 +111,224 @@ class TestEmitResponse:
         data = json.loads(captured.out)
         assert "result" not in data
         assert data["summary"] == "done"
+
+    def test_human_emits_warnings_errors_and_next(self, capsys):
+        r = CommandResponse(
+            command="test",
+            scope="repo",
+            status="error",
+            summary="broke",
+            warnings=["warn-a"],
+            errors=["err-b"],
+            next_actions=["retry"],
+        )
+        emit_response(r)
+        captured = capsys.readouterr()
+        # summary on stdout
+        assert "broke" in captured.out
+        assert "Next: retry" in captured.out
+        # warnings / errors go to stderr
+        assert "Warning: warn-a" in captured.err
+        assert "err-b" in captured.err
+
+    def test_summary_mode_without_next(self, capsys):
+        r = CommandResponse(command="test", scope="repo", status="ok", summary="q")
+        emit_response(r, summary_only=True)
+        captured = capsys.readouterr()
+        assert "q" in captured.out
+        assert "Next:" not in captured.out
+
+    @pytest.mark.parametrize(
+        "status,label",
+        [
+            ("ok", "[ok]"),
+            ("error", "[error]"),
+            ("action-required", "[action]"),
+            ("blocked", "[blocked]"),
+            ("partial", "[partial]"),
+            ("weird", "[weird]"),
+        ],
+    )
+    def test_status_icon_renders(self, capsys, status, label):
+        r = CommandResponse(command="c", scope="s", status=status, summary="x")
+        emit_response(r)
+        captured = capsys.readouterr()
+        assert label in captured.out
+
+
+class TestRegistryFormatters:
+    def test_workspace_status_formatter(self, capsys):
+        r = CommandResponse.ok(
+            "workspace status",
+            "workspace",
+            "ok",
+            {
+                "workspace": {"name": "demo"},
+                "repos": [
+                    {"name": "a", "present": True, "branch": "main", "dirty": False},
+                    {"name": "b", "present": True, "branch": "dev", "dirty": True},
+                    {"name": "c", "present": False},
+                ],
+            },
+        )
+        emit_response(r)
+        out = capsys.readouterr().out
+        assert "demo" in out
+        assert "Repositories: 3" in out
+        assert "a (main)" in out
+        assert "b (dev)" in out
+        assert "c" in out and "missing" in out
+
+    def test_branch_formatter(self, capsys):
+        r = CommandResponse.ok("workspace branch", "workspace", "ok", {"branch": "feat/x"})
+        emit_response(r)
+        assert "feat/x" in capsys.readouterr().out
+
+    def test_branch_formatter_no_branch_key(self, capsys):
+        r = CommandResponse.ok("workspace branch", "workspace", "ok", {})
+        emit_response(r)
+        # No crash; branch line simply absent.
+        assert "Branch" not in capsys.readouterr().out
+
+    def test_check_formatter(self, capsys):
+        r = CommandResponse.ok(
+            "workspace check",
+            "workspace",
+            "ok",
+            {
+                "phases": [
+                    {"phase": "lint", "status": "passed", "duration_seconds": 1.234},
+                    {
+                        "phase": "test",
+                        "status": "failed",
+                        "duration_seconds": 2.0,
+                        "failures": ["oops"],
+                    },
+                ]
+            },
+        )
+        emit_response(r)
+        out = capsys.readouterr().out
+        assert "lint" in out and "1.2s" in out
+        assert "test" in out and "2.0s" in out
+        assert "oops" in out
+
+    def test_foreach_formatter_success_and_failure(self, capsys):
+        r = CommandResponse.ok(
+            "workspace foreach",
+            "workspace",
+            "ok",
+            {
+                "results": [
+                    {"repo": "a", "success": True, "output": "hello\n\nworld"},
+                    {"name": "b", "success": False, "exit_code": 2},
+                ]
+            },
+        )
+        emit_response(r)
+        out = capsys.readouterr().out
+        assert "a" in out and "b" in out
+        assert "hello" in out and "world" in out
+        assert "exit 2" in out
+
+    def test_ide_info_formatter(self, capsys):
+        r = CommandResponse.ok(
+            "ide info",
+            "ide",
+            "ok",
+            {
+                "project_name": "proj",
+                "venv_path": "/v",
+                "python_version": "3.12",
+                "sdk_name": "Python 3.12 (proj)",
+                "iml_path": "/p/proj.iml",
+                "idea_dir_exists": True,
+                "windows_project_dir": "C:\\proj",
+                "jb_options_dir": "/jb",
+                "gh_token_present": True,
+            },
+        )
+        emit_response(r)
+        out = capsys.readouterr().out
+        assert "proj" in out
+        assert "Python  : 3.12" in out
+        assert "proj.iml" in out
+        assert "C:\\proj" in out
+        assert "/jb" in out
+        assert "set" in out  # GH_TOKEN present
+
+    def test_ide_info_formatter_missing_optional(self, capsys):
+        r = CommandResponse.ok(
+            "ide info",
+            "ide",
+            "ok",
+            {
+                "project_name": "proj",
+                "venv_path": "/v",
+                "python_version": "3.12",
+                "sdk_name": "sdk",
+                "iml_path": None,
+                "idea_dir_exists": False,
+                "gh_token_present": False,
+            },
+        )
+        emit_response(r)
+        out = capsys.readouterr().out
+        assert "(none)" in out
+        assert "missing" in out
+        assert "not set" in out
+
+    def test_ide_setup_formatter(self, capsys):
+        r = CommandResponse.ok("ide setup", "ide", "ok", {"sdk_name": "sdk-xyz"})
+        emit_response(r)
+        assert "sdk-xyz" in capsys.readouterr().out
+
+    def test_ide_setup_formatter_without_sdk(self, capsys):
+        r = CommandResponse.ok("ide setup", "ide", "ok", {})
+        emit_response(r)
+        assert "SDK name to use" not in capsys.readouterr().out
+
+    def test_env_classify_formatter(self, capsys):
+        r = CommandResponse.ok(
+            "gh classify",
+            "env",
+            "ok",
+            {
+                "secrets": [{"key": "API_KEY", "reasons": ["high entropy"]}],
+                "variables": ["LOG_LEVEL"],
+                "skipped": ["COMMENT"],
+            },
+        )
+        emit_response(r)
+        out = capsys.readouterr().out
+        assert "API_KEY" in out and "high entropy" in out
+        assert "LOG_LEVEL" in out
+        assert "COMMENT" in out
+
+    def test_env_classify_empty(self, capsys):
+        r = CommandResponse.ok("gh classify", "env", "ok", {})
+        emit_response(r)
+        # no Secrets/Variables/Skipped headers when all empty
+        out = capsys.readouterr().out
+        assert "Secrets:" not in out
+        assert "Variables:" not in out
+        assert "Skipped:" not in out
+
+
+class TestEmitHelpers:
+    def test_emit_warning_goes_to_stderr(self, capsys):
+        emit_warning("heads up")
+        captured = capsys.readouterr()
+        assert captured.out == ""
+        assert "Warning: heads up" in captured.err
+
+    def test_emit_error_without_exit(self, capsys):
+        emit_error("uh oh")
+        captured = capsys.readouterr()
+        assert "Error: uh oh" in captured.err
+
+    def test_emit_error_with_exit_code(self, capsys):
+        with pytest.raises(SystemExit) as exc:
+            emit_error("fatal", exit_code=3)
+        assert exc.value.code == 3
+        assert "fatal" in capsys.readouterr().err

--- a/tests/unit/test_team_secrets_checkout.py
+++ b/tests/unit/test_team_secrets_checkout.py
@@ -1,6 +1,18 @@
 """Tests for team_secrets.checkout module."""
 
-from augint_tools.team_secrets.checkout import DEFAULT_ORG, secrets_repo_slug
+from pathlib import Path
+from subprocess import CompletedProcess
+from unittest.mock import patch
+
+import pytest
+
+from augint_tools.team_secrets.checkout import (
+    DEFAULT_ORG,
+    _commit_and_push,
+    _has_changes,
+    ephemeral_checkout,
+    secrets_repo_slug,
+)
 
 
 def test_secrets_repo_slug_default_org():
@@ -13,3 +25,122 @@ def test_secrets_repo_slug_custom_org():
 
 def test_default_org():
     assert DEFAULT_ORG == "augmenting-integrations"
+
+
+class TestHasChanges:
+    def test_detects_changes(self):
+        with patch(
+            "augint_tools.team_secrets.checkout.subprocess.run",
+            return_value=CompletedProcess(args=[], returncode=0, stdout=" M file.py\n"),
+        ):
+            assert _has_changes(Path("/tmp")) is True
+
+    def test_clean_repo(self):
+        with patch(
+            "augint_tools.team_secrets.checkout.subprocess.run",
+            return_value=CompletedProcess(args=[], returncode=0, stdout="   \n"),
+        ):
+            assert _has_changes(Path("/tmp")) is False
+
+
+class TestCommitAndPush:
+    def test_runs_add_commit_push_in_order(self):
+        with patch(
+            "augint_tools.team_secrets.checkout.subprocess.run",
+            return_value=CompletedProcess(args=[], returncode=0, stdout=""),
+        ) as mock_run:
+            _commit_and_push(Path("/tmp/repo"))
+        invoked = [c.args[0] for c in mock_run.call_args_list]
+        assert invoked[0] == ["git", "add", "-A"]
+        assert invoked[1][:2] == ["git", "commit"]
+        assert "chore: update secrets via ai-tools" in invoked[1][-1]
+        assert invoked[2] == ["git", "push"]
+
+    def test_custom_commit_message(self):
+        with patch(
+            "augint_tools.team_secrets.checkout.subprocess.run",
+            return_value=CompletedProcess(args=[], returncode=0, stdout=""),
+        ) as mock_run:
+            _commit_and_push(Path("/tmp/repo"), message="chore: custom")
+        commit_call = mock_run.call_args_list[1].args[0]
+        assert commit_call[-1] == "chore: custom"
+
+
+class TestEphemeralCheckout:
+    def test_raises_when_clone_fails(self, tmp_path):
+        with (
+            patch(
+                "augint_tools.team_secrets.checkout.tempfile.mkdtemp",
+                return_value=str(tmp_path),
+            ),
+            patch(
+                "augint_tools.team_secrets.checkout.subprocess.run",
+                return_value=CompletedProcess(
+                    args=[], returncode=1, stdout="", stderr="access denied"
+                ),
+            ),
+            patch("augint_tools.team_secrets.checkout.shutil.rmtree") as mock_rm,
+        ):
+            with pytest.raises(RuntimeError, match="Failed to clone"):
+                with ephemeral_checkout("woxom"):
+                    pass
+        # Cleanup still happens via finally.
+        mock_rm.assert_called_once()
+
+    def test_happy_path_commits_and_pushes(self, tmp_path):
+        clone_ok = CompletedProcess(args=[], returncode=0, stdout="")
+        with (
+            patch(
+                "augint_tools.team_secrets.checkout.tempfile.mkdtemp",
+                return_value=str(tmp_path),
+            ),
+            patch(
+                "augint_tools.team_secrets.checkout.subprocess.run",
+                return_value=clone_ok,
+            ),
+            patch("augint_tools.team_secrets.checkout._has_changes", return_value=True),
+            patch("augint_tools.team_secrets.checkout._commit_and_push") as mock_commit,
+            patch("augint_tools.team_secrets.checkout.shutil.rmtree") as mock_rm,
+        ):
+            with ephemeral_checkout("woxom") as repo_path:
+                assert repo_path == tmp_path
+        mock_commit.assert_called_once()
+        mock_rm.assert_called_once()
+
+    def test_no_changes_skips_commit(self, tmp_path):
+        clone_ok = CompletedProcess(args=[], returncode=0, stdout="")
+        with (
+            patch(
+                "augint_tools.team_secrets.checkout.tempfile.mkdtemp",
+                return_value=str(tmp_path),
+            ),
+            patch(
+                "augint_tools.team_secrets.checkout.subprocess.run",
+                return_value=clone_ok,
+            ),
+            patch("augint_tools.team_secrets.checkout._has_changes", return_value=False),
+            patch("augint_tools.team_secrets.checkout._commit_and_push") as mock_commit,
+            patch("augint_tools.team_secrets.checkout.shutil.rmtree"),
+        ):
+            with ephemeral_checkout("woxom"):
+                pass
+        mock_commit.assert_not_called()
+
+    def test_push_on_exit_false_skips_commit(self, tmp_path):
+        clone_ok = CompletedProcess(args=[], returncode=0, stdout="")
+        with (
+            patch(
+                "augint_tools.team_secrets.checkout.tempfile.mkdtemp",
+                return_value=str(tmp_path),
+            ),
+            patch(
+                "augint_tools.team_secrets.checkout.subprocess.run",
+                return_value=clone_ok,
+            ),
+            patch("augint_tools.team_secrets.checkout._has_changes", return_value=True),
+            patch("augint_tools.team_secrets.checkout._commit_and_push") as mock_commit,
+            patch("augint_tools.team_secrets.checkout.shutil.rmtree"),
+        ):
+            with ephemeral_checkout("woxom", push_on_exit=False):
+                pass
+        mock_commit.assert_not_called()

--- a/tests/unit/test_team_secrets_sync.py
+++ b/tests/unit/test_team_secrets_sync.py
@@ -1,8 +1,18 @@
 """Tests for team_secrets.sync module."""
 
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import click
+import pytest
+
+from augint_tools.team_secrets.models import ConflictEntry
 from augint_tools.team_secrets.sync import (
+    _truncate,
     compute_merge,
     parse_dotenv_content,
+    perform_team_sync,
+    resolve_conflicts_interactive,
     serialize_dotenv,
 )
 
@@ -119,3 +129,314 @@ class TestComputeMerge:
         assert result.merged["SHARED"] == "same"
         assert result.merged["TEAM_ONLY"] == "t"
         assert result.merged["LOCAL_ONLY"] == "l"
+
+
+class TestTruncate:
+    def test_short_string_untouched(self):
+        assert _truncate("hello", 10) == "hello"
+
+    def test_long_string_gets_ellipsis(self):
+        assert _truncate("a" * 100, 10) == "aaaaaaa..."
+
+
+class TestResolveConflictsInteractive:
+    def _conflict(self, key="K", local="lv", team="tv") -> ConflictEntry:
+        return ConflictEntry(key=key, local_value=local, team_value=team)
+
+    def test_keep_team(self):
+        with patch("augint_tools.team_secrets.sync.click.prompt", return_value="t"):
+            resolved = resolve_conflicts_interactive([self._conflict()])
+        assert resolved == {"K": "tv"}
+
+    def test_keep_local(self):
+        with patch("augint_tools.team_secrets.sync.click.prompt", return_value="L"):
+            resolved = resolve_conflicts_interactive([self._conflict()])
+        assert resolved == {"K": "lv"}
+
+    def test_custom_value(self):
+        with patch(
+            "augint_tools.team_secrets.sync.click.prompt",
+            side_effect=["c", "custom-val"],
+        ):
+            resolved = resolve_conflicts_interactive([self._conflict()])
+        assert resolved == {"K": "custom-val"}
+
+
+class TestPerformTeamSync:
+    """The full sync workflow: patches decrypt/encrypt/commit so no subprocess runs."""
+
+    def _setup_repo(self, tmp_path, *, team_body: str = "SHARED=t\nTEAM_ONLY=t\n") -> Path:
+        repo = tmp_path / "team-repo"
+        (repo / "secrets" / "proj" / "env").mkdir(parents=True)
+        enc = repo / "secrets" / "proj" / "env" / "dev.enc.env"
+        enc.write_text("<encrypted>")
+        # Record the expected path for assertions.
+        return repo
+
+    def test_raises_when_encrypted_file_missing(self, tmp_path):
+        with patch(
+            "augint_tools.team_secrets.repo.get_encrypted_env_path",
+            return_value=tmp_path / "missing.enc.env",
+        ):
+            with pytest.raises(click.ClickException, match="No encrypted file"):
+                perform_team_sync(
+                    team_repo_path=tmp_path,
+                    project="p",
+                    env="dev",
+                    key_file=tmp_path / "key",
+                )
+
+    def test_no_local_env_diff_only(self, tmp_path):
+        enc = tmp_path / "e.enc.env"
+        enc.write_text("<enc>")
+        with (
+            patch("augint_tools.team_secrets.repo.get_encrypted_env_path", return_value=enc),
+            patch(
+                "augint_tools.team_secrets.sync.decrypt_file",
+                return_value="A=1\nB=2\n",
+            ),
+        ):
+            result = perform_team_sync(
+                team_repo_path=tmp_path,
+                project="p",
+                env="dev",
+                key_file=tmp_path / "key",
+                local_env_path=tmp_path / "absent.env",
+                diff_only=True,
+            )
+        assert result["diff"] == "No local .env to compare"
+        assert set(result["team_keys"]) == {"A", "B"}
+
+    def test_no_local_env_writes_local_dry_run(self, tmp_path):
+        enc = tmp_path / "e.enc.env"
+        enc.write_text("<enc>")
+        target = tmp_path / "fresh.env"
+        with (
+            patch("augint_tools.team_secrets.repo.get_encrypted_env_path", return_value=enc),
+            patch(
+                "augint_tools.team_secrets.sync.decrypt_file",
+                return_value="A=1\n",
+            ),
+        ):
+            result = perform_team_sync(
+                team_repo_path=tmp_path,
+                project="p",
+                env="dev",
+                key_file=tmp_path / "key",
+                local_env_path=target,
+                dry_run=True,
+                write_local_env=True,
+            )
+        assert result == {"action": "wrote_local", "keys_written": 1, "dry_run": True}
+        # Dry run -> nothing written.
+        assert not target.exists()
+
+    def test_no_local_env_writes_local_for_real(self, tmp_path):
+        enc = tmp_path / "e.enc.env"
+        enc.write_text("<enc>")
+        target = tmp_path / "fresh.env"
+        with (
+            patch("augint_tools.team_secrets.repo.get_encrypted_env_path", return_value=enc),
+            patch(
+                "augint_tools.team_secrets.sync.decrypt_file",
+                return_value="A=1\n",
+            ),
+        ):
+            result = perform_team_sync(
+                team_repo_path=tmp_path,
+                project="p",
+                env="dev",
+                key_file=tmp_path / "key",
+                local_env_path=target,
+                write_local_env=True,
+            )
+        assert result["action"] == "wrote_local"
+        assert target.read_text().strip() == "A=1"
+
+    def test_no_local_env_default(self, tmp_path):
+        enc = tmp_path / "e.enc.env"
+        enc.write_text("<enc>")
+        with (
+            patch("augint_tools.team_secrets.repo.get_encrypted_env_path", return_value=enc),
+            patch(
+                "augint_tools.team_secrets.sync.decrypt_file",
+                return_value="A=1\nB=2\n",
+            ),
+        ):
+            result = perform_team_sync(
+                team_repo_path=tmp_path,
+                project="p",
+                env="dev",
+                key_file=tmp_path / "key",
+                local_env_path=tmp_path / "missing.env",
+            )
+        assert result["action"] == "no_local_env"
+        assert set(result["team_keys"]) == {"A", "B"}
+
+    def test_diff_only_with_conflicts_and_additions(self, tmp_path):
+        enc = tmp_path / "e.enc.env"
+        enc.write_text("<enc>")
+        local_env = tmp_path / ".env"
+        local_env.write_text("A=local\nNEW=added\n")
+        with (
+            patch("augint_tools.team_secrets.repo.get_encrypted_env_path", return_value=enc),
+            patch(
+                "augint_tools.team_secrets.sync.decrypt_file",
+                return_value="A=team\nB=same\n",
+            ),
+        ):
+            result = perform_team_sync(
+                team_repo_path=tmp_path,
+                project="p",
+                env="dev",
+                key_file=tmp_path / "key",
+                local_env_path=local_env,
+                diff_only=True,
+            )
+        assert result["additions"] == ["NEW"]
+        assert len(result["conflicts"]) == 1
+        assert result["conflicts"][0]["key"] == "A"
+
+    def test_non_interactive_conflicts_return_action_required(self, tmp_path, monkeypatch):
+        enc = tmp_path / "e.enc.env"
+        enc.write_text("<enc>")
+        local_env = tmp_path / ".env"
+        local_env.write_text("A=local\n")
+        # Force non-tty path.
+        monkeypatch.setattr("sys.stdin.isatty", lambda: False)
+        with (
+            patch("augint_tools.team_secrets.repo.get_encrypted_env_path", return_value=enc),
+            patch(
+                "augint_tools.team_secrets.sync.decrypt_file",
+                return_value="A=team\n",
+            ),
+        ):
+            result = perform_team_sync(
+                team_repo_path=tmp_path,
+                project="p",
+                env="dev",
+                key_file=tmp_path / "key",
+                local_env_path=local_env,
+            )
+        assert result["status"] == "action-required"
+        assert result["conflicts"][0]["key"] == "A"
+
+    def test_full_sync_writes_commits_pushes(self, tmp_path):
+        enc = tmp_path / "e.enc.env"
+        enc.write_text("<enc>")
+        local_env = tmp_path / ".env"
+        local_env.write_text("SHARED=same\nNEW=added\n")
+        commit_mock = MagicMock()
+        encrypt_mock = MagicMock()
+        with (
+            patch("augint_tools.team_secrets.repo.get_encrypted_env_path", return_value=enc),
+            patch(
+                "augint_tools.team_secrets.sync.decrypt_file",
+                return_value="SHARED=same\nTEAM_ONLY=t\n",
+            ),
+            patch("augint_tools.team_secrets.sync.encrypt_content", encrypt_mock),
+            patch("augint_tools.team_secrets.repo.commit_and_push", commit_mock),
+        ):
+            result = perform_team_sync(
+                team_repo_path=tmp_path,
+                project="p",
+                env="dev",
+                key_file=tmp_path / "key",
+                local_env_path=local_env,
+                write_local_env=True,
+            )
+        assert "encrypted" in result["actions"]
+        assert "committed and pushed" in result["actions"]
+        assert any(a.endswith("wrote local .env") for a in result["actions"])
+        assert result["additions"] == ["NEW"]
+        assert result["dry_run"] is False
+        commit_mock.assert_called_once()
+        encrypt_mock.assert_called_once()
+
+    def test_no_push_mode_commits_without_pushing(self, tmp_path):
+        enc = tmp_path / "e.enc.env"
+        enc.write_text("<enc>")
+        local_env = tmp_path / ".env"
+        local_env.write_text("SHARED=same\n")
+        with (
+            patch("augint_tools.team_secrets.repo.get_encrypted_env_path", return_value=enc),
+            patch(
+                "augint_tools.team_secrets.sync.decrypt_file",
+                return_value="SHARED=same\n",
+            ),
+            patch("augint_tools.team_secrets.sync.encrypt_content"),
+            patch("subprocess.run") as mock_sub,
+        ):
+            result = perform_team_sync(
+                team_repo_path=tmp_path,
+                project="p",
+                env="dev",
+                key_file=tmp_path / "key",
+                local_env_path=local_env,
+                no_push=True,
+            )
+        assert "committed (not pushed)" in result["actions"]
+        # Should have invoked `git add` + `git commit`, no `git push`.
+        calls = [c.args[0] for c in mock_sub.call_args_list]
+        assert ["git", "add", "-A"] in calls
+        assert any(c[:2] == ["git", "commit"] for c in calls)
+        assert not any("push" in c for c in calls)
+
+    def test_dry_run_skips_api_calls(self, tmp_path):
+        enc = tmp_path / "e.enc.env"
+        enc.write_text("<enc>")
+        local_env = tmp_path / ".env"
+        local_env.write_text("SHARED=same\n")
+        encrypt_mock = MagicMock()
+        commit_mock = MagicMock()
+        with (
+            patch("augint_tools.team_secrets.repo.get_encrypted_env_path", return_value=enc),
+            patch(
+                "augint_tools.team_secrets.sync.decrypt_file",
+                return_value="SHARED=same\n",
+            ),
+            patch("augint_tools.team_secrets.sync.encrypt_content", encrypt_mock),
+            patch("augint_tools.team_secrets.repo.commit_and_push", commit_mock),
+        ):
+            result = perform_team_sync(
+                team_repo_path=tmp_path,
+                project="p",
+                env="dev",
+                key_file=tmp_path / "key",
+                local_env_path=local_env,
+                dry_run=True,
+                write_local_env=True,
+            )
+        assert result["dry_run"] is True
+        encrypt_mock.assert_not_called()
+        commit_mock.assert_not_called()
+        # Under dry-run the action log records "would encrypt" rather than "encrypted".
+        assert "would encrypt" in result["actions"]
+
+    def test_interactive_conflict_resolution(self, tmp_path, monkeypatch):
+        enc = tmp_path / "e.enc.env"
+        enc.write_text("<enc>")
+        local_env = tmp_path / ".env"
+        local_env.write_text("A=local\n")
+        monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+        with (
+            patch("augint_tools.team_secrets.repo.get_encrypted_env_path", return_value=enc),
+            patch(
+                "augint_tools.team_secrets.sync.decrypt_file",
+                return_value="A=team\n",
+            ),
+            patch(
+                "augint_tools.team_secrets.sync.resolve_conflicts_interactive",
+                return_value={"A": "final"},
+            ),
+            patch("augint_tools.team_secrets.sync.encrypt_content"),
+            patch("augint_tools.team_secrets.repo.commit_and_push"),
+        ):
+            result = perform_team_sync(
+                team_repo_path=tmp_path,
+                project="p",
+                env="dev",
+                key_file=tmp_path / "key",
+                local_env_path=local_env,
+            )
+        assert result["conflicts_resolved"] == 1


### PR DESCRIPTION
## Summary
- Adds unit tests across git, github, detection, execution, checks, output formatter, dashboard internals (_data, _common, _helpers), and team_secrets (sync, checkout).
- All non-TUI modules that were below the 80% threshold are now covered.
- TOTAL coverage is now 80.30% (up from 74%), and the \`--cov-fail-under=80\` gate in pyproject passes.

## Test plan
- [x] \`uv run pytest --cov=src --cov-fail-under=80\` -- 935 passed, coverage 80.30%
- [x] \`uv run mypy src/\` -- clean
- [x] \`uv run ruff check src/ tests/\` -- clean
- [x] \`uv run pre-commit run --files ...\` -- all hooks pass