### PR TITLE
fix(ci): pass GH_TOKEN env var to semantic-release step

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -252,6 +252,8 @@ jobs:
 
       - name: Run semantic release
         id: release
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
           RELEASED="false"
 
@@ -264,7 +266,7 @@ jobs:
             echo "Semantic release succeeded"
             RELEASED="true"
           else
-            echo "No release needed"
+            echo "No release needed (exit code $SEMANTIC_EXIT_CODE)"
           fi
 
           echo "released=$RELEASED" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary
- Add `env: GH_TOKEN` to the semantic release pipeline step
- python-semantic-release reads `GH_TOKEN` from the environment (configured in `pyproject.toml [tool.semantic_release.remote.token]`) to create GitHub Releases
- The checkout step's `token:` only covers git push -- it does not propagate as an env var
- Without this, release creation fails with 401, the error is swallowed as "no release needed", and PyPI publishing is skipped
- Versions 5.37.1 through 5.39.0 all bumped on main but never published

## Test plan
- [ ] Verify CI passes on this PR
- [ ] After merge, confirm the post-merge pipeline creates a GitHub Release and publishes to PyPI
- [ ] Confirm `Token value is missing!` warning no longer appears in semantic release logs

Canonical template already fixed in augmenting-integrations/ai-cc-tools@3010fca (closes augmenting-integrations/ai-cc-tools#152).