### PR TITLE
feat(dashboard): health scores, fuzzy search, API counter, sort modes, dev-default fix

### DIFF
--- a/src/augint_tools/dashboard/_gql.py
+++ b/src/augint_tools/dashboard/_gql.py
@@ -158,6 +158,7 @@ class WorkspaceSnapshot:
     # Total rate-limit cost of the queries that built this snapshot.
     rate_limit_cost: int = 0
     rate_limit_remaining: int = 0
+    rate_limit_limit: int = 5000
     rate_limit_reset_at: datetime | None = None
     # Repos that couldn't be fetched (e.g. archived, renamed, permission errors).
     # Left to the caller to handle (typically by preserving previous state).
@@ -216,6 +217,17 @@ fragment RepoFields on Repository {{
     }}
   }}
   _dev: ref(qualifiedName: "refs/heads/dev") {{
+    target {{
+      ... on Commit {{
+        oid
+        statusCheckRollup {{ state }}
+        history(first: {_HISTORY_LOOKBACK}) {{
+          nodes {{ statusCheckRollup {{ state }} }}
+        }}
+      }}
+    }}
+  }}
+  _main: ref(qualifiedName: "refs/heads/main") {{
     target {{
       ... on Commit {{
         oid
@@ -365,6 +377,11 @@ def _parse_repo(data: dict) -> RepoSnapshot:
     dev_rollup_state = _resolve_rollup_state(dev_target)
     dev_head_sha = dev_target.get("oid") if isinstance(dev_target, dict) else None
 
+    main_ref = data.get("_main")
+    main_ref_target = (main_ref or {}).get("target") or {} if isinstance(main_ref, dict) else {}
+    main_ref_rollup = _resolve_rollup_state(main_ref_target)
+    main_ref_sha = main_ref_target.get("oid") if isinstance(main_ref_target, dict) else None
+
     # When ``dev`` is the default branch -- common on new projects that stage
     # on dev before cutting main, and on repos like aillc-web -- the
     # defaultBranchRef and the refs/heads/dev lookup alias the same commit.
@@ -375,9 +392,18 @@ def _parse_repo(data: dict) -> RepoSnapshot:
     if default_branch == "dev":
         dev_rollup_state = main_rollup_state
         dev_head_sha = main_head_sha
-        main_rollup_state = "ABSENT"
-        main_head_sha = None
         has_dev_branch = True
+        # Use the explicit main branch ref if it exists, otherwise ABSENT.
+        if main_ref is not None and main_ref_rollup is not None:
+            main_rollup_state = main_ref_rollup
+            main_head_sha = main_ref_sha
+        elif main_ref is not None:
+            # main branch exists but has no CI rollup
+            main_rollup_state = None  # will translate to "unknown"
+            main_head_sha = main_ref_sha
+        else:
+            main_rollup_state = "ABSENT"
+            main_head_sha = None
 
     root_tree = data.get("_rootTree")
     if isinstance(root_tree, dict):
@@ -597,6 +623,7 @@ def fetch_workspace_snapshot(gh: Github, repos: list[Repository]) -> WorkspaceSn
     errored: dict[str, str] = {}
     total_cost = 0
     last_remaining = 0
+    last_limit = 5000
     reset_at: datetime | None = None
 
     if not repos:
@@ -626,12 +653,14 @@ def fetch_workspace_snapshot(gh: Github, repos: list[Repository]) -> WorkspaceSn
         if isinstance(rate_limit, dict):
             total_cost += int(rate_limit.get("cost") or 0)
             last_remaining = int(rate_limit.get("remaining") or last_remaining)
+            last_limit = int(rate_limit.get("limit") or last_limit)
             reset_at = _parse_ts(rate_limit.get("resetAt")) or reset_at
 
     return WorkspaceSnapshot(
         by_full_name=by_full_name,
         rate_limit_cost=total_cost,
         rate_limit_remaining=last_remaining,
+        rate_limit_limit=last_limit,
         rate_limit_reset_at=reset_at,
         errored=errored,
     )

--- a/src/augint_tools/dashboard/app.py
+++ b/src/augint_tools/dashboard/app.py
@@ -70,6 +70,7 @@ from .widgets.dashboard_footer import DashboardFooter
 from .widgets.drawer import Drawer
 from .widgets.effect_sprite import SPRITE_WIDTH, EffectKind, EffectSprite
 from .widgets.error_drawer import ErrorDrawer
+from .widgets.fuzzy_search import FuzzySearchBar
 from .widgets.highlight_bar import HighlightBar
 from .widgets.network_drawer import NetworkDrawer
 from .widgets.repo_card import RepoCard
@@ -81,7 +82,7 @@ if TYPE_CHECKING:
     from github import Github
     from github.Repository import Repository
 
-    from ._gql import TeamsSnapshot
+    from ._gql import TeamsSnapshot, WorkspaceSnapshot
 
 
 def _progress_bar(fraction: float, width: int) -> str:
@@ -222,6 +223,7 @@ class MainScreen(Screen[None]):
         self._system_drawer = SystemDrawer()
         self._network_drawer = NetworkDrawer()
         self._aws_drawer = AwsDrawer()
+        self._fuzzy_search = FuzzySearchBar()
         self._cards_by_name: dict[str, RepoCard] = {}
         # Active effect sprites keyed by repo full_name. Persistent until
         # the user clicks anywhere; positioned over the matching card's
@@ -234,6 +236,7 @@ class MainScreen(Screen[None]):
         yield self._status_bar
         self._highlight_bar.bind_state(self._state, refresh_seconds=self._refresh_seconds)
         yield self._highlight_bar
+        yield self._fuzzy_search
         yield self._top_drawer
         yield Container(self._card_container)
         yield self._aws_drawer
@@ -288,6 +291,16 @@ class MainScreen(Screen[None]):
         # the user sees a live "next: in Xs" tick down -- proof that the
         # refresh loop is running even when the data itself hasn't changed.
         self._highlight_bar.rerender()
+
+    def toggle_fuzzy_search(self) -> None:
+        if self._fuzzy_search.is_visible:
+            self._fuzzy_search.hide()
+        else:
+            self._fuzzy_search.show()
+
+    def close_fuzzy_search(self) -> None:
+        if self._fuzzy_search.is_visible:
+            self._fuzzy_search.hide()
 
     def apply_flash_phase(self, phase: bool, *, window_seconds: int) -> None:
         """Propagate the global flash phase to each card."""
@@ -1325,6 +1338,8 @@ class DashboardApp(App[None]):
         Binding("v", "open_deployment_4", show=False),
         Binding("b", "open_deployment_5", show=False),
         Binding("f", "manage_deployments", "URLs"),
+        Binding("slash", "toggle_fuzzy_search", "Search", show=False),
+        Binding("grave_accent", "toggle_fuzzy_search", show=False),
         Binding("question_mark", "show_help", "Help"),
         Binding("f5", "full_restart", "Restart", show=False),
         Binding("plus", "widen_card", "Wider", show=False),
@@ -1865,7 +1880,13 @@ class DashboardApp(App[None]):
 
         # Commit the new state on the main thread so action handlers don't
         # observe healths and health_by_name in a half-updated state.
-        self.call_from_thread(self._commit_refresh, healths, teams_snapshot, failed_repos)
+        self.call_from_thread(
+            self._commit_refresh,
+            healths,
+            teams_snapshot,
+            failed_repos,
+            snapshot_set,
+        )
 
     def _apply_failing_detail(
         self,
@@ -1891,6 +1912,7 @@ class DashboardApp(App[None]):
         healths: list[RepoHealth],
         teams_snapshot: TeamsSnapshot | None = None,
         failed_repos: set[str] | None = None,
+        ws_snapshot: WorkspaceSnapshot | None = None,
     ) -> None:
         # Merge the batched teams snapshot if this refresh rebuilt it. The
         # main thread is the only place that mutates repo_teams / team_labels.
@@ -1916,6 +1938,22 @@ class DashboardApp(App[None]):
         self.state.stale_repos = failed_repos or set()
         self.state.last_refresh_at = datetime.now(UTC)
         self.state.is_refreshing = False
+
+        # Update API rate limit tracking.
+        if ws_snapshot is not None:
+            self.state.gql_remaining = ws_snapshot.rate_limit_remaining
+            self.state.gql_limit = ws_snapshot.rate_limit_limit
+            self.state.gql_reset_at = ws_snapshot.rate_limit_reset_at
+        if self._github_client is not None:
+            try:
+                rest_remaining, rest_limit = self._github_client.rate_limiting
+                self.state.rest_remaining = rest_remaining
+                self.state.rest_limit = rest_limit
+                self.state.rest_reset_at = datetime.fromtimestamp(
+                    self._github_client.rate_limiting_resettime, tz=UTC
+                )
+            except Exception:
+                pass  # REST rate limit info is best-effort
         vis = visible_healths(self.state)
         logger.debug(
             f"commit: {len(healths)} total, {len(vis)} visible, "
@@ -2205,6 +2243,16 @@ class DashboardApp(App[None]):
         self.state.active_filters = set(message.selected)
         self._rerender()
 
+    def on_fuzzy_search_bar_changed(self, message: FuzzySearchBar.Changed) -> None:
+        self.state.search_text = message.query
+        self._rerender()
+
+    def on_fuzzy_search_bar_dismissed(self, message: FuzzySearchBar.Dismissed) -> None:
+        self.state.search_text = ""
+        if self._main is not None:
+            self._main.close_fuzzy_search()
+        self._rerender()
+
     def action_cycle_layout(self) -> None:
         layouts = list_layouts()
         try:
@@ -2348,6 +2396,10 @@ class DashboardApp(App[None]):
 
     def action_show_help(self) -> None:
         self.push_screen(HelpScreen())
+
+    def action_toggle_fuzzy_search(self) -> None:
+        if self._main is not None:
+            self._main.toggle_fuzzy_search()
 
     def action_manage_repos(self) -> None:
         """Open the repo manager to enable/disable individual repos."""

--- a/src/augint_tools/dashboard/health/_models.py
+++ b/src/augint_tools/dashboard/health/_models.py
@@ -81,6 +81,16 @@ class RepoHealth:
         return int(self.worst_severity) * 1000 - non_ok * 10
 
     @property
+    def passed_checks(self) -> int:
+        """Number of checks that passed (severity == OK)."""
+        return sum(1 for c in self.checks if c.severity == Severity.OK)
+
+    @property
+    def total_checks(self) -> int:
+        """Total number of checks that ran."""
+        return len(self.checks)
+
+    @property
     def findings(self) -> list[HealthCheckResult]:
         """Non-OK check results, sorted worst-first."""
         return sorted(

--- a/src/augint_tools/dashboard/screens/help.py
+++ b/src/augint_tools/dashboard/screens/help.py
@@ -37,7 +37,7 @@ Overlays
   e                   Toggle error drawer
   E                   Clear errors
   ?                   This help
-  /                   Command palette
+  / or `              Fuzzy search repos
   esc                 Dismiss
 
 Quit

--- a/src/augint_tools/dashboard/state.py
+++ b/src/augint_tools/dashboard/state.py
@@ -29,7 +29,7 @@ PANEL_WIDTH_STEP = 2
 UNASSIGNED_TEAM = "unassigned"
 OPEN_SOURCE_TEAM = "__open_source__"
 
-SORT_MODES: tuple[str, ...] = ("health", "alpha")
+SORT_MODES: tuple[str, ...] = ("health", "alpha", "issues", "prs")
 
 # --- Filter categories ---------------------------------------------------
 VISIBILITY_FILTERS: tuple[str, ...] = ("private", "public")
@@ -101,6 +101,7 @@ class AppState:
     sort_mode: str = SORT_MODES[0]
     active_filters: set[str] = field(default_factory=set)
     hide_workspace: bool = False
+    search_text: str = ""
     layout_name: str = "packed"
     theme_name: str = "default"
     panel_width: int = PANEL_WIDTH_DEFAULT
@@ -112,6 +113,14 @@ class AppState:
     is_refreshing: bool = False
     consecutive_errors: int = 0
     last_error_message: str | None = None
+
+    # API rate limit tracking (updated after each refresh).
+    gql_remaining: int = 5000
+    gql_limit: int = 5000
+    gql_reset_at: datetime | None = None
+    rest_remaining: int = 5000
+    rest_limit: int = 5000
+    rest_reset_at: datetime | None = None
 
     # Repos whose most recent refresh attempt failed (shown gray/stale).
     stale_repos: set[str] = field(default_factory=set)
@@ -265,6 +274,10 @@ def apply_sort(
 ) -> list[RepoHealth]:
     if mode == "alpha":
         return sorted(healths, key=lambda h: h.status.name.lower())
+    if mode == "issues":
+        return sorted(healths, key=lambda h: h.status.open_issues, reverse=True)
+    if mode == "prs":
+        return sorted(healths, key=lambda h: h.status.open_prs, reverse=True)
     # "health": primary=severity, secondary=team, tertiary=problem count.
     teams = repo_teams or {}
     return sorted(
@@ -378,12 +391,34 @@ def available_filter_modes(
     return [*FILTER_MODES, *sections.orgs, *sections.teams]
 
 
+def fuzzy_match(haystack: str, needle: str) -> bool:
+    """fzf-style fuzzy match: chars of needle appear in order in haystack."""
+    if not needle:
+        return True
+    hay = haystack.lower()
+    ndl = needle.lower()
+    it = iter(hay)
+    return all(c in it for c in ndl)
+
+
+def apply_fuzzy_filter(
+    healths: list[RepoHealth],
+    query: str,
+) -> list[RepoHealth]:
+    """Filter repos by fuzzy-matching the query against full_name."""
+    if not query:
+        return healths
+    return [h for h in healths if fuzzy_match(h.status.full_name, query)]
+
+
 def visible_healths(state: AppState) -> list[RepoHealth]:
     pool = state.healths
     if state.hide_workspace:
         pool = [h for h in pool if not h.status.is_workspace]
+    pool = apply_active_filters(pool, state.active_filters, state.repo_teams)
+    pool = apply_fuzzy_filter(pool, state.search_text)
     return apply_sort(
-        apply_active_filters(pool, state.active_filters, state.repo_teams),
+        pool,
         state.sort_mode,
         state.repo_teams,
     )

--- a/src/augint_tools/dashboard/widgets/fuzzy_search.py
+++ b/src/augint_tools/dashboard/widgets/fuzzy_search.py
@@ -1,0 +1,75 @@
+"""Floating fuzzy-search overlay for filtering repos by name."""
+
+from __future__ import annotations
+
+from textual import events
+from textual.containers import Container
+from textual.message import Message
+from textual.widgets import Input
+
+
+class FuzzySearchBar(Container):
+    """Overlay search bar that filters repos with fzf-style fuzzy matching."""
+
+    DEFAULT_CSS = """
+    FuzzySearchBar {
+        dock: top;
+        layer: overlay;
+        height: auto;
+        max-height: 3;
+        width: 100%;
+        display: none;
+        padding: 0 1;
+        background: transparent;
+    }
+    FuzzySearchBar.visible {
+        display: block;
+    }
+    FuzzySearchBar Input {
+        width: 50;
+        background: $surface;
+        border: round $accent;
+    }
+    """
+
+    class Changed(Message):
+        """Emitted when the search query text changes."""
+
+        def __init__(self, query: str) -> None:
+            super().__init__()
+            self.query = query
+
+    class Dismissed(Message):
+        """Emitted when the user dismisses the search bar."""
+
+    def compose(self):
+        yield Input(placeholder="fuzzy search repos...", id="fuzzy-input", disabled=True)
+
+    def show(self) -> None:
+        """Show the search bar and focus the input."""
+        inp = self.query_one(Input)
+        inp.disabled = False
+        self.add_class("visible")
+        inp.focus()
+
+    def hide(self) -> None:
+        """Hide the search bar and clear the query."""
+        inp = self.query_one(Input)
+        inp.value = ""
+        inp.disabled = True
+        self.remove_class("visible")
+        self.post_message(self.Changed(""))
+
+    @property
+    def is_visible(self) -> bool:
+        return self.has_class("visible")
+
+    def on_input_changed(self, event: Input.Changed) -> None:
+        event.stop()
+        self.post_message(self.Changed(event.value))
+
+    def on_key(self, event: events.Key) -> None:
+        if event.key == "escape":
+            event.stop()
+            event.prevent_default()
+            self.post_message(self.Dismissed())

--- a/src/augint_tools/dashboard/widgets/highlight_bar.py
+++ b/src/augint_tools/dashboard/widgets/highlight_bar.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections import defaultdict
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
@@ -9,7 +10,7 @@ from rich.text import Text
 from textual.widgets import Static
 
 from ..health import Severity
-from ..state import visible_healths
+from ..state import owner_of, visible_healths
 from .status_bar import format_header_refresh_line
 
 if TYPE_CHECKING:
@@ -67,6 +68,38 @@ class HighlightBar(Static):
         line1.append(f"{visible_issues}/{total_issues}")
         line1.append("   prs: ", style="bold")
         line1.append(f"{visible_prs}/{total_prs}")
+
+        # Per-org health score fractions.
+        org_passed: dict[str, int] = defaultdict(int)
+        org_total: dict[str, int] = defaultdict(int)
+        for h in state.healths:
+            org = owner_of(h.status.full_name)
+            org_passed[org] += h.passed_checks
+            org_total[org] += h.total_checks
+        for owner in sorted(org_passed):
+            p, t = org_passed[owner], org_total[owner]
+            line1.append(f"   {owner}: ", style="bold")
+            ratio = p / t if t > 0 else 1.0
+            color = "green" if ratio >= 1.0 else "yellow" if ratio > 0.5 else "red"
+            line1.append(f"{p}/{t}", style=color)
+
+        # Rate limit display.
+        now = datetime.now(UTC)
+        for label, remaining, limit, reset_at in [
+            ("GQL", state.gql_remaining, state.gql_limit, state.gql_reset_at),
+            ("REST", state.rest_remaining, state.rest_limit, state.rest_reset_at),
+        ]:
+            used = limit - remaining
+            ratio = remaining / limit if limit > 0 else 1.0
+            color = "green" if ratio > 0.5 else "yellow" if ratio > 0.2 else "red"
+            line1.append("   ", style="bold")
+            line1.append(f"{label}: ", style="bold")
+            line1.append(f"{used}/{limit}", style=color)
+            if reset_at is not None:
+                secs = max(0, int((reset_at - now).total_seconds()))
+                mins, s = divmod(secs, 60)
+                reset_label = f"{mins}m" if mins > 0 else f"{s}s"
+                line1.append(f" ({reset_label})", style="dim")
 
         self.update(Text("\n").join([line1, self._refresh_line(), Text(" ")]))
 

--- a/src/augint_tools/dashboard/widgets/repo_card.py
+++ b/src/augint_tools/dashboard/widgets/repo_card.py
@@ -297,6 +297,18 @@ class RepoCard(Widget):
             line.append("  ws", style="dim")
         for tag in health.status.tags:
             line.append(f"  {tag}", style="dim italic")
+        # Health score fraction (e.g. "9/10").
+        total = health.total_checks
+        if total > 0:
+            passed = health.passed_checks
+            ratio = passed / total
+            if ratio >= 1.0:
+                color = "green"
+            elif ratio > 0.5:
+                color = "yellow"
+            else:
+                color = "red"
+            line.append(f"  {passed}/{total}", style=color)
         return line
 
     def _ci_line(self, health: RepoHealth) -> Text:


### PR DESCRIPTION
## Summary
Five dashboard enhancements:

- **Health scores**: passed/total fraction on each card (green/yellow/red by ratio), per-org aggregates in highlight bar.
- **Sort modes**: add `issues` and `prs` (descending). Cycles via the existing `2` key.
- **Fuzzy search**: `/` or backtick opens a floating Input; fzf-style matching against repo full_name; composes with existing filters; Esc dismisses.
- **API rate-limit counter**: GraphQL and REST budgets in the highlight bar (`used/limit (resets Xm)`), color-coded by remaining ratio. Captures `rateLimit.limit` from GraphQL and PyGithub's `rate_limiting` tuple.
- **Fix dev-default N/A**: GraphQL fragment now also queries `refs/heads/main`, so repos whose default branch is `dev` (e.g. aillc-web) show actual main CI status when present, instead of always rendering `N/A`.

## Test plan
- [ ] Launch `ai-tools dashboard` and verify each card shows `N/M` score after the repo name.
- [ ] Press `2` to cycle: health -> alpha -> issues -> prs.
- [ ] Press `/` (and backtick), type a query, verify cards filter live; Esc clears.
- [ ] Verify `GQL: X/Y (Zm)  REST: X/Y (Zm)` appears at the end of the highlight bar.
- [ ] Confirm a repo whose default branch is `dev` and that has a real `main` branch with CI now shows the main status (not `N/A`).