### PR TITLE
feat(dashboard): pipeline path probes for publish.yaml and deploy.yaml

### DIFF
--- a/src/augint_tools/dashboard/_gql.py
+++ b/src/augint_tools/dashboard/_gql.py
@@ -40,7 +40,11 @@ RENOVATE_PATHS: tuple[str, ...] = (
 )
 
 # Pipeline workflow paths, canonical first. Mirrors the CoverageCheck probe list.
+# Libraries use publish.yaml, services use deploy.yaml. Legacy pipeline.yaml
+# is probed last for repos not yet re-standardized.
 PIPELINE_PATHS: tuple[str, ...] = (
+    ".github/workflows/publish.yaml",
+    ".github/workflows/deploy.yaml",
     ".github/workflows/pipeline.yaml",
     ".github/workflows/pipeline.yml",
 )

--- a/src/augint_tools/dashboard/health/_engine.py
+++ b/src/augint_tools/dashboard/health/_engine.py
@@ -570,33 +570,53 @@ def _precondition_met(entry: dict, context: FetchContext) -> tuple[bool, str | N
     return False, f"requires {required} (not present)"
 
 
-def _parse_compliance_overrides(text: str | None) -> tuple[set[str], dict[str, dict]]:
+_OVERRIDE_META_KEYS = frozenset({"reason", "created_at", "approved_by"})
+
+
+def _parse_compliance_overrides(
+    text: str | None,
+) -> tuple[dict[str, str | None], dict[str, dict]]:
     """Parse ``.ai-compliance.yaml`` into ``(disabled_checks, overrides)``.
 
+    ``disabled_checks`` maps each disabled check ID to its reason string
+    (or ``None`` when no reason is provided).
+
+    ``overrides`` maps each check ID to its parameter dict with metadata
+    keys (``reason``, ``created_at``, ``approved_by``) stripped out.
+
     Tolerant of absent, empty, or malformed documents -- misconfiguration
-    never breaks the refresh loop. The dashboard surfaces parse failures
-    as a visible finding so the maintainer notices.
+    never breaks the refresh loop.
     """
     if not text:
-        return set(), {}
+        return {}, {}
     try:
         doc = yaml.safe_load(text)
     except yaml.YAMLError:
-        return set(), {}
+        return {}, {}
     if not isinstance(doc, dict):
-        return set(), {}
+        return {}, {}
+
+    # --- disabled_checks ---
     raw_disabled = doc.get("disabled_checks") or []
-    disabled: set[str] = (
-        {str(x) for x in raw_disabled if isinstance(x, str)}
-        if isinstance(raw_disabled, list)
-        else set()
-    )
+    disabled: dict[str, str | None] = {}
+    if isinstance(raw_disabled, list):
+        for entry in raw_disabled:
+            if isinstance(entry, dict):
+                check_id = entry.get("id")
+                if isinstance(check_id, str):
+                    disabled[check_id] = entry.get("reason")
+            # Bare strings no longer supported -- skip silently.
+
+    # --- overrides ---
     raw_overrides = doc.get("overrides") or {}
     overrides: dict[str, dict] = {}
     if isinstance(raw_overrides, dict):
         for check_id, params in raw_overrides.items():
             if isinstance(check_id, str) and isinstance(params, dict):
-                overrides[check_id] = params
+                # Strip metadata keys; they are not check parameters.
+                overrides[check_id] = {
+                    k: v for k, v in params.items() if k not in _OVERRIDE_META_KEYS
+                }
     return disabled, overrides
 
 
@@ -646,7 +666,7 @@ def run_engine(
     }
     disabled, overrides = _parse_compliance_overrides(context.compliance_overrides_text)
     known_ids = {str(e.get("id")) for e in checks if isinstance(e, dict)}
-    stale_opt_outs = disabled - known_ids
+    stale_opt_outs = set(disabled) - known_ids
     results: list[HealthCheckResult] = []
     for entry in checks:
         if not isinstance(entry, dict):
@@ -658,11 +678,17 @@ def run_engine(
             # Surface opt-outs as OK-with-reason so coverage reduction stays
             # visible in the dashboard; silent drops are the failure mode we
             # don't want.
+            check_name = entry.get("name") or check_id
+            reason = disabled[check_id]
+            summary = f"{check_name}: disabled by .ai-compliance.yaml"
+            if reason:
+                truncated = reason[:80] + "..." if len(reason) > 80 else reason
+                summary = f"{summary} -- {truncated}"
             results.append(
                 HealthCheckResult(
                     check_name=check_id,
                     severity=Severity.OK,
-                    summary=f"{entry.get('name') or check_id}: disabled by .ai-compliance.yaml",
+                    summary=summary,
                 )
             )
             continue

--- a/src/augint_tools/dashboard/health/checks/coverage.py
+++ b/src/augint_tools/dashboard/health/checks/coverage.py
@@ -1,7 +1,7 @@
 """Health check: test-coverage threshold enforcement in CI.
 
 Parses the repository's canonical GitHub Actions workflow
-(``.github/workflows/pipeline.yaml``) and inspects the ``unit-tests`` job
+(``publish.yaml`` for libraries, ``deploy.yaml`` for services) and inspects the ``unit-tests`` job
 for signals that the coverage gate has been **actively weakened**:
 
 - Python: ``pytest --cov-fail-under=N`` with N below the canonical 80% baseline
@@ -14,8 +14,8 @@ for signals that the coverage gate has been **actively weakened**:
   the repo adopted the standardized job name but the gate is missing, which
   is a regression from standard, not non-adoption.
 
-**True non-adoption is benign.** Repos with no ``pipeline.yaml`` at all, or
-with a ``pipeline.yaml`` that has no ``unit-tests`` job, return OK severity
+**True non-adoption is benign.** Repos with no canonical pipeline at all, or
+with a pipeline that has no ``unit-tests`` job, return OK severity
 with an informative summary. This is observational, not a warning -- a repo
 is not "unhealthy" just because it doesn't follow the standard naming
 convention for its workflow files.
@@ -87,7 +87,7 @@ class CoverageCheck:
             return HealthCheckResult(
                 check_name=self.name,
                 severity=Severity.OK,
-                summary="not standardized (no pipeline.yaml)",
+                summary="not standardized (no canonical pipeline)",
             )
 
         workflow_link = f"https://github.com/{status.full_name}/blob/{default_branch}/{used_path}"
@@ -98,7 +98,7 @@ class CoverageCheck:
             return HealthCheckResult(
                 check_name=self.name,
                 severity=Severity.MEDIUM,
-                summary="pipeline.yaml parse error",
+                summary="pipeline parse error",
                 link=workflow_link,
             )
 
@@ -106,7 +106,7 @@ class CoverageCheck:
             return HealthCheckResult(
                 check_name=self.name,
                 severity=Severity.MEDIUM,
-                summary="pipeline.yaml not a mapping",
+                summary="pipeline not a mapping",
                 link=workflow_link,
             )
 
@@ -115,7 +115,7 @@ class CoverageCheck:
             return HealthCheckResult(
                 check_name=self.name,
                 severity=Severity.OK,
-                summary="pipeline.yaml has no jobs",
+                summary="pipeline has no jobs",
             )
 
         unit_tests = jobs.get("unit-tests")

--- a/tests/unit/test_gql.py
+++ b/tests/unit/test_gql.py
@@ -329,7 +329,7 @@ class TestParseResponse:
         payload = _graphql_repo_payload(
             full_name="org/a",
             renovate_hits={"renovate.json5": '{"extends":["config:base"]}'},
-            pipeline_hits={".github/workflows/pipeline.yaml": "jobs:\n  unit-tests: {}"},
+            pipeline_hits={".github/workflows/publish.yaml": "jobs:\n  unit-tests: {}"},
         )
         response = {"data": {"r0": payload}}
         snapshots, _, _ = parse_response(response, [_mock_repo("org/a")])
@@ -338,7 +338,7 @@ class TestParseResponse:
         assert rpath == "renovate.json5"
         assert "config:base" in rtext
         ppath, ptext = pick_pipeline_yaml(snap)
-        assert ppath == ".github/workflows/pipeline.yaml"
+        assert ppath == ".github/workflows/publish.yaml"
         assert "unit-tests" in ptext
 
     def test_rollup_walks_history_when_tip_has_no_rollup(self):

--- a/tests/unit/test_health.py
+++ b/tests/unit/test_health.py
@@ -827,7 +827,7 @@ jobs:
         run: uv run pytest -v
 """
 
-    def _evaluate(self, text: str | None, *, path: str = ".github/workflows/pipeline.yaml"):
+    def _evaluate(self, text: str | None, *, path: str = ".github/workflows/publish.yaml"):
         ctx = _ctx(
             pipeline_path=path if text is not None else None,
             pipeline_text=text,
@@ -845,7 +845,7 @@ jobs:
         assert "60" in result.summary
         assert "reduced" in result.summary
         assert result.link is not None
-        assert "pipeline.yaml" in result.link
+        assert "publish.yaml" in result.link
 
     def test_no_fail_under_is_low(self):
         result = self._evaluate(self._NO_FAIL_UNDER_PY)

--- a/tests/unit/test_standards_engine.py
+++ b/tests/unit/test_standards_engine.py
@@ -573,6 +573,34 @@ def test_disabled_check_object_format_with_reason():
     assert "Check not applicable" in finding.summary
 
 
+def test_disabled_check_reason_truncated_at_80_chars():
+    long_reason = "A" * 120
+    ctx = _ctx(
+        compliance_overrides_text=(
+            "disabled_checks:\n"
+            "  - id: x.fail\n"
+            f'    reason: "{long_reason}"\n'
+            "    created_at: 2026-04-23\n"
+            '    approved_by: "dev@example.com"\n'
+        ),
+    )
+    doc = {
+        "checks": [
+            {
+                "id": "x.fail",
+                "severity": "HIGH",
+                "name": "Always fails",
+                "check": {"type": "handler", "name": "_test_always_fail"},
+            }
+        ]
+    }
+    results = _run_with_doc(doc, ctx)
+    finding = next(r for r in results if r.check_name == "x.fail")
+    # Reason should be truncated to 80 chars with ellipsis.
+    assert len(finding.summary) < 200
+    assert finding.summary.endswith("...")
+
+
 def test_override_strips_metadata_keys():
     captured: dict = {}
 

--- a/tests/unit/test_standards_engine.py
+++ b/tests/unit/test_standards_engine.py
@@ -534,6 +534,33 @@ def test_malformed_compliance_yaml_does_not_break_engine():
     assert results[0].severity == Severity.OK
 
 
+def test_disabled_check_object_format_with_reason():
+    ctx = _ctx(
+        compliance_overrides_text=(
+            "disabled_checks:\n"
+            "  - id: x.fail\n"
+            '    reason: "Check not applicable"\n'
+            "    created_at: 2026-04-23\n"
+            '    approved_by: "dev@example.com"\n'
+        ),
+    )
+    doc = {
+        "checks": [
+            {
+                "id": "x.fail",
+                "severity": "HIGH",
+                "name": "Always fails",
+                "check": {"type": "handler", "name": "_test_always_fail"},
+            }
+        ]
+    }
+    results = _run_with_doc(doc, ctx)
+    finding = next(r for r in results if r.check_name == "x.fail")
+    assert finding.severity == Severity.OK
+    assert "disabled by .ai-compliance.yaml" in finding.summary
+    assert "Check not applicable" in finding.summary
+
+
 # ---------------------------------------------------------------------------
 # Engine without network (gh=None) returns informational result
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_standards_engine.py
+++ b/tests/unit/test_standards_engine.py
@@ -443,7 +443,13 @@ def test_builtin_handlers_are_registered():
 
 def test_disabled_check_emits_ok_with_reason():
     ctx = _ctx(
-        compliance_overrides_text="disabled_checks:\n  - x.fail\n",
+        compliance_overrides_text=(
+            "disabled_checks:\n"
+            "  - id: x.fail\n"
+            '    reason: "Not applicable"\n'
+            "    created_at: 2026-04-23\n"
+            '    approved_by: "dev@example.com"\n'
+        ),
     )
     doc = {
         "checks": [
@@ -500,7 +506,13 @@ def test_override_merges_into_handler_params():
 
 def test_stale_override_id_surfaces_finding():
     ctx = _ctx(
-        compliance_overrides_text="disabled_checks:\n  - retired.check.id\n",
+        compliance_overrides_text=(
+            "disabled_checks:\n"
+            "  - id: retired.check.id\n"
+            '    reason: "Was needed before"\n'
+            "    created_at: 2026-04-23\n"
+            '    approved_by: "dev@example.com"\n'
+        ),
     )
     doc = {
         "checks": [
@@ -559,6 +571,46 @@ def test_disabled_check_object_format_with_reason():
     assert finding.severity == Severity.OK
     assert "disabled by .ai-compliance.yaml" in finding.summary
     assert "Check not applicable" in finding.summary
+
+
+def test_override_strips_metadata_keys():
+    captured: dict = {}
+
+    @register_handler("_test_capture_stripped")
+    def _capture(_context, params):
+        captured.update(params)
+        return True, "ok"
+
+    ctx = _ctx(
+        compliance_overrides_text=(
+            "overrides:\n"
+            "  x.probe:\n"
+            '    reason: "Custom health endpoint"\n'
+            "    created_at: 2026-04-23\n"
+            '    approved_by: "dev@example.com"\n'
+            "    url: https://override.example/health\n"
+        ),
+    )
+    doc = {
+        "checks": [
+            {
+                "id": "x.probe",
+                "severity": "CRITICAL",
+                "check": {
+                    "type": "handler",
+                    "name": "_test_capture_stripped",
+                    "url": "https://default.example/health",
+                },
+            }
+        ]
+    }
+    results = _run_with_doc(doc, ctx)
+    assert results[0].severity == Severity.OK
+    assert captured["url"] == "https://override.example/health"
+    # Metadata keys must NOT leak into handler params.
+    assert "reason" not in captured
+    assert "created_at" not in captured
+    assert "approved_by" not in captured
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add `publish.yaml` and `deploy.yaml` to PIPELINE_PATHS in the GraphQL fetcher (canonical names for libraries and services respectively)
- Legacy `pipeline.yaml` still probed for repos not yet re-standardized
- Update coverage check messages to be filename-agnostic
- Update test fixtures to use `publish.yaml` as default

## Context
Companion to Augmenting-Integrations/ai-cc-tools PR (pipeline rename in templates + skills). This PR adds the new filenames to the dashboard's probe list so it finds them via GraphQL.

Note: this branch also includes the compliance justification commits from the prior PR (#97). Those are already approved -- this adds the pipeline path changes on top.

## Test plan
- [x] 134/134 tests passing
- [x] Coverage check messages are filename-agnostic
- [x] PIPELINE_PATHS probes publish.yaml first, then deploy.yaml, then legacy pipeline.yaml