### PR TITLE
docs: document YAML compliance engine and dashboard architecture

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # Repository Guidelines
 
 ## Project Structure & Module Organization
-Source code lives under `src/augint_tools/`. Keep feature logic inside the existing domain packages: `cli/` for Click entrypoints and subcommands, `checks/` for validation planning and execution, `git/` and `github/` for VCS integrations, `detection/` for repo/toolchain discovery, and `output/` for structured responses. Tests live in `tests/unit/`; shared sample data belongs in `tests/fixtures/`. CI assets and report styling live in `ci-resources/`.
+Source code lives under `src/augint_tools/`. Keep feature logic inside the existing domain packages: `cli/` for Click entrypoints and subcommands, `checks/` for validation planning and execution, `git/` and `github/` for VCS integrations, `detection/` for repo/toolchain discovery, `output/` for structured responses, and `dashboard/` for the Textual TUI and its health check system (including the YAML compliance engine -- see CLAUDE.md for architecture). Tests live in `tests/unit/`; shared sample data belongs in `tests/fixtures/`. CI assets and report styling live in `ci-resources/`.
 
 ## Build, Test, and Development Commands
 Use `uv` for local development.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,29 @@ Global output flags: `--json`, `--actionable`, `--summary`
 - **Check system** (`src/augint_tools/checks/`): Phase enum, presets (quick/default/full/ci), plan resolution, execution runner.
 - **Output model** (`src/augint_tools/output/response.py`): `CommandResponse` dataclass, `ExitCode` enum. All commands return structured responses via `emit_response()`.
 
+### Dashboard & Health System (`src/augint_tools/dashboard/`)
+
+The dashboard is a Textual TUI that monitors repos across orgs. Its data pipeline:
+
+1. **GraphQL fetch** (`_gql.py`): Batched query for CI status, PRs, issues, file contents. Rulesets are NOT in this query (moved to REST for rate-limit savings).
+2. **REST rulesets** (`_rulesets.py`): Fetches rulesets via REST API (separate 5,000 req/hr budget). Caches detail responses by `updated_at` -- only re-fetches when a ruleset is actually modified.
+3. **Health checks** (`health/`): Pluggable check system. Each check implements the `HealthCheck` protocol and receives a `FetchContext` with pre-fetched data. No check makes its own API call.
+4. **YAML compliance engine** (`health/_engine.py`, `health/_handlers.py`, `health/checks/yaml_engine.py`): Fetches `standards.yaml` from ai-cc-tools and evaluates declarative rules. See below.
+
+### YAML Compliance Engine
+
+**Design principle:** Rule ownership lives with the standards maintainer (ai-cc-tools repo), not here. Adding a new compliance rule is a YAML edit in ai-cc-tools, not a code change in augint-tools.
+
+Key modules:
+- `health/_engine.py` -- Core evaluation loop. Built-in check types: `file_exists`, `file_absent`, `file_content_matches`, `workflow_job_has_step`, `workflow_all_jobs_scan`, `ruleset_has_required_checks`. Template substitution (`{owner}`, `{repo_name}`, `{default_branch}`) in messages and links.
+- `health/_handlers.py` -- Escape hatch for checks needing external data (AWS, HTTP). Register new handlers with `@register_handler("name")`. Three built-in: `aws_oidc_trust_policy_scope`, `http_health_probe`, `lambda_deploy_sha_match`.
+- `health/checks/yaml_engine.py` -- The `YamlEngineCheck` class that bridges the engine to the health check protocol. Caches results per repo by `(commit_sha, rulesets_fingerprint)` -- unchanged repos skip re-evaluation.
+- `_rulesets.py` -- REST fetcher with `updated_at` caching and a format adapter that transforms REST responses to match the GraphQL shape the engine expects.
+
+**Adding a new built-in check type:** Add a function to `_BUILTIN_DISPATCH` in `_engine.py`.
+**Adding a new handler:** Decorate a function in `_handlers.py` with `@register_handler("name")`.
+**Neither needed?** Just add a YAML entry in ai-cc-tools `standards.yaml` using existing check types.
+
 ### Output Contract
 
 Every command returns a `CommandResponse` with this JSON shape:
@@ -113,6 +136,12 @@ Exit codes: 0=success, 1=failure, 2=action-required, 3=blocked, 4=partial
 ## Key Files
 
 - `pyproject.toml` - Python packaging, dependencies, tool config
+- `src/augint_tools/dashboard/_gql.py` - GraphQL query builder, response parser, `RepoSnapshot`
+- `src/augint_tools/dashboard/_rulesets.py` - REST rulesets fetcher with `updated_at` caching
+- `src/augint_tools/dashboard/health/_engine.py` - YAML compliance engine core
+- `src/augint_tools/dashboard/health/_handlers.py` - Handler registry for external-data checks
+- `src/augint_tools/dashboard/health/_registry.py` - `HealthCheck` protocol, check registration
+- `src/augint_tools/dashboard/health/__init__.py` - `FetchContext` dataclass, `run_health_checks()`
 
 ## Testing Strategy
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ CLI orchestration layer for AI-assisted repository workflows.
 - **Repo-type aware**: Understands library and service repository patterns
 - **Safe defaults**: No destructive git operations without explicit commands
 - **GitHub integration**: Issue management, PR creation, CI status monitoring
+- **Health dashboard**: Real-time TUI showing CI, PRs, issues, and compliance across all your repos
+- **YAML compliance engine**: Declarative standards checking driven by a single `standards.yaml` -- rule ownership lives with the standards maintainer, not in this tool
 
 ## Installation
 
@@ -69,6 +71,35 @@ ai-tools repo submit
 - `submit` - Push branch and create PR with automerge
 - `ci watch` - Monitor CI run
 - `ci triage` - Classify CI failures
+
+## Dashboard & Compliance Engine
+
+The dashboard (`ai-tools dashboard`) is a Textual TUI that monitors all your repos in real time: CI status, open PRs, issue counts, and compliance findings on one screen. It refreshes via batched GraphQL queries with REST-based ruleset fetching on a separate rate-limit pool.
+
+### YAML Compliance Engine
+
+The dashboard includes a declarative compliance engine that evaluates repos against rules defined in a `standards.yaml` file maintained in the [ai-cc-tools](https://github.com/augmenting-integrations/ai-cc-tools) repo. This is the key design decision: **rule ownership lives with the standards maintainer, not in augint-tools.**
+
+Adding a new compliance rule is a single YAML entry in ai-cc-tools -- no code change in augint-tools required (unless the rule needs a new handler type).
+
+**Built-in check types:**
+- `file_exists` / `file_absent` -- verify presence of config files
+- `file_content_matches` -- regex with numeric/string assertions (e.g., coverage threshold >= 80)
+- `workflow_job_has_step` -- verify pipeline jobs contain required steps
+- `workflow_all_jobs_scan` -- detect cheat patterns (`|| true`, `continue-on-error`, `set +e`)
+- `ruleset_has_required_checks` -- verify GitHub rulesets enforce expected status checks
+
+**Handler escape hatch:** For checks that need external data (AWS API calls, HTTP probes), a `handler` type dispatches to registered Python functions. Three built-in handlers ship today: `aws_oidc_trust_policy_scope`, `http_health_probe`, and `lambda_deploy_sha_match`.
+
+**Caching:** The engine caches results per repo by `(commit_sha, rulesets_fingerprint)`. Unchanged repos skip re-evaluation entirely. Rulesets are fetched via REST with `updated_at`-based caching so config drift is detected in real time without re-fetching detail data every cycle.
+
+```bash
+# Launch the dashboard
+ai-tools dashboard --all
+
+# Override the standards URL (e.g., test a branch's rules before merge)
+ai-tools dashboard --all --standards-yaml-url "https://api.github.com/repos/org/repo/contents/standards.yaml?ref=my-branch"
+```
 
 ## Dashboard Deployment Links
 


### PR DESCRIPTION
## Summary

- Update README.md with dashboard and YAML compliance engine feature descriptions, check types, handler escape hatch, caching strategy, and CLI usage examples
- Update CLAUDE.md with full dashboard data pipeline architecture, engine module map, and guidance for adding new check types vs handlers vs YAML-only rules
- Update AGENTS.md to include `dashboard/` in the project structure description

Key narrative: **rule ownership lives with the standards maintainer (ai-cc-tools), not in augint-tools.** Adding a new compliance rule is a YAML edit in one repo, not a code change in two.

## Test plan

- [x] Pre-commit clean
- [x] No code changes, documentation only