### PR TITLE
feat(dashboard): deployment links on repo cards

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,72 @@ ai-tools repo submit
 - `ci watch` - Monitor CI run
 - `ci triage` - Classify CI failures
 
+## Dashboard Deployment Links
+
+Each repo card can surface clickable shortcuts to its live deployment URLs (plus the repo's PyPI page for Python libraries). Links come from a user-global yaml file so the same config works from any terminal or WSL shell.
+
+### Yaml file
+
+Path: `~/.augint-tools/deployments.yaml` (resolves to `%USERPROFILE%\.augint-tools\deployments.yaml` on Windows).
+
+Schema: a map of `owner/repo` slugs to a flat list of `{label, url}` entries.
+
+```yaml
+augmentingintegrations/aillc-web:
+  - { label: dev,  url: "https://www.org.aillc.link/" }
+  - { label: main, url: "https://www.augmentingintegrations.com/" }
+augmentingintegrations/ai-lls-api:
+  - { label: dev,  url: "https://lls-api.lls.aillc.link" }
+  - { label: main, url: "https://lls-api.landlinescrubber.link" }
+augmentingintegrations/woxom-sales-dashboard:
+  - { label: dashboard,         url: "https://dashboard.woxom.aillc.link/" }
+  - { label: jacksonhealthcare, url: "https://jacksonhealthcare.woxom.aillc.link/" }
+```
+
+### Reserved labels
+
+| label  | glyph | treatment |
+|--------|-------|-----------|
+| `main` | `p`   | prod -- middle-click on card title opens this |
+| `dev`  | `s`   | staging -- shift + middle-click on card title opens this |
+| `pypi` | `π`   | auto-synthesized for Python libraries (see below); manual entry overrides the auto guess |
+
+Any other label is free-form; the card glyph is the first alphanumeric character of the label (lowercased).
+
+Deployment glyphs are rendered right-aligned on the CI status line of each card (e.g. `dev PASS  main PASS       s p`). Each glyph is an OSC-8 hyperlink clickable in supported terminals.
+
+### Auto-PyPI
+
+If a repo has the `py` tag, is not a service (`looks_like_service=False`), and is not an org repo (`is_org=False`), the card and drawer get an automatic `https://pypi.org/project/<repo-name>/` link rendered in a dim style. If the repo's PyPI name differs from its GitHub name, add a manual `pypi` entry in the yaml -- manual entries always win.
+
+### Interaction model
+
+**Keyboard shortcuts** (work on the selected repo, one-hand cluster):
+
+| Key | Action |
+|-----|--------|
+| `z` | Open prod/main deployment URL |
+| `x` | Open dev/staging deployment URL |
+| `c` | Open 1st supplemental link (after main/dev) |
+| `v` | Open 2nd supplemental link |
+| `b` | Open 3rd supplemental link |
+| `f` | Open the "Manage deployment links" modal |
+
+**Mouse** (on the title row; depends on terminal modifier support):
+
+- **Middle-click on the title** -> open prod URL (falls back to the GitHub repo page if no `main` link is configured).
+- **Shift + middle-click on the title** -> open dev URL, or toast "no url configured for dev" if none.
+- **Ctrl + left-click on the title** -> open the "Manage deployment links" modal for that repo.
+- **Left-click on a glyph** (`s` / `p` / `π` / first-letter) -> terminal-native OSC-8 link opens the URL directly.
+
+Note: mouse modifier support (shift+click, ctrl+click) varies by terminal. Windows Terminal may intercept ctrl+click for OSC-8 link handling. The keyboard shortcuts (`p`, `P`, `u`) are the reliable primary interface.
+
+The detail drawer (press `d`) lists every link in a `deployments:` section with the host shown as visible text and the full URL as the OSC-8 target.
+
+### Manage modal
+
+Press `f` or middle-click on the repo name to open a modal scoped to the selected repo. The modal has dedicated fields for Production and Staging URLs at the top (Set/Clear), plus an add row for supplemental links. Existing supplementals are listed inline with Remove buttons (AWS Security Groups style). Every mutation writes the yaml immediately. Auto-PyPI entries are not listed (they aren't stored in the yaml); add a manual `pypi` row to override the guess.
+
 ## Development
 
 ### Setup

--- a/src/augint_tools/dashboard/_data.py
+++ b/src/augint_tools/dashboard/_data.py
@@ -26,8 +26,13 @@ if TYPE_CHECKING:
 
     from ._gql import RepoSnapshot
 
-CACHE_DIR = Path.home() / ".cache" / "ai-gh"
+CACHE_DIR = Path.home() / ".cache" / "ai-tools-dashboard"
 CACHE_FILE = CACHE_DIR / "tui_cache.json"
+
+# One-time migration from the old cache directory name.
+_OLD_CACHE_DIR = Path.home() / ".cache" / "ai-gh"
+if _OLD_CACHE_DIR.is_dir() and not CACHE_DIR.exists():
+    _OLD_CACHE_DIR.rename(CACHE_DIR)
 
 # Renovate's default "Dependency Dashboard" issue. Users don't treat it as a
 # real issue -- it's a persistent control panel -- so the dashboard excludes

--- a/src/augint_tools/dashboard/app.py
+++ b/src/augint_tools/dashboard/app.py
@@ -579,6 +579,7 @@ class MainScreen(Screen[None]):
             style=f"link {pulls_url}",
         )
         t.append("\n\n")
+        self._append_deployments_block(t, health)
         if health.findings:
             t.append("findings:\n", style="bold")
             for finding in health.findings:
@@ -592,6 +593,31 @@ class MainScreen(Screen[None]):
                 t.append("\n")
         t.append("\npress d to close, enter for full drilldown.", style="dim")
         return t
+
+    def _append_deployments_block(self, t: Text, health: RepoHealth) -> None:
+        """Append a ``deployments:`` section listing each configured / auto link.
+
+        Emits one line per link with the label, the URL host as the visible
+        text, and an OSC-8 hyperlink so the user can click straight to the
+        deployment. Auto-synthesised PyPI entries are rendered dim to signal
+        they came from detection, not the user's yaml.
+        """
+        from . import deployments as dep
+
+        links = dep.resolve_links(health.status)
+        if not links:
+            return
+        t.append("deployments:\n", style="bold")
+        for link in dep.sort_links_for_display(links):
+            t.append(f"  {link.label}: ")
+            # Strip the scheme for display; keep the full URL in the OSC-8 target.
+            display = link.url.split("://", 1)[-1].rstrip("/")
+            style = f"link {link.url}"
+            if link.source == "auto":
+                style = f"dim link {link.url}"
+            t.append(display, style=style)
+            t.append("\n")
+        t.append("\n")
 
     def _healthy_summary_line(
         self,
@@ -1227,7 +1253,7 @@ class MainScreen(Screen[None]):
 class DashboardApp(App[None]):
     """V2 interactive health dashboard for GitHub repositories."""
 
-    TITLE = "ai-gh dashboard"
+    TITLE = "ai-tools dashboard"
     ANIMATION_LEVEL = "full"
     CSS = """
     Screen {
@@ -1256,6 +1282,12 @@ class DashboardApp(App[None]):
         Binding("E", "clear_errors", "Clear Errors", show=False),
         Binding("m", "manage_repos", "Repos"),
         Binding("O", "manage_orgs", "Orgs"),
+        Binding("z", "open_deployment_main", "Prod", show=False),
+        Binding("x", "open_deployment_dev", "Dev", show=False),
+        Binding("c", "open_deployment_3", show=False),
+        Binding("v", "open_deployment_4", show=False),
+        Binding("b", "open_deployment_5", show=False),
+        Binding("f", "manage_deployments", "URLs"),
         Binding("question_mark", "show_help", "Help"),
         Binding("f5", "full_restart", "Restart", show=False),
         Binding("plus", "widen_card", "Wider", show=False),
@@ -2261,6 +2293,69 @@ class DashboardApp(App[None]):
         if health is not None:
             webbrowser.open(f"https://github.com/{health.status.full_name}")
 
+    def _open_deployment_by_label(self, label: str) -> None:
+        """Open a deployment link by reserved label (``main`` or ``dev``)."""
+        from .deployments import find_link, resolve_links
+
+        health = selected_health(self.state)
+        if health is None:
+            return
+        links = resolve_links(health.status)
+        link = find_link(links, label)
+        if link:
+            webbrowser.open(link.url)
+        else:
+            self.notify(
+                f"no url configured for {label} on {health.status.full_name}",
+                severity="warning",
+                timeout=3,
+            )
+
+    def _open_deployment_supplemental(self, index: int) -> None:
+        """Open a supplemental link by 0-based index (after main/dev are excluded)."""
+        from .deployments import resolve_links, sort_links_for_display
+
+        health = selected_health(self.state)
+        if health is None:
+            return
+        links = resolve_links(health.status)
+        supplementals = [
+            link for link in sort_links_for_display(links) if link.label not in ("main", "dev")
+        ]
+        if index < len(supplementals):
+            webbrowser.open(supplementals[index].url)
+        else:
+            self.notify("no supplemental link at that position", severity="warning", timeout=3)
+
+    def action_open_deployment_main(self) -> None:
+        """``z`` -- open the main/prod deployment URL for the selected repo."""
+        self._open_deployment_by_label("main")
+
+    def action_open_deployment_dev(self) -> None:
+        """``x`` -- open the dev/staging deployment URL for the selected repo."""
+        self._open_deployment_by_label("dev")
+
+    def action_open_deployment_3(self) -> None:
+        """``c`` -- open the 1st supplemental link (after main/dev)."""
+        self._open_deployment_supplemental(0)
+
+    def action_open_deployment_4(self) -> None:
+        """``v`` -- open the 2nd supplemental link."""
+        self._open_deployment_supplemental(1)
+
+    def action_open_deployment_5(self) -> None:
+        """``b`` -- open the 3rd supplemental link."""
+        self._open_deployment_supplemental(2)
+
+    def action_manage_deployments(self) -> None:
+        """``u`` -- open the manage-deployment-links modal for the selected repo."""
+        from .screens.manage_deployments import ManageDeployments
+
+        health = selected_health(self.state)
+        if health is None:
+            return
+        self.push_screen(ManageDeployments(health.status.full_name))
+
     # ---- message handlers ----
 
     def on_repo_card_selected(self, message: RepoCard.Selected) -> None:
@@ -2274,6 +2369,14 @@ class DashboardApp(App[None]):
 
     def on_repo_card_open_url(self, message: RepoCard.OpenUrl) -> None:
         webbrowser.open_new_tab(message.url)
+
+    def on_repo_card_manage_deployments_requested(
+        self,
+        message: RepoCard.ManageDeploymentsRequested,
+    ) -> None:
+        from .screens.manage_deployments import ManageDeployments
+
+        self.push_screen(ManageDeployments(message.full_name))
 
     def on_repo_card_go_back(self, _message: RepoCard.GoBack) -> None:
         if self._main is not None:

--- a/src/augint_tools/dashboard/awsprobe.py
+++ b/src/augint_tools/dashboard/awsprobe.py
@@ -16,7 +16,7 @@ from pathlib import Path
 
 _PROFILE_NAME_RE = re.compile(r"^[a-zA-Z0-9._-]+$")
 
-_CACHE_DIR = Path.home() / ".cache" / "ai-gh"
+_CACHE_DIR = Path.home() / ".cache" / "ai-tools-dashboard"
 _CACHE_FILE = _CACHE_DIR / "aws_cache.json"
 
 

--- a/src/augint_tools/dashboard/cmd.py
+++ b/src/augint_tools/dashboard/cmd.py
@@ -5,6 +5,8 @@ Widget-per-card Textual dashboard; pluggable layouts and themes.
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import click
 from loguru import logger
 from rich import print
@@ -21,6 +23,24 @@ from ._helpers import (
 from .layouts import list_layouts
 from .prefs import load_prefs
 from .themes import list_themes
+
+
+def _apply_debug_cache_dir() -> None:
+    """Override the cache/prefs directory to ``./.cache/ai-tools-dashboard``.
+
+    Must be called before ``run_dashboard`` but after module-level imports
+    have evaluated. Patches the module-level constants in ``_data``,
+    ``awsprobe``, and ``prefs`` so every component reads/writes the local
+    directory.
+    """
+    local_cache = Path.cwd() / ".cache" / "ai-tools-dashboard"
+    from . import _data, awsprobe, prefs
+
+    _data.CACHE_DIR = local_cache
+    _data.CACHE_FILE = local_cache / "tui_cache.json"
+    awsprobe._CACHE_DIR = local_cache
+    awsprobe._CACHE_FILE = local_cache / "aws_cache.json"
+    prefs.PREFS_FILE = local_cache / "dashboard_prefs.json"
 
 
 @click.command("dashboard")
@@ -72,6 +92,11 @@ from .themes import list_themes
     default=None,
     help="Write debug logs to a file (tail -f alongside the TUI).",
 )
+@click.option(
+    "--debug",
+    is_flag=True,
+    help="Enable debug mode: log to ./tui.log and use ./.cache for cache/prefs.",
+)
 @click.pass_context
 def dashboard_command(
     ctx: click.Context,
@@ -86,8 +111,13 @@ def dashboard_command(
     no_refresh: bool,
     verbose: bool,
     log_file: str | None,
+    debug: bool,
 ) -> None:
     """Interactive Textual health dashboard for GitHub repositories."""
+    if debug:
+        if log_file is None:
+            log_file = "./tui.log"
+        _apply_debug_cache_dir()
     configure_logging(verbose, log_file=log_file)
 
     try:

--- a/src/augint_tools/dashboard/deployments.py
+++ b/src/augint_tools/dashboard/deployments.py
@@ -1,0 +1,264 @@
+"""Deployment-link store for the dashboard.
+
+Manages ``~/.augint-tools/deployments.yaml`` -- a per-user file that maps
+``owner/repo`` slugs to a flat list of ``{label, url}`` entries. The dashboard
+reads this file to surface deployment URLs on each repo card and in the
+detail drawer.
+
+Reserved labels ``dev``, ``main``, ``pypi`` get special rendering on the
+card; any other label is treated as a free-form tag with its first letter
+as the card glyph.
+
+For Python library repos (``py`` tag, non-service, non-org) a ``pypi`` entry
+is synthesised automatically from the repo name when the yaml doesn't
+already declare one. Users can override the guess by adding a manual
+``pypi`` entry -- manual always wins.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Literal
+
+import yaml
+from loguru import logger
+
+if TYPE_CHECKING:
+    from ._data import RepoStatus
+
+
+DeploymentSource = Literal["yaml", "auto"]
+
+
+@dataclass(frozen=True)
+class DeploymentLink:
+    """One deployment entry for a repo."""
+
+    label: str
+    url: str
+    source: DeploymentSource = "yaml"
+
+
+def get_deployments_path() -> Path:
+    """Path to ``~/.augint-tools/deployments.yaml`` (resolves to %USERPROFILE% on Windows)."""
+    return Path.home() / ".augint-tools" / "deployments.yaml"
+
+
+def _load_raw(path: Path | None = None) -> dict[str, list[dict]]:
+    """Load the raw yaml as ``{full_name: [{label, url}, ...]}``. Empty dict on failure."""
+    p = path or get_deployments_path()
+    if not p.exists():
+        return {}
+    try:
+        with p.open("r", encoding="utf-8") as f:
+            data = yaml.safe_load(f) or {}
+    except (yaml.YAMLError, OSError) as exc:
+        logger.warning(f"could not read {p}: {exc}")
+        return {}
+    if not isinstance(data, dict):
+        logger.warning(f"{p} top level is not a mapping; ignoring")
+        return {}
+    clean: dict[str, list[dict]] = {}
+    for repo, entries in data.items():
+        if not isinstance(repo, str) or not isinstance(entries, list):
+            continue
+        rows: list[dict] = []
+        for entry in entries:
+            if not isinstance(entry, dict):
+                continue
+            label = entry.get("label")
+            url = entry.get("url")
+            if isinstance(label, str) and isinstance(url, str) and label and url:
+                rows.append({"label": label, "url": url})
+        if rows:
+            clean[repo] = rows
+    return clean
+
+
+def load_deployments(path: Path | None = None) -> dict[str, list[DeploymentLink]]:
+    """Return the yaml-declared links, one list per repo slug."""
+    raw = _load_raw(path)
+    return {
+        repo: [DeploymentLink(label=row["label"], url=row["url"], source="yaml") for row in rows]
+        for repo, rows in raw.items()
+    }
+
+
+def _save_raw(data: dict[str, list[dict]], path: Path | None = None) -> None:
+    """Atomically write the raw deployments yaml.
+
+    Uses a temp file in the same directory + ``os.replace`` so partial writes
+    can never be observed. ``os.replace`` is cross-platform (unlike
+    ``os.rename`` on Windows when the target exists).
+    """
+    p = path or get_deployments_path()
+    p.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(prefix=".deployments.", suffix=".yaml.tmp", dir=str(p.parent))
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            yaml.safe_dump(data, f, default_flow_style=False, sort_keys=True)
+        os.replace(tmp_name, p)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+def save_deployments(links: dict[str, list[DeploymentLink]], path: Path | None = None) -> None:
+    """Persist the manual (``yaml``-sourced) links. Auto-derived entries are never written."""
+    raw: dict[str, list[dict]] = {}
+    for repo, entries in links.items():
+        rows = [{"label": e.label, "url": e.url} for e in entries if e.source == "yaml"]
+        if rows:
+            raw[repo] = rows
+    _save_raw(raw, path)
+
+
+def add_link(
+    full_name: str,
+    label: str,
+    url: str,
+    *,
+    path: Path | None = None,
+) -> None:
+    """Append a new ``{label, url}`` entry for ``full_name`` and save."""
+    raw = _load_raw(path)
+    raw.setdefault(full_name, []).append({"label": label, "url": url})
+    _save_raw(raw, path)
+
+
+def remove_link(
+    full_name: str,
+    label: str,
+    url: str,
+    *,
+    path: Path | None = None,
+) -> None:
+    """Remove the first entry matching ``(label, url)`` for ``full_name`` and save."""
+    raw = _load_raw(path)
+    entries = raw.get(full_name)
+    if not entries:
+        return
+    for idx, row in enumerate(entries):
+        if row.get("label") == label and row.get("url") == url:
+            entries.pop(idx)
+            break
+    if entries:
+        raw[full_name] = entries
+    else:
+        raw.pop(full_name, None)
+    _save_raw(raw, path)
+
+
+def update_link(
+    full_name: str,
+    old_label: str,
+    old_url: str,
+    new_label: str,
+    new_url: str,
+    *,
+    path: Path | None = None,
+) -> None:
+    """Replace the first ``(old_label, old_url)`` entry for ``full_name`` with new values."""
+    raw = _load_raw(path)
+    entries = raw.get(full_name)
+    if not entries:
+        return
+    for idx, row in enumerate(entries):
+        if row.get("label") == old_label and row.get("url") == old_url:
+            entries[idx] = {"label": new_label, "url": new_url}
+            break
+    raw[full_name] = entries
+    _save_raw(raw, path)
+
+
+_IAC_FRAMEWORK_TAGS = frozenset({"cdk", "tf", "next", "vite"})
+
+
+def pypi_package_name(status: RepoStatus) -> str | None:
+    """Return a guessed PyPI package name for a Python library repo, else None.
+
+    A repo qualifies only when ALL of the following hold:
+
+    - Has the ``py`` tag (Python code present).
+    - Not a service (``looks_like_service``).
+    - Not an org repo (``is_org``).
+    - No IaC/framework tags (``sam``, ``cdk``, ``tf``, ``next``, ``vite``) --
+      these repos use ``pyproject.toml`` for dev-tooling, not packaging.
+    - No dev branch -- Python libraries ship from main only; a dev branch
+      signals a service/deploy workflow.
+
+    The guess is the bare repo name. Users can override by adding a manual
+    ``pypi`` entry in the yaml.
+    """
+    if "py" not in status.tags:
+        return None
+    if status.looks_like_service or status.is_org:
+        return None
+    if _IAC_FRAMEWORK_TAGS & set(status.tags):
+        return None
+    if status.has_dev_branch:
+        return None
+    return status.name
+
+
+def resolve_links(
+    status: RepoStatus,
+    path: Path | None = None,
+) -> list[DeploymentLink]:
+    """Return all links for ``status``, merging yaml + auto-PyPI.
+
+    Manual entries always win over the auto-PyPI synthesis (including for the
+    ``pypi`` label).
+    """
+    by_repo = load_deployments(path)
+    manual = list(by_repo.get(status.full_name, []))
+    if any(link.label == "pypi" for link in manual):
+        return manual
+    pkg = pypi_package_name(status)
+    if pkg is None:
+        return manual
+    auto = DeploymentLink(label="pypi", url=f"https://pypi.org/project/{pkg}/", source="auto")
+    return manual + [auto]
+
+
+def find_link(links: list[DeploymentLink], label: str) -> DeploymentLink | None:
+    """Return the first link matching ``label`` or ``None``."""
+    for link in links:
+        if link.label == label:
+            return link
+    return None
+
+
+_RESERVED_GLYPHS: dict[str, str] = {
+    "dev": "s",
+    "main": "p",
+    "pypi": "π",
+}
+
+
+def tag_glyph(label: str) -> str:
+    """Return the single-character glyph used on the card for ``label``.
+
+    Reserved labels map to fixed glyphs (``dev``->s, ``main``->p, ``pypi``->π).
+    Any other label takes its first lowercase character, or ``?`` if empty.
+    """
+    if label in _RESERVED_GLYPHS:
+        return _RESERVED_GLYPHS[label]
+    for ch in label.lower():
+        if ch.isalnum():
+            return ch
+    return "?"
+
+
+def sort_links_for_display(links: list[DeploymentLink]) -> list[DeploymentLink]:
+    """Return links in display order: main, dev, pypi, then others in original order."""
+    order = {"main": 0, "dev": 1, "pypi": 2}
+    indexed = list(enumerate(links))
+    indexed.sort(key=lambda item: (order.get(item[1].label, 99), item[0]))
+    return [link for _, link in indexed]

--- a/src/augint_tools/dashboard/screens/help.py
+++ b/src/augint_tools/dashboard/screens/help.py
@@ -8,7 +8,7 @@ from textual.containers import Container
 from textual.screen import ModalScreen
 from textual.widgets import Static
 
-_HELP_TEXT = """ai-gh dashboard -- controls
+_HELP_TEXT = """ai-tools dashboard -- controls
 
 Navigation
   h j k l / arrows    Move selection

--- a/src/augint_tools/dashboard/screens/manage_deployments.py
+++ b/src/augint_tools/dashboard/screens/manage_deployments.py
@@ -1,0 +1,243 @@
+"""ManageDeployments -- modal to edit deployment URLs for a single repo.
+
+Layout modeled after AWS Security Groups: dedicated rows for production
+and staging, then an add-row for supplementals followed by a list of
+existing supplemental entries each with an inline Remove button.
+
+Every mutation writes ``~/.augint-tools/deployments.yaml`` immediately.
+"""
+
+from __future__ import annotations
+
+from textual import events
+from textual.binding import Binding
+from textual.containers import Container, Horizontal, VerticalScroll
+from textual.screen import ModalScreen
+from textual.widgets import Button, Input, Static
+
+from .. import deployments as dep
+
+
+class ManageDeployments(ModalScreen[None]):
+    """Modal for CRUD on the deployment-links yaml for a single repo."""
+
+    DEFAULT_CSS = """
+    ManageDeployments {
+        align: center middle;
+    }
+    ManageDeployments > Container {
+        width: 80;
+        max-height: 85%;
+        border: thick $accent;
+        background: $surface;
+        padding: 1 2;
+    }
+    ManageDeployments #md-title {
+        text-style: bold;
+        height: auto;
+        margin: 0 0 1 0;
+    }
+    ManageDeployments .md-env-row {
+        height: auto;
+        margin: 0 0 1 0;
+    }
+    ManageDeployments .md-env-row Static {
+        width: 18;
+        height: 3;
+        content-align-vertical: middle;
+    }
+    ManageDeployments .md-env-row Input {
+        width: 1fr;
+        margin: 0 1 0 0;
+    }
+    ManageDeployments .md-env-row Button {
+        min-width: 8;
+        margin: 0 0 0 1;
+    }
+    ManageDeployments #md-section-label {
+        text-style: bold;
+        height: auto;
+        margin: 1 0 0 0;
+    }
+    ManageDeployments .md-add-row {
+        height: auto;
+        margin: 0 0 1 0;
+    }
+    ManageDeployments .md-add-row Input {
+        margin: 0 1 0 0;
+    }
+    ManageDeployments .md-add-row #md-sup-label {
+        width: 18;
+    }
+    ManageDeployments .md-add-row #md-sup-url {
+        width: 1fr;
+    }
+    ManageDeployments .md-add-row Button {
+        min-width: 8;
+        margin: 0 0 0 1;
+    }
+    ManageDeployments #md-sup-list {
+        height: auto;
+        max-height: 12;
+        margin: 0 0 1 0;
+    }
+    ManageDeployments .md-sup-row {
+        height: 1;
+        margin: 0 0 0 0;
+    }
+    ManageDeployments .md-sup-row .md-sup-lbl {
+        width: 18;
+        color: cyan;
+    }
+    ManageDeployments .md-sup-row .md-sup-url {
+        width: 1fr;
+    }
+    ManageDeployments .md-sup-row Button {
+        min-width: 10;
+        margin: 0 0 0 1;
+    }
+    ManageDeployments #md-footer {
+        color: $text-muted;
+        height: auto;
+        margin: 1 0 0 0;
+    }
+    """
+
+    BINDINGS = [
+        Binding("escape", "dismiss_panel", "Close"),
+    ]
+
+    def __init__(self, full_name: str) -> None:
+        super().__init__()
+        self._full_name = full_name
+
+    def compose(self):
+        by_repo = dep.load_deployments()
+        entries = by_repo.get(self._full_name, [])
+        prod_url = next((e.url for e in entries if e.label == "main"), "")
+        dev_url = next((e.url for e in entries if e.label == "dev"), "")
+
+        yield Container(
+            Static(f"Deployment links: {self._full_name}", id="md-title"),
+            # Production row
+            Horizontal(
+                Static("Production (z)"),
+                Input(value=prod_url, placeholder="https://...", id="md-prod-url"),
+                Button("Set", id="md-prod-set", variant="primary"),
+                Button("Clear", id="md-prod-clear", variant="error"),
+                classes="md-env-row",
+            ),
+            # Staging row
+            Horizontal(
+                Static("Staging (x)"),
+                Input(value=dev_url, placeholder="https://...", id="md-dev-url"),
+                Button("Set", id="md-dev-set", variant="primary"),
+                Button("Clear", id="md-dev-clear", variant="error"),
+                classes="md-env-row",
+            ),
+            # Supplementals section
+            Static("Supplementals (c, v, b)", id="md-section-label"),
+            Horizontal(
+                Input(placeholder="label", id="md-sup-label"),
+                Input(placeholder="https://...", id="md-sup-url"),
+                Button("Add", id="md-sup-add", variant="success"),
+                classes="md-add-row",
+            ),
+            VerticalScroll(id="md-sup-list"),
+            Static(
+                "middle-click title or f to open  |  esc to close",
+                id="md-footer",
+            ),
+        )
+
+    def on_mount(self) -> None:
+        self._refresh_supplementals()
+
+    def _refresh_supplementals(self) -> None:
+        """Rebuild the supplemental-links list from the yaml."""
+        container = self.query_one("#md-sup-list", VerticalScroll)
+        container.remove_children()
+        by_repo = dep.load_deployments()
+        entries = by_repo.get(self._full_name, [])
+        supplementals = [e for e in entries if e.label not in ("main", "dev")]
+        for idx, link in enumerate(supplementals):
+            row = Horizontal(
+                Static(link.label, classes="md-sup-lbl"),
+                Static(link.url, classes="md-sup-url"),
+                Button("Remove", id=f"md-sup-remove-{idx}", variant="error"),
+                classes="md-sup-row",
+            )
+            container.mount(row)
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        btn_id = event.button.id or ""
+        if btn_id == "md-prod-set":
+            self._set_env("main", "md-prod-url")
+        elif btn_id == "md-prod-clear":
+            self._clear_env("main", "md-prod-url")
+        elif btn_id == "md-dev-set":
+            self._set_env("dev", "md-dev-url")
+        elif btn_id == "md-dev-clear":
+            self._clear_env("dev", "md-dev-url")
+        elif btn_id == "md-sup-add":
+            self._add_supplemental()
+        elif btn_id.startswith("md-sup-remove-"):
+            self._remove_supplemental(int(btn_id.split("-")[-1]))
+
+    def _set_env(self, label: str, input_id: str) -> None:
+        url = self.query_one(f"#{input_id}", Input).value.strip()
+        if not url:
+            self.notify("url is required", severity="warning")
+            return
+        # Remove existing entry for this label, then add the new one.
+        by_repo = dep.load_deployments()
+        for existing in by_repo.get(self._full_name, []):
+            if existing.label == label:
+                dep.remove_link(self._full_name, label, existing.url)
+                break
+        dep.add_link(self._full_name, label, url)
+        self.notify(f"set {label}")
+
+    def _clear_env(self, label: str, input_id: str) -> None:
+        by_repo = dep.load_deployments()
+        for existing in by_repo.get(self._full_name, []):
+            if existing.label == label:
+                dep.remove_link(self._full_name, label, existing.url)
+                self.query_one(f"#{input_id}", Input).value = ""
+                self.notify(f"cleared {label}")
+                return
+        self.notify(f"no {label} url to clear", severity="information")
+
+    def _add_supplemental(self) -> None:
+        label = self.query_one("#md-sup-label", Input).value.strip()
+        url = self.query_one("#md-sup-url", Input).value.strip()
+        if not label or not url:
+            self.notify("label and url are required", severity="warning")
+            return
+        if label in ("main", "dev"):
+            self.notify("use the fields above for main/dev", severity="warning")
+            return
+        dep.add_link(self._full_name, label, url)
+        self.query_one("#md-sup-label", Input).value = ""
+        self.query_one("#md-sup-url", Input).value = ""
+        self.notify(f"added {label}")
+        self._refresh_supplementals()
+
+    def _remove_supplemental(self, index: int) -> None:
+        by_repo = dep.load_deployments()
+        entries = by_repo.get(self._full_name, [])
+        supplementals = [e for e in entries if e.label not in ("main", "dev")]
+        if 0 <= index < len(supplementals):
+            link = supplementals[index]
+            dep.remove_link(self._full_name, link.label, link.url)
+            self.notify(f"removed {link.label}")
+            self._refresh_supplementals()
+
+    # ---- dismiss ----
+
+    def on_click(self, event: events.Click) -> None:
+        if event.button == 3:
+            self.action_dismiss_panel()
+
+    def action_dismiss_panel(self) -> None:
+        self.dismiss(None)

--- a/src/augint_tools/dashboard/widgets/repo_card.py
+++ b/src/augint_tools/dashboard/widgets/repo_card.py
@@ -18,6 +18,7 @@ from textual.message import Message
 from textual.reactive import reactive
 from textual.widget import Widget
 
+from .. import deployments as dep
 from ..health import RepoHealth, Severity
 
 if TYPE_CHECKING:
@@ -129,6 +130,13 @@ class RepoCard(Widget):
     class GoBack(Message):
         """Emitted on right-click -- app closes drawer or pops the top screen."""
 
+    class ManageDeploymentsRequested(Message):
+        """Emitted on ctrl + left-click on the title -- open the deployment-links modal."""
+
+        def __init__(self, full_name: str) -> None:
+            super().__init__()
+            self.full_name = full_name
+
     health: reactive[RepoHealth | None] = reactive(None)
     selected: reactive[bool] = reactive(False)
     stale: reactive[bool] = reactive(False)
@@ -153,6 +161,15 @@ class RepoCard(Widget):
         self.can_focus = True
         # Rebuilt on every render: y-coordinate inside the card -> click target.
         self._click_map: dict[int, _ClickRegion] = {}
+        # Deployment URLs resolved during render, used by click routing.
+        self._title_prod_url: str | None = None
+        self._title_dev_url: str | None = None
+        # X-range of the repo name on the title line (y=1), for left-click → GitHub.
+        self._title_name_x: tuple[int, int] = (0, 0)
+        # CI-line click zones: (x_start, x_end, left_url, middle_url, middle_only).
+        self._ci_click_zones: list[tuple[int, int, str, str, bool]] = []
+        # Y coordinate of the CI line, set during render.
+        self._ci_line_y: int = 2
 
     @property
     def repo_full_name(self) -> str:
@@ -263,10 +280,13 @@ class RepoCard(Widget):
 
     def _title_line(self, health: RepoHealth) -> Text:
         line = Text()
+        offset = self._content_start_x()
         if self.selected:
             line.append(" > ", style=f"bold black on {self._theme_spec.status_pass}")
             line.append(" ")
+        x0 = offset + len(line.plain)
         line.append(health.status.name, style="bold")
+        self._title_name_x = (x0, offset + len(line.plain))
         # "svc" is the union of both signals: a repo is service-flavoured if
         # it either runs a dev branch (gitflow-style) or carries a structural
         # marker like template.yaml/Dockerfile. Repos satisfying neither are
@@ -282,24 +302,81 @@ class RepoCard(Widget):
     def _ci_line(self, health: RepoHealth) -> Text:
         spec = self._theme_spec
         status = health.status
+        offset = self._content_start_x()
         line = Text()
+        # Deployment click zones rebuilt each render.  Each entry is
+        # (x_start, x_end, left_url, middle_url, middle_only).
+        # ``middle_only=True`` means left-click falls through to select (used
+        # for the dev/main labels so only middle-click opens the deployment).
+        # ``left_url`` / ``middle_url`` can differ (e.g. pypi vs pypistats).
+        zones: list[tuple[int, int, str, str, bool]] = []
+
+        links = dep.resolve_links(status)
+        self._title_prod_url = None
+        self._title_dev_url = None
+        dev_link = dep.find_link(links, "dev")
+        main_link = dep.find_link(links, "main")
+        if dev_link:
+            self._title_dev_url = dev_link.url
+        if main_link:
+            self._title_prod_url = main_link.url
+
+        _LINK_STYLE = "cyan underline"
+
         if status.has_dev_branch and status.dev_status is not None:
-            line.append("dev ")
+            # "dev" label -- middle-click only opens the deployment URL.
+            x0 = offset + len(line.plain)
+            line.append("dev", style=_LINK_STYLE if dev_link else "")
+            if dev_link:
+                zones.append((x0, offset + len(line.plain), dev_link.url, dev_link.url, True))
+            line.append(" ")
             line.append(
                 _STATUS_ICON.get(status.dev_status, "?"),
                 style=self._status_style(status.dev_status, spec),
             )
-            line.append("  main ")
+            line.append("  ")
+            # "main" label -- middle-click only.
+            x0 = offset + len(line.plain)
+            line.append("main", style=_LINK_STYLE if main_link else "")
+            if main_link:
+                zones.append((x0, offset + len(line.plain), main_link.url, main_link.url, True))
+            line.append(" ")
             line.append(
                 _STATUS_ICON.get(status.main_status, "?"),
                 style=self._status_style(status.main_status, spec),
             )
         else:
-            line.append("main ")
+            x0 = offset + len(line.plain)
+            line.append("main", style=_LINK_STYLE if main_link else "")
+            if main_link:
+                zones.append((x0, offset + len(line.plain), main_link.url, main_link.url, True))
+            line.append(" ")
             line.append(
                 _STATUS_ICON.get(status.main_status, "?"),
                 style=self._status_style(status.main_status, spec),
             )
+
+        # Supplemental links as bracketed badges, appended inline.
+        # Both left and middle click work on badges.
+        supplementals = [
+            link for link in dep.sort_links_for_display(links) if link.label not in ("dev", "main")
+        ]
+        for link in supplementals:
+            line.append("  ")
+            glyph = dep.tag_glyph(link.label)
+            x0 = offset + len(line.plain)
+            badge_style = "cyan bold" if link.source != "auto" else "cyan dim"
+            line.append(f"[{glyph}]", style=badge_style)
+            # PyPI: left -> pypistats (quick stats), middle -> pypi.org (package page).
+            if link.label == "pypi":
+                left_url = f"https://pypistats.org/packages/{status.name}"
+                middle_url = link.url
+            else:
+                left_url = link.url
+                middle_url = link.url
+            zones.append((x0, offset + len(line.plain), left_url, middle_url, False))
+
+        self._ci_click_zones = zones
         return line
 
     def _counts_line(self, health: RepoHealth) -> Text:
@@ -430,10 +507,12 @@ class RepoCard(Widget):
         self._click_map[len(parts)] = _ClickRegion(url=self._repo_url(health))
 
         parts.append(self._ci_line(health))
+        self._ci_line_y = len(parts)
         self._click_map[len(parts)] = _ClickRegion(url=self._actions_url(health))
 
         parts.append(self._counts_line(health))
         self._click_map[len(parts)] = self._counts_click_region(health)
+
 
         for line, url in self._findings_lines(health, 3):
             parts.append(line)
@@ -449,6 +528,7 @@ class RepoCard(Widget):
         self._click_map[len(parts)] = _ClickRegion(url=self._repo_url(health))
 
         parts.append(self._ci_line(health))
+        self._ci_line_y = len(parts)
         self._click_map[len(parts)] = _ClickRegion(url=self._actions_url(health))
 
         for line, url in self._findings_lines(health, 1):
@@ -465,6 +545,7 @@ class RepoCard(Widget):
         self._click_map[len(parts)] = _ClickRegion(url=self._repo_url(health))
 
         parts.append(self._ci_line(health))
+        self._ci_line_y = len(parts)
         self._click_map[len(parts)] = _ClickRegion(url=self._actions_url(health))
 
         parts.append(self._counts_line(health))
@@ -537,16 +618,38 @@ class RepoCard(Widget):
         if event.button == 3:
             self.post_message(self.GoBack())
             return
+        y = getattr(event, "y", 0)
+        x = getattr(event, "x", 0)
+        # Middle-click on the title row (y=1) opens the manage-deployments
+        # modal instead of the GitHub repo page.
+        if y == 1 and event.button == 2 and self.repo_full_name:
+            self.post_message(self.ManageDeploymentsRequested(self.repo_full_name))
+            return
+        # CI-line deployment zones: left or middle click on an underlined
+        # "dev"/"main" label or a [badge] opens the deployment URL directly.
+        # Clicks outside zones fall through to the normal per-row handler
+        # (which routes to /actions for the CI row).
+        if y == self._ci_line_y and event.button in (1, 2):
+            for x_start, x_end, left_url, middle_url, middle_only in self._ci_click_zones:
+                if x_start <= x < x_end:
+                    if event.button == 2:
+                        self.post_message(self.OpenUrl(middle_url))
+                        return
+                    if event.button == 1 and not middle_only:
+                        self.post_message(self.OpenUrl(left_url))
+                        return
         if event.button == 2 or (event.button == 1 and getattr(event, "meta", False)):
             url = self._resolve_click_url(event)
             self.post_message(self.OpenUrl(url))
             return
         if event.button == 1:
-            # Single click only selects -- a plain click must never
-            # trap the user in a modal drilldown screen.  Use a
-            # double-click (chord), the Enter key, or 'o' to open full
-            # detail; ``event.chain`` is 2 on the second click of a
-            # double-click.
+            # Left-click on the repo name text (title row) opens the GitHub
+            # code page. Left-click anywhere else on the card selects it.
+            if y == 1 and self.repo_full_name:
+                nx0, nx1 = self._title_name_x
+                if nx0 <= x < nx1:
+                    self.post_message(self.OpenUrl(self._repo_url(self.health)))
+                    return
             self.post_message(self.Selected(self.repo_full_name))
             if getattr(event, "chain", 1) >= 2:
                 self.post_message(self.DrilldownRequested(self.repo_full_name))

--- a/src/augint_tools/dashboard/widgets/repo_card.py
+++ b/src/augint_tools/dashboard/widgets/repo_card.py
@@ -513,7 +513,6 @@ class RepoCard(Widget):
         parts.append(self._counts_line(health))
         self._click_map[len(parts)] = self._counts_click_region(health)
 
-
         for line, url in self._findings_lines(health, 3):
             parts.append(line)
             self._click_map[len(parts)] = _ClickRegion(url=url)
@@ -645,7 +644,7 @@ class RepoCard(Widget):
         if event.button == 1:
             # Left-click on the repo name text (title row) opens the GitHub
             # code page. Left-click anywhere else on the card selects it.
-            if y == 1 and self.repo_full_name:
+            if y == 1 and self.repo_full_name and self.health is not None:
                 nx0, nx1 = self._title_name_x
                 if nx0 <= x < nx1:
                     self.post_message(self.OpenUrl(self._repo_url(self.health)))

--- a/tests/unit/test_deployments.py
+++ b/tests/unit/test_deployments.py
@@ -1,0 +1,249 @@
+"""Tests for the deployment-links store."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from augint_tools.dashboard import deployments as dep
+from augint_tools.dashboard._data import RepoStatus
+
+
+def _status(
+    name: str = "aillc-web",
+    full_name: str | None = None,
+    *,
+    tags: tuple[str, ...] = (),
+    looks_like_service: bool = False,
+    is_org: bool = False,
+) -> RepoStatus:
+    return RepoStatus(
+        name=name,
+        full_name=full_name or f"augmentingintegrations/{name}",
+        has_dev_branch=False,
+        main_status="success",
+        main_error=None,
+        dev_status=None,
+        dev_error=None,
+        open_issues=0,
+        open_prs=0,
+        draft_prs=0,
+        tags=tags,
+        looks_like_service=looks_like_service,
+        is_org=is_org,
+    )
+
+
+@pytest.fixture
+def yaml_path(tmp_path: Path) -> Path:
+    return tmp_path / "deployments.yaml"
+
+
+class TestLoadDeployments:
+    def test_missing_file_returns_empty(self, yaml_path: Path):
+        assert dep.load_deployments(yaml_path) == {}
+
+    def test_malformed_yaml_returns_empty(self, yaml_path: Path):
+        yaml_path.write_text("this is: [not: valid: yaml")
+        assert dep.load_deployments(yaml_path) == {}
+
+    def test_top_level_list_returns_empty(self, yaml_path: Path):
+        yaml_path.write_text("- just\n- a\n- list\n")
+        assert dep.load_deployments(yaml_path) == {}
+
+    def test_round_trip(self, yaml_path: Path):
+        yaml_path.write_text(
+            "org/repo:\n"
+            "  - {label: dev,  url: 'https://dev.example.com'}\n"
+            "  - {label: main, url: 'https://example.com'}\n"
+        )
+        loaded = dep.load_deployments(yaml_path)
+        assert set(loaded.keys()) == {"org/repo"}
+        labels = [link.label for link in loaded["org/repo"]]
+        assert labels == ["dev", "main"]
+        assert all(link.source == "yaml" for link in loaded["org/repo"])
+
+    def test_drops_malformed_entries(self, yaml_path: Path):
+        yaml_path.write_text(
+            "org/repo:\n"
+            "  - {label: dev, url: 'https://ok.example'}\n"
+            "  - 'not a dict'\n"
+            "  - {label: nourl}\n"
+            "  - {url: nolabel}\n"
+        )
+        loaded = dep.load_deployments(yaml_path)
+        assert [link.label for link in loaded["org/repo"]] == ["dev"]
+
+
+class TestMutations:
+    def test_add_creates_file(self, yaml_path: Path):
+        assert not yaml_path.exists()
+        dep.add_link("org/repo", "main", "https://example.com", path=yaml_path)
+        loaded = dep.load_deployments(yaml_path)
+        assert [link.label for link in loaded["org/repo"]] == ["main"]
+        assert yaml_path.exists()
+
+    def test_add_appends_to_existing(self, yaml_path: Path):
+        dep.add_link("org/repo", "dev", "https://dev.example", path=yaml_path)
+        dep.add_link("org/repo", "main", "https://example.com", path=yaml_path)
+        loaded = dep.load_deployments(yaml_path)
+        assert [link.label for link in loaded["org/repo"]] == ["dev", "main"]
+
+    def test_remove_only_drops_matching_entry(self, yaml_path: Path):
+        dep.add_link("org/repo", "dev", "https://dev.example", path=yaml_path)
+        dep.add_link("org/repo", "main", "https://example.com", path=yaml_path)
+        dep.remove_link("org/repo", "dev", "https://dev.example", path=yaml_path)
+        loaded = dep.load_deployments(yaml_path)
+        assert [link.label for link in loaded["org/repo"]] == ["main"]
+
+    def test_remove_last_entry_removes_repo_key(self, yaml_path: Path):
+        dep.add_link("org/repo", "main", "https://example.com", path=yaml_path)
+        dep.remove_link("org/repo", "main", "https://example.com", path=yaml_path)
+        assert dep.load_deployments(yaml_path) == {}
+
+    def test_remove_noop_when_missing(self, yaml_path: Path):
+        # Should not raise even if the repo or entry doesn't exist.
+        dep.remove_link("org/missing", "dev", "https://none", path=yaml_path)
+        assert dep.load_deployments(yaml_path) == {}
+
+    def test_update_replaces_entry(self, yaml_path: Path):
+        dep.add_link("org/repo", "dev", "https://old.example", path=yaml_path)
+        dep.update_link(
+            "org/repo",
+            "dev",
+            "https://old.example",
+            "dev",
+            "https://new.example",
+            path=yaml_path,
+        )
+        loaded = dep.load_deployments(yaml_path)
+        assert loaded["org/repo"][0].url == "https://new.example"
+
+
+class TestResolveLinks:
+    def test_empty_yaml_no_library(self, yaml_path: Path):
+        st = _status(tags=("sam",), looks_like_service=True)
+        assert dep.resolve_links(st, yaml_path) == []
+
+    def test_library_auto_pypi(self, yaml_path: Path):
+        # Pure Python library: py tag, no IaC tags, no dev branch.
+        st = _status(name="augint-tools", tags=("py",))
+        links = dep.resolve_links(st, yaml_path)
+        assert len(links) == 1
+        assert links[0].label == "pypi"
+        assert links[0].source == "auto"
+        assert links[0].url == "https://pypi.org/project/augint-tools/"
+
+    def test_service_no_auto_pypi(self, yaml_path: Path):
+        st = _status(name="ai-lls-api", tags=("py",), looks_like_service=True)
+        assert dep.resolve_links(st, yaml_path) == []
+
+    def test_org_repo_no_auto_pypi(self, yaml_path: Path):
+        st = _status(name="aillc-org", tags=("py",), is_org=True)
+        assert dep.resolve_links(st, yaml_path) == []
+
+    def test_iac_tags_suppress_auto_pypi(self, yaml_path: Path):
+        """Repos with pyproject.toml + IaC tags use uv for dev tooling, not packaging."""
+        for iac_tag in ("cdk", "tf", "next", "vite"):
+            st = _status(name=f"myrepo-{iac_tag}", tags=("py", iac_tag))
+            assert dep.resolve_links(st, yaml_path) == [], (
+                f"py + {iac_tag} should not get auto pypi"
+            )
+
+    def test_sam_tag_does_not_suppress_auto_pypi(self, yaml_path: Path):
+        """Python libraries with SAM for test infra still get auto pypi."""
+        st = _status(name="my-lib", tags=("py", "sam"))
+        links = dep.resolve_links(st, yaml_path)
+        assert len(links) == 1
+        assert links[0].label == "pypi"
+
+    def test_dev_branch_suppresses_auto_pypi(self, yaml_path: Path):
+        """Repos with a dev branch follow a deploy workflow, not a library release."""
+        st = RepoStatus(
+            name="my-service",
+            full_name="org/my-service",
+            has_dev_branch=True,
+            main_status="success",
+            main_error=None,
+            dev_status="success",
+            dev_error=None,
+            open_issues=0,
+            open_prs=0,
+            draft_prs=0,
+            tags=("py",),
+        )
+        assert dep.resolve_links(st, yaml_path) == []
+
+    def test_manual_pypi_overrides_auto(self, yaml_path: Path):
+        st = _status(name="augint-tools", tags=("py",))
+        dep.add_link(
+            st.full_name,
+            "pypi",
+            "https://pypi.org/project/custom-name/",
+            path=yaml_path,
+        )
+        links = dep.resolve_links(st, yaml_path)
+        # The auto entry must be suppressed because a manual pypi already exists.
+        assert len(links) == 1
+        assert links[0].source == "yaml"
+        assert links[0].url == "https://pypi.org/project/custom-name/"
+
+    def test_manual_links_plus_auto_pypi(self, yaml_path: Path):
+        st = _status(name="augint-tools", tags=("py",))
+        dep.add_link(st.full_name, "main", "https://example.com", path=yaml_path)
+        links = dep.resolve_links(st, yaml_path)
+        labels = [link.label for link in links]
+        # Auto pypi gets appended after manual entries.
+        assert labels == ["main", "pypi"]
+        assert links[-1].source == "auto"
+
+
+class TestDisplayHelpers:
+    def test_sort_order_puts_reserved_first(self):
+        links = [
+            dep.DeploymentLink("jacksonhealthcare", "u1"),
+            dep.DeploymentLink("pypi", "u2", source="auto"),
+            dep.DeploymentLink("dashboard", "u3"),
+            dep.DeploymentLink("dev", "u4"),
+            dep.DeploymentLink("main", "u5"),
+        ]
+        ordered = [link.label for link in dep.sort_links_for_display(links)]
+        # main, dev, pypi, then others in original list order.
+        assert ordered == ["main", "dev", "pypi", "jacksonhealthcare", "dashboard"]
+
+    @pytest.mark.parametrize(
+        "label, glyph",
+        [
+            ("dev", "s"),
+            ("main", "p"),
+            ("pypi", "π"),
+            ("dashboard", "d"),
+            ("jacksonhealthcare", "j"),
+            ("Staging", "s"),
+            ("", "?"),
+        ],
+    )
+    def test_tag_glyph(self, label: str, glyph: str):
+        assert dep.tag_glyph(label) == glyph
+
+    def test_find_link(self):
+        links = [
+            dep.DeploymentLink("dev", "u1"),
+            dep.DeploymentLink("main", "u2"),
+        ]
+        assert dep.find_link(links, "main").url == "u2"
+        assert dep.find_link(links, "pypi") is None
+
+
+class TestSaveDeployments:
+    def test_auto_entries_are_not_persisted(self, yaml_path: Path):
+        links = {
+            "org/repo": [
+                dep.DeploymentLink("main", "https://example.com"),
+                dep.DeploymentLink("pypi", "https://pypi.org/project/x/", source="auto"),
+            ]
+        }
+        dep.save_deployments(links, path=yaml_path)
+        reloaded = dep.load_deployments(yaml_path)
+        assert [link.label for link in reloaded["org/repo"]] == ["main"]

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,10 @@
 version = 1
 revision = 3
 requires-python = ">=3.12"
+resolution-markers = [
+    "python_full_version >= '3.15'",
+    "python_full_version < '3.15'",
+]
 
 [[package]]
 name = "annotated-types"
@@ -159,11 +163,11 @@ filecache = [
 
 [[package]]
 name = "certifi"
-version = "2026.2.25"
+version = "2026.4.22"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/af/2d/7bf41579a8986e348fa033a31cdd0e4121114f6bce2457e8876010b092dd/certifi-2026.2.25.tar.gz", hash = "sha256:e887ab5cee78ea814d3472169153c2d12cd43b14bd03329a39a9c6e2e80bfba7", size = 155029, upload-time = "2026-02-25T02:54:17.342Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/25/ee/6caf7a40c36a1220410afe15a1cc64993a1f864871f698c0f93acb72842a/certifi-2026.4.22.tar.gz", hash = "sha256:8d455352a37b71bf76a79caa83a3d6c25afee4a385d632127b6afb3963f1c580", size = 137077, upload-time = "2026-04-22T11:26:11.191Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/3c/c17fb3ca2d9c3acff52e30b309f538586f9f5b9c9cf454f3845fc9af4881/certifi-2026.2.25-py3-none-any.whl", hash = "sha256:027692e4402ad994f1c42e52a4997a9763c646b73e4096e4d5d6db8af1d6f0fa", size = 153684, upload-time = "2026-02-25T02:54:15.766Z" },
+    { url = "https://files.pythonhosted.org/packages/22/30/7cd8fdcdfbc5b869528b079bfb76dcdf6056b1a2097a662e5e8c04f42965/certifi-2026.4.22-py3-none-any.whl", hash = "sha256:3cb2210c8f88ba2318d29b0388d1023c8492ff72ecdde4ebdaddbb13a31b1c4a", size = 135707, upload-time = "2026-04-22T11:26:09.372Z" },
 ]
 
 [[package]]
@@ -567,14 +571,14 @@ wheels = [
 
 [[package]]
 name = "gitpython"
-version = "3.1.46"
+version = "3.1.47"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gitdb" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/df/b5/59d16470a1f0dfe8c793f9ef56fd3826093fc52b3bd96d6b9d6c26c7e27b/gitpython-3.1.46.tar.gz", hash = "sha256:400124c7d0ef4ea03f7310ac2fbf7151e09ff97f2a3288d64a440c584a29c37f", size = 215371, upload-time = "2026-01-01T15:37:32.073Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c1/bd/50db468e9b1310529a19fce651b3b0e753b5c07954d486cba31bbee9a5d5/gitpython-3.1.47.tar.gz", hash = "sha256:dba27f922bd2b42cb54c87a8ab3cb6beb6bf07f3d564e21ac848913a05a8a3cd", size = 216978, upload-time = "2026-04-22T02:44:44.059Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6a/09/e21df6aef1e1ffc0c816f0522ddc3f6dcded766c3261813131c78a704470/gitpython-3.1.46-py3-none-any.whl", hash = "sha256:79812ed143d9d25b6d176a10bb511de0f9c67b1fa641d82097b0ab90398a2058", size = 208620, upload-time = "2026-01-01T15:37:30.574Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/c5/a1bc0996af85757903cf2bf444a7824e68e0035ce63fb41d6f76f9def68b/gitpython-3.1.47-py3-none-any.whl", hash = "sha256:489f590edfd6d20571b2c0e72c6a6ac6915ee8b8cd04572330e3842207a78905", size = 209547, upload-time = "2026-04-22T02:44:41.271Z" },
 ]
 
 [[package]]
@@ -588,11 +592,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.11"
+version = "3.13"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ce/cc/762dfb036166873f0059f3b7de4565e1b5bc3d6f28a414c13da27e442f99/idna-3.13.tar.gz", hash = "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242", size = 194210, upload-time = "2026-04-22T16:42:42.314Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl", hash = "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3", size = 68629, upload-time = "2026-04-22T16:42:40.909Z" },
 ]
 
 [[package]]
@@ -881,7 +885,7 @@ wheels = [
 
 [[package]]
 name = "mypy"
-version = "1.20.1"
+version = "1.20.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "librt", marker = "platform_python_implementation != 'PyPy'" },
@@ -889,37 +893,37 @@ dependencies = [
     { name = "pathspec" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0b/3d/5b373635b3146264eb7a68d09e5ca11c305bbb058dfffbb47c47daf4f632/mypy-1.20.1.tar.gz", hash = "sha256:6fc3f4ecd52de81648fed1945498bf42fa2993ddfad67c9056df36ae5757f804", size = 3815892, upload-time = "2026-04-13T02:46:51.474Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/04/af/e3d4b3e9ec91a0ff9aabfdb38692952acf49bbb899c2e4c29acb3a6da3ae/mypy-1.20.2.tar.gz", hash = "sha256:e8222c26daaafd9e8626dec58ae36029f82585890589576f769a650dd20fd665", size = 3817349, upload-time = "2026-04-21T17:12:28.473Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/69/1b/75a7c825a02781ca10bc2f2f12fba2af5202f6d6005aad8d2d1f264d8d78/mypy-1.20.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:36ee2b9c6599c230fea89bbd79f401f9f9f8e9fcf0c777827789b19b7da90f51", size = 14494077, upload-time = "2026-04-13T02:45:55.085Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/54/5e5a569ea5c2b4d48b729fb32aa936eeb4246e4fc3e6f5b3d36a2dfbefb9/mypy-1.20.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fba3fb0968a7b48806b0c90f38d39296f10766885a94c83bd21399de1e14eb28", size = 13319495, upload-time = "2026-04-13T02:45:29.674Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/a4/a1945b19f33e91721b59deee3abb484f2fa5922adc33bb166daf5325d76d/mypy-1.20.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ef1415a637cd3627d6304dfbeddbadd21079dafc2a8a753c477ce4fc0c2af54f", size = 13696948, upload-time = "2026-04-13T02:46:15.006Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/c6/75e969781c2359b2f9c15b061f28ec6d67c8b61865ceda176e85c8e7f2de/mypy-1.20.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ef3461b1ad5cd446e540016e90b5984657edda39f982f4cc45ca317b628f5a37", size = 14706744, upload-time = "2026-04-13T02:46:00.482Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/6e/b221b1de981fc4262fe3e0bf9ec272d292dfe42394a689c2d49765c144c4/mypy-1.20.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:542dd63c9e1339b6092eb25bd515f3a32a1453aee8c9521d2ddb17dacd840237", size = 14949035, upload-time = "2026-04-13T02:45:06.021Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/4b/298ba2de0aafc0da3ff2288da06884aae7ba6489bc247c933f87847c41b3/mypy-1.20.1-cp312-cp312-win_amd64.whl", hash = "sha256:1d55c7cd8ca22e31f93af2a01160a9e95465b5878de23dba7e48116052f20a8d", size = 10883216, upload-time = "2026-04-13T02:45:47.232Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/f9/5e25b8f0b8cb92f080bfed9c21d3279b2a0b6a601cdca369a039ba84789d/mypy-1.20.1-cp312-cp312-win_arm64.whl", hash = "sha256:f5b84a79070586e0d353ee07b719d9d0a4aa7c8ee90c0ea97747e98cbe193019", size = 9814299, upload-time = "2026-04-13T02:45:21.934Z" },
-    { url = "https://files.pythonhosted.org/packages/21/e8/ef0991aa24c8f225df10b034f3c2681213cb54cf247623c6dec9a5744e70/mypy-1.20.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8f3886c03e40afefd327bd70b3f634b39ea82e87f314edaa4d0cce4b927ddcc1", size = 14500739, upload-time = "2026-04-13T02:46:05.442Z" },
-    { url = "https://files.pythonhosted.org/packages/23/73/416ebec3047636ed89fa871dc8c54bf05e9e20aa9499da59790d7adb312d/mypy-1.20.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e860eb3904f9764e83bafd70c8250bdffdc7dde6b82f486e8156348bf7ceb184", size = 13314735, upload-time = "2026-04-13T02:46:47.154Z" },
-    { url = "https://files.pythonhosted.org/packages/10/1e/1505022d9c9ac2e014a384eb17638fb37bf8e9d0a833ea60605b66f8f7ba/mypy-1.20.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a4b5aac6e785719da51a84f5d09e9e843d473170a9045b1ea7ea1af86225df4b", size = 13704356, upload-time = "2026-04-13T02:45:19.773Z" },
-    { url = "https://files.pythonhosted.org/packages/98/91/275b01f5eba5c467a3318ec214dd865abb66e9c811231c8587287b92876a/mypy-1.20.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f37b6cd0fe2ad3a20f05ace48ca3523fc52ff86940e34937b439613b6854472e", size = 14696420, upload-time = "2026-04-13T02:45:24.205Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/57/b3779e134e1b7250d05f874252780d0a88c068bc054bcff99ca20a3a2986/mypy-1.20.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e4bbb0f6b54ce7cc350ef4a770650d15fa70edd99ad5267e227133eda9c94218", size = 14936093, upload-time = "2026-04-13T02:45:32.087Z" },
-    { url = "https://files.pythonhosted.org/packages/be/33/81b64991b0f3f278c3b55c335888794af190b2d59031a5ad1401bcb69f1e/mypy-1.20.1-cp313-cp313-win_amd64.whl", hash = "sha256:c3dc20f8ec76eecd77148cdd2f1542ed496e51e185713bf488a414f862deb8f2", size = 10889659, upload-time = "2026-04-13T02:46:02.926Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/fd/7adcb8053572edf5ef8f3db59599dfeeee3be9cc4c8c97e2d28f66f42ac5/mypy-1.20.1-cp313-cp313-win_arm64.whl", hash = "sha256:a9d62bbac5d6d46718e2b0330b25e6264463ed832722b8f7d4440ff1be3ca895", size = 9815515, upload-time = "2026-04-13T02:46:32.103Z" },
-    { url = "https://files.pythonhosted.org/packages/40/cd/db831e84c81d57d4886d99feee14e372f64bbec6a9cb1a88a19e243f2ef5/mypy-1.20.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:12927b9c0ed794daedcf1dab055b6c613d9d5659ac511e8d936d96f19c087d12", size = 14483064, upload-time = "2026-04-13T02:45:26.901Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/82/74e62e7097fa67da328ac8ece8de09133448c04d20ddeaeba251a3000f01/mypy-1.20.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:752507dd481e958b2c08fc966d3806c962af5a9433b5bf8f3bdd7175c20e34fe", size = 13335694, upload-time = "2026-04-13T02:46:12.514Z" },
-    { url = "https://files.pythonhosted.org/packages/74/c4/97e9a0abe4f3cdbbf4d079cb87a03b786efeccf5bf2b89fe4f96939ab2e6/mypy-1.20.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c614655b5a065e56274c6cbbe405f7cf7e96c0654db7ba39bc680238837f7b08", size = 13726365, upload-time = "2026-04-13T02:45:17.422Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/aa/a19d884a8d28fcd3c065776323029f204dbc774e70ec9c85eba228b680de/mypy-1.20.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2c3f6221a76f34d5100c6d35b3ef6b947054123c3f8d6938a4ba00b1308aa572", size = 14693472, upload-time = "2026-04-13T02:46:41.253Z" },
-    { url = "https://files.pythonhosted.org/packages/84/44/cc9324bd21cf786592b44bf3b5d224b3923c1230ec9898d508d00241d465/mypy-1.20.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:4bdfc06303ac06500af71ea0cdbe995c502b3c9ba32f3f8313523c137a25d1b6", size = 14919266, upload-time = "2026-04-13T02:46:28.37Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/dc/779abb25a8c63e8f44bf5a336217fa92790fa17e0c40e0c725d10cb01bbd/mypy-1.20.1-cp314-cp314-win_amd64.whl", hash = "sha256:0131edd7eba289973d1ba1003d1a37c426b85cdef76650cd02da6420898a5eb3", size = 11049713, upload-time = "2026-04-13T02:45:57.673Z" },
-    { url = "https://files.pythonhosted.org/packages/28/08/4172be2ad7de9119b5a92ca36abbf641afdc5cb1ef4ae0c3a8182f29674f/mypy-1.20.1-cp314-cp314-win_arm64.whl", hash = "sha256:33f02904feb2c07e1fdf7909026206396c9deeb9e6f34d466b4cfedb0aadbbe4", size = 9999819, upload-time = "2026-04-13T02:46:35.039Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/af/af9e46b0c8eabbce9fc04a477564170f47a1c22b308822282a59b7ff315f/mypy-1.20.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:168472149dd8cc505c98cefd21ad77e4257ed6022cd5ed2fe2999bed56977a5a", size = 15547508, upload-time = "2026-04-13T02:46:25.588Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/cd/39c9e4ad6ba33e069e5837d772a9e6c304b4a5452a14a975d52b36444650/mypy-1.20.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:eb674600309a8f22790cca883a97c90299f948183ebb210fbef6bcee07cb1986", size = 14399557, upload-time = "2026-04-13T02:46:10.021Z" },
-    { url = "https://files.pythonhosted.org/packages/83/c1/3fd71bdc118ffc502bf57559c909927bb7e011f327f7bb8e0488e98a5870/mypy-1.20.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ef2b2e4cc464ba9795459f2586923abd58a0055487cbe558cb538ea6e6bc142a", size = 15045789, upload-time = "2026-04-13T02:45:10.81Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/73/6f07ff8b57a7d7b3e6e5bf34685d17632382395c8bb53364ec331661f83e/mypy-1.20.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dee461d396dd46b3f0ed5a098dbc9b8860c81c46ad44fa071afcfbc149f167c9", size = 15850795, upload-time = "2026-04-13T02:45:03.349Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/e2/f7dffec1c7767078f9e9adf0c786d1fe0ff30964a77eb213c09b8b58cb76/mypy-1.20.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:e364926308b3e66f1361f81a566fc1b2f8cd47fc8525e8136d4058a65a4b4f02", size = 16088539, upload-time = "2026-04-13T02:46:17.841Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/76/e0dee71035316e75a69d73aec2f03c39c21c967b97e277fd0ef8fd6aec66/mypy-1.20.1-cp314-cp314t-win_amd64.whl", hash = "sha256:a0c17fbd746d38c70cbc42647cfd884f845a9708a4b160a8b4f7e70d41f4d7fa", size = 12575567, upload-time = "2026-04-13T02:45:34.795Z" },
-    { url = "https://files.pythonhosted.org/packages/22/a8/7ed43c9d9c3d1468f86605e323a5d97e411a448790a00f07e779f3211a46/mypy-1.20.1-cp314-cp314t-win_arm64.whl", hash = "sha256:db2cb89654626a912efda69c0d5c1d22d948265e2069010d3dde3abf751c7d08", size = 10378823, upload-time = "2026-04-13T02:45:13.35Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/28/926bd972388e65a39ee98e188ccf67e81beb3aacfd5d6b310051772d974b/mypy-1.20.1-py3-none-any.whl", hash = "sha256:1aae28507f253fe82d883790d1c0a0d35798a810117c88184097fe8881052f06", size = 2636553, upload-time = "2026-04-13T02:46:30.45Z" },
+    { url = "https://files.pythonhosted.org/packages/71/4e/7560e4528db9e9b147e4c0f22660466bf30a0a1fe3d63d1b9d3b0fd354ee/mypy-1.20.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:4dbfcf869f6b0517f70cf0030ba6ea1d6645e132337a7d5204a18d8d5636c02b", size = 14539393, upload-time = "2026-04-21T17:07:12.52Z" },
+    { url = "https://files.pythonhosted.org/packages/32/d9/34a5efed8124f5a9234f55ac6a4ced4201e2c5b81e1109c49ad23190ec8c/mypy-1.20.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4b6481b228d072315b053210b01ac320e1be243dc17f9e5887ef167f23f5fae4", size = 13361642, upload-time = "2026-04-21T17:06:53.742Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/14/eb377acf78c03c92d566a1510cda8137348215b5335085ef662ab82ecd3a/mypy-1.20.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:34397cdced6b90b836e38182076049fdb41424322e0b0728c946b0939ebdf9f6", size = 13740347, upload-time = "2026-04-21T17:12:04.73Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/94/7e4634a32b641aa1c112422eed1bbece61ee16205f674190e8b536f884de/mypy-1.20.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a5da6976f20cae27059ea8d0c86e7cef3de720e04c4bb9ee18e3690fdb792066", size = 14734042, upload-time = "2026-04-21T17:07:43.16Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/f3/f7e62395cb7f434541b4491a01149a4439e28ace4c0c632bbf5431e92d1f/mypy-1.20.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:56908d7e08318d39f85b1f0c6cfd47b0cac1a130da677630dac0de3e0623e102", size = 14964958, upload-time = "2026-04-21T17:11:00.665Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/0d/47e3c3a0ec2a876e35aeac365df3cac7776c36bbd4ed18cc521e1b9d255b/mypy-1.20.2-cp312-cp312-win_amd64.whl", hash = "sha256:d52ad8d78522da1d308789df651ee5379088e77c76cb1994858d40a426b343b9", size = 10911340, upload-time = "2026-04-21T17:10:49.179Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/b2/6c852d72e0ea8b01f49da817fb52539993cde327e7d010e0103dc12d0dac/mypy-1.20.2-cp312-cp312-win_arm64.whl", hash = "sha256:785b08db19c9f214dc37d65f7c165d19a30fcecb48abfa30f31b01b5acaabb58", size = 9833947, upload-time = "2026-04-21T17:09:05.267Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/c4/b93812d3a192c9bcf5df405bd2f30277cd0e48106a14d1023c7f6ed6e39b/mypy-1.20.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:edfbfca868cdd6bd8d974a60f8a3682f5565d3f5c99b327640cedd24c4264026", size = 14524670, upload-time = "2026-04-21T17:10:30.737Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/47/42c122501bff18eaf1e8f457f5c017933452d8acdc52918a9f59f6812955/mypy-1.20.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e2877a02380adfcdbc69071a0f74d6e9dbbf593c0dc9d174e1f223ffd5281943", size = 13336218, upload-time = "2026-04-21T17:08:44.069Z" },
+    { url = "https://files.pythonhosted.org/packages/92/8f/75bbc92f41725fbd585fb17b440b1119b576105df1013622983e18640a93/mypy-1.20.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7488448de6007cd5177c6cea0517ac33b4c0f5ee9b5e9f2be51ce75511a85517", size = 13724906, upload-time = "2026-04-21T17:08:01.02Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/32/4c49da27a606167391ff0c39aa955707a00edc500572e562f7c36c08a71f/mypy-1.20.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bb9c2fa06887e21d6a3a868762acb82aec34e2c6fd0174064f27c93ede68ad15", size = 14726046, upload-time = "2026-04-21T17:11:22.354Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/fc/4e354a1bd70216359deb0c9c54847ee6b32ef78dfb09f5131ff99b494078/mypy-1.20.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9d56a78b646f2e3daa865bc70cd5ec5a46c50045801ca8ff17a0c43abc97e3ee", size = 14955587, upload-time = "2026-04-21T17:12:16.033Z" },
+    { url = "https://files.pythonhosted.org/packages/62/b2/c0f2056e9eb8f08c62cafd9715e4584b89132bdc832fcf85d27d07b5f3e5/mypy-1.20.2-cp313-cp313-win_amd64.whl", hash = "sha256:2a4102b03bb7481d9a91a6da8d174740c9c8c4401024684b9ca3b7cc5e49852f", size = 10922681, upload-time = "2026-04-21T17:06:35.842Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/14/065e333721f05de8ef683d0aa804c23026bcc287446b61cac657b902ccac/mypy-1.20.2-cp313-cp313-win_arm64.whl", hash = "sha256:a95a9248b0c6fd933a442c03c3b113c3b61320086b88e2c444676d3fd1ca3330", size = 9830560, upload-time = "2026-04-21T17:07:51.023Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/d1/b4ec96b0ecc620a4443570c6e95c867903428cfcde4206518eafdd5880c3/mypy-1.20.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:419413398fe250aae057fd2fe50166b61077083c9b82754c341cf4fd73038f30", size = 14524561, upload-time = "2026-04-21T17:06:27.325Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/63/d2c2ff4fa66bc49477d32dfa26e8a167ba803ea6a69c5efb416036909d30/mypy-1.20.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:e73c07f23009962885c197ccb9b41356a30cc0e5a1d0c2ea8fd8fb1362d7f924", size = 13363883, upload-time = "2026-04-21T17:11:11.239Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/56/983916806bf4eddeaaa2c9230903c3669c6718552a921154e1c5182c701f/mypy-1.20.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0c64e5973df366b747646fc98da921f9d6eba9716d57d1db94a83c026a08e0fb", size = 13742945, upload-time = "2026-04-21T17:08:34.181Z" },
+    { url = "https://files.pythonhosted.org/packages/19/65/0cd9285ab010ee8214c83d67c6b49417c40d86ce46f1aa109457b5a9b8d7/mypy-1.20.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a65aa591af023864fd08a97da9974e919452cfe19cb146c8a5dc692626445dc", size = 14706163, upload-time = "2026-04-21T17:05:15.51Z" },
+    { url = "https://files.pythonhosted.org/packages/94/97/48ff3b297cafcc94d185243a9190836fb1b01c1b0918fff64e941e973cc9/mypy-1.20.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:4fef51b01e638974a6e69885687e9bd40c8d1e09a6cd291cca0619625cf1f558", size = 14938677, upload-time = "2026-04-21T17:05:39.562Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/a1/1b4233d255bdd0b38a1f284feeb1c143ca508c19184964e22f8d837ec851/mypy-1.20.2-cp314-cp314-win_amd64.whl", hash = "sha256:913485a03f1bcf5d279409a9d2b9ed565c151f61c09f29991e5faa14033da4c8", size = 11089322, upload-time = "2026-04-21T17:06:44.29Z" },
+    { url = "https://files.pythonhosted.org/packages/78/c2/ce7ee2ba36aeb954ba50f18fa25d9c1188578654b97d02a66a15b6f09531/mypy-1.20.2-cp314-cp314-win_arm64.whl", hash = "sha256:c3bae4f855d965b5453784300c12ffc63a548304ac7f99e55d4dc7c898673aa3", size = 10017775, upload-time = "2026-04-21T17:07:20.732Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/a1/9d93a7d0b5859af0ead82b4888b46df6c8797e1bc5e1e262a08518c6d48e/mypy-1.20.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:2de3dcea53babc1c3237a19002bc3d228ce1833278f093b8d619e06e7cc79609", size = 15549002, upload-time = "2026-04-21T17:08:23.107Z" },
+    { url = "https://files.pythonhosted.org/packages/00/d2/09a6a10ee1bf0008f6c144d9676f2ca6a12512151b4e0ad0ff6c4fac5337/mypy-1.20.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:52b176444e2e5054dfcbcb8c75b0b719865c96247b37407184bbfca5c353f2c2", size = 14401942, upload-time = "2026-04-21T17:07:31.837Z" },
+    { url = "https://files.pythonhosted.org/packages/57/da/9594b75c3c019e805250bed3583bdf4443ff9e6ef08f97e39ae308cb06f2/mypy-1.20.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:688c3312e5dadb573a2c69c82af3a298d43ecf9e6d264e0f95df960b5f6ac19c", size = 15041649, upload-time = "2026-04-21T17:09:34.653Z" },
+    { url = "https://files.pythonhosted.org/packages/97/77/f75a65c278e6e8eba2071f7f5a90481891053ecc39878cc444634d892abe/mypy-1.20.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:29752dbbf8cc53f89f6ac096d363314333045c257c9c75cbd189ca2de0455744", size = 15864588, upload-time = "2026-04-21T17:11:44.936Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/46/1a4e1c66e96c1a3246ddf5403d122ac9b0a8d2b7e65730b9d6533ba7a6d3/mypy-1.20.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:803203d2b6ea644982c644895c2f78b28d0e208bba7b27d9b921e0ec5eb207c6", size = 16093956, upload-time = "2026-04-21T17:10:17.683Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/2c/78a8851264dec38cd736ca5b8bc9380674df0dd0be7792f538916157716c/mypy-1.20.2-cp314-cp314t-win_amd64.whl", hash = "sha256:9bcb8aa397ff0093c824182fd76a935a9ba7ad097fcbef80ae89bf6c1731d8ec", size = 12568661, upload-time = "2026-04-21T17:11:54.473Z" },
+    { url = "https://files.pythonhosted.org/packages/83/01/cd7318aa03493322ce275a0e14f4f52b8896335e4e79d4fb8153a7ad2b77/mypy-1.20.2-cp314-cp314t-win_arm64.whl", hash = "sha256:e061b58443f1736f8a37c48978d7ab581636d6ab03e3d4f99e3fa90463bb9382", size = 10389240, upload-time = "2026-04-21T17:09:42.719Z" },
+    { url = "https://files.pythonhosted.org/packages/28/9a/f23c163e25b11074188251b0b5a0342625fc1cdb6af604757174fa9acc9b/mypy-1.20.2-py3-none-any.whl", hash = "sha256:a94c5a76ab46c5e6257c7972b6c8cff0574201ca7dc05647e33e795d78680563", size = 2637314, upload-time = "2026-04-21T17:05:54.5Z" },
 ]
 
 [[package]]
@@ -1069,7 +1073,7 @@ wheels = [
 
 [[package]]
 name = "pre-commit"
-version = "4.5.1"
+version = "4.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cfgv" },
@@ -1078,9 +1082,9 @@ dependencies = [
     { name = "pyyaml" },
     { name = "virtualenv" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/40/f1/6d86a29246dfd2e9b6237f0b5823717f60cad94d47ddc26afa916d21f525/pre_commit-4.5.1.tar.gz", hash = "sha256:eb545fcff725875197837263e977ea257a402056661f09dae08e4b149b030a61", size = 198232, upload-time = "2025-12-16T21:14:33.552Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/22/2de9408ac81acbb8a7d05d4cc064a152ccf33b3d480ebe0cd292153db239/pre_commit-4.6.0.tar.gz", hash = "sha256:718d2208cef53fdc38206e40524a6d4d9576d103eb16f0fec11c875e7716e9d9", size = 198525, upload-time = "2026-04-21T20:31:41.613Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/19/fd3ef348460c80af7bb4669ea7926651d1f95c23ff2df18b9d24bab4f3fa/pre_commit-4.5.1-py2.py3-none-any.whl", hash = "sha256:3b3afd891e97337708c1674210f8eba659b52a38ea5f822ff142d10786221f77", size = 226437, upload-time = "2025-12-16T21:14:32.409Z" },
+    { url = "https://files.pythonhosted.org/packages/80/6e/4b28b62ecb6aae56769c34a8ff1d661473ec1e9519e2d5f8b2c150086b26/pre_commit-4.6.0-py2.py3-none-any.whl", hash = "sha256:e2cf246f7299edcabcf15f9b0571fdce06058527f0a06535068a86d38089f29b", size = 226472, upload-time = "2026-04-21T20:31:40.092Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Add `~/.augint-tools/deployments.yaml` store for per-repo deployment URLs (cross-platform, Windows-compatible)
- CI line shows "dev"/"main" as cyan underlined links when deployment URLs are configured; supplemental links as `[bracketed]` badges
- Manage modal (press `f` or middle-click repo name): AWS Security Groups style with dedicated Production/Staging fields and inline supplemental rows
- Auto-PyPI: Python library repos get automatic `[π]` badge linking to pypi.org (left-click -> pypistats, middle-click -> pypi.org)
- Keyboard shortcuts: `z`=prod, `x`=dev, `c`/`v`/`b`=supplementals (left-hand one-hand cluster)
- Click routing: left-click repo name -> GitHub, middle-click -> manage modal, middle-click dev/main -> deployment URL
- Renames cache directory from `ai-gh` to `ai-tools-dashboard` (auto-migrates existing cache)
- Adds `--debug` flag: logs to `./tui.log` and uses `./.cache` for cache/prefs
- 30 new unit tests for the deployments store

## Test plan
- [x] `uv run pytest` -- 946 passed
- [x] `uv run pre-commit run --all-files` -- all hooks pass
- [ ] Manual TUI testing: verify card glyphs, click routing, manage modal, keyboard shortcuts