### PR TITLE
fix(health): broaden service detection for CDK repos with nested cdk.json

### DIFF
--- a/src/augint_tools/dashboard/_data.py
+++ b/src/augint_tools/dashboard/_data.py
@@ -75,7 +75,9 @@ _LANG_MAP: dict[str, str] = {
 
 
 def _detect_tags(
-    primary_language: str | None, root_entries: tuple[str, ...]
+    primary_language: str | None,
+    root_entries: tuple[str, ...],
+    nested_cdk_paths: tuple[str, ...] = (),
 ) -> tuple[bool, tuple[str, ...]]:
     """Derive workspace-flag and framework/IaC tags from tree entry names."""
     tags: list[str] = []
@@ -86,7 +88,7 @@ def _detect_tags(
     names = set(root_entries)
     is_workspace = "workspace.yaml" in names
 
-    if "cdk.json" in names:
+    if "cdk.json" in names or nested_cdk_paths:
         tags.append("cdk")
     if "template.yaml" in names or "samconfig.toml" in names:
         tags.append("sam")
@@ -132,7 +134,11 @@ def _is_org_repo(name: str) -> bool:
     return name.endswith("-org")
 
 
-def _detect_service_markers(name: str, root_entries: tuple[str, ...]) -> tuple[str, ...]:
+def _detect_service_markers(
+    name: str,
+    root_entries: tuple[str, ...],
+    nested_cdk_paths: tuple[str, ...] = (),
+) -> tuple[str, ...]:
     """Return the subset of service-marker files indicating a deployable service.
 
     Returns an empty tuple for repos that look like *something other than* a
@@ -144,16 +150,25 @@ def _detect_service_markers(name: str, root_entries: tuple[str, ...]) -> tuple[s
     - **Python packages** (``pyproject.toml`` without ``package.json``):
       libraries published to PyPI that frequently ship a SAM template purely
       for ephemeral test environments or CI infrastructure, not production
-      deploys.
+      deploys. Exception: CDK presence (root or nested) always indicates a
+      deployable service.
     """
     if _is_org_repo(name):
         return ()
     names = set(root_entries)
     if "workspace.yaml" in names:
         return ()
-    if "pyproject.toml" in names and "package.json" not in names:
+
+    has_cdk = "cdk.json" in names or bool(nested_cdk_paths)
+
+    # Python packages without a package.json are treated as libraries UNLESS
+    # CDK infrastructure is detected (root or nested).
+    if not has_cdk and "pyproject.toml" in names and "package.json" not in names:
         return ()
-    return tuple(marker for marker in _SERVICE_MARKERS if marker in names)
+
+    markers = [marker for marker in _SERVICE_MARKERS if marker in names]
+    markers.extend(nested_cdk_paths)
+    return tuple(markers)
 
 
 # ---------------------------------------------------------------------------
@@ -265,8 +280,12 @@ def build_status_from_snapshot(
     dashboard_count = sum(1 for i in snapshot.issues if _is_renovate_dashboard(i))
     open_issues = max(0, snapshot.issue_total_count - dashboard_count)
 
-    is_workspace, tags = _detect_tags(snapshot.primary_language, snapshot.root_entries)
-    service_markers = _detect_service_markers(snapshot.name, snapshot.root_entries)
+    is_workspace, tags = _detect_tags(
+        snapshot.primary_language, snapshot.root_entries, snapshot.nested_cdk_paths
+    )
+    service_markers = _detect_service_markers(
+        snapshot.name, snapshot.root_entries, snapshot.nested_cdk_paths
+    )
     is_org = _is_org_repo(snapshot.name)
 
     main_status = translate_rollup_state(snapshot.main_rollup_state)

--- a/src/augint_tools/dashboard/_gql.py
+++ b/src/augint_tools/dashboard/_gql.py
@@ -59,6 +59,13 @@ PRECOMMIT_PATHS: tuple[str, ...] = (".pre-commit-config.yaml", ".pre-commit-conf
 # Placed by /ai-standardize-compliance; read by _engine.apply_overrides.
 COMPLIANCE_PATHS: tuple[str, ...] = (".github/.ai-compliance.yaml", ".github/.ai-compliance.yml")
 CODEOWNERS_PATHS: tuple[str, ...] = (".github/CODEOWNERS",)
+# Nested CDK paths to probe when cdk.json isn't at root. Common subdirectory
+# layouts used by repos that keep CDK infrastructure separate from app code.
+CDK_NESTED_PATHS: tuple[str, ...] = (
+    "cdk/cdk.json",
+    "infrastructure/cdk.json",
+    "infra/cdk.json",
+)
 
 # Chunk size for repo batches per GraphQL query. GitHub's API has a per-query
 # complexity budget of 500k nodes. With blob fields, PRs, and issues the
@@ -160,6 +167,9 @@ class RepoSnapshot:
     compliance_contents: dict[str, str | None] = field(default_factory=dict)
     # .github/CODEOWNERS contents; keyed by canonical path.
     codeowners_contents: dict[str, str | None] = field(default_factory=dict)
+    # Nested CDK paths found (e.g. "cdk/cdk.json", "infrastructure/cdk.json").
+    # Used by service-marker detection when cdk.json isn't at root.
+    nested_cdk_paths: tuple[str, ...] = ()
 
 
 @dataclass
@@ -218,6 +228,11 @@ def _fragment() -> str:
         f'    _codeowners_{i}: object(expression: "HEAD:{path}") {{ '
         f"... on Blob {{ text isTruncated }} }}"
         for i, path in enumerate(CODEOWNERS_PATHS)
+    )
+    cdk_nested_fields = "\n".join(
+        f'    _cdk_nested_{i}: object(expression: "HEAD:{path}") {{ '
+        f"... on Blob {{ text isTruncated }} }}"
+        for i, path in enumerate(CDK_NESTED_PATHS)
     )
     return f"""
 fragment RepoFields on Repository {{
@@ -292,6 +307,7 @@ fragment RepoFields on Repository {{
 {precommit_fields}
 {compliance_fields}
 {codeowners_fields}
+{cdk_nested_fields}
 }}
 """
 
@@ -528,6 +544,12 @@ def _parse_repo(data: dict) -> RepoSnapshot:
     for i, path in enumerate(CODEOWNERS_PATHS):
         codeowners_contents[path] = _extract_blob_text(data.get(f"_codeowners_{i}"))
 
+    nested_cdk: list[str] = []
+    for i, path in enumerate(CDK_NESTED_PATHS):
+        blob = data.get(f"_cdk_nested_{i}")
+        if isinstance(blob, dict):
+            nested_cdk.append(path)
+
     return RepoSnapshot(
         full_name=full_name,
         name=name,
@@ -553,6 +575,7 @@ def _parse_repo(data: dict) -> RepoSnapshot:
         precommit_contents=precommit_contents,
         compliance_contents=compliance_contents,
         codeowners_contents=codeowners_contents,
+        nested_cdk_paths=tuple(nested_cdk),
     )
 
 

--- a/src/augint_tools/dashboard/health/_engine.py
+++ b/src/augint_tools/dashboard/health/_engine.py
@@ -668,7 +668,7 @@ def run_engine(
     }
     disabled, overrides = _parse_compliance_overrides(context.compliance_overrides_text)
     known_ids = {str(e.get("id")) for e in checks if isinstance(e, dict)}
-    stale_opt_outs = set(disabled) - known_ids
+    stale_opt_outs = (set(disabled) | set(overrides)) - known_ids
     results: list[HealthCheckResult] = []
     for entry in checks:
         if not isinstance(entry, dict):

--- a/tests/unit/test_dashboard_data.py
+++ b/tests/unit/test_dashboard_data.py
@@ -82,6 +82,59 @@ class TestServiceMarkers:
         markers = _detect_service_markers("svc", ("template.yaml", "cdk.json"))
         assert set(markers) == {"template.yaml", "cdk.json"}
 
+    def test_nested_cdk_detected_as_service(self):
+        """Repos with cdk.json in a subdirectory should be classified as services."""
+        markers = _detect_service_markers(
+            "svc", ("package.json",), nested_cdk_paths=("cdk/cdk.json",)
+        )
+        assert "cdk/cdk.json" in markers
+
+    def test_python_with_nested_cdk_is_service(self):
+        """Python repos with nested CDK infra must not be excluded as libraries."""
+        markers = _detect_service_markers(
+            "svc",
+            ("pyproject.toml",),
+            nested_cdk_paths=("infrastructure/cdk.json",),
+        )
+        assert "infrastructure/cdk.json" in markers
+
+    def test_python_with_root_cdk_is_service(self):
+        """Python repos with root cdk.json must not be excluded as libraries."""
+        markers = _detect_service_markers("svc", ("pyproject.toml", "cdk.json"))
+        assert "cdk.json" in markers
+
+    def test_nested_cdk_excluded_for_org_repo(self):
+        """Org repos are excluded even with nested CDK."""
+        assert (
+            _detect_service_markers(
+                "my-org", ("pyproject.toml",), nested_cdk_paths=("cdk/cdk.json",)
+            )
+            == ()
+        )
+
+    def test_nested_cdk_excluded_for_workspace(self):
+        """Workspace repos are excluded even with nested CDK."""
+        assert (
+            _detect_service_markers("svc", ("workspace.yaml",), nested_cdk_paths=("cdk/cdk.json",))
+            == ()
+        )
+
+
+class TestDetectTagsNestedCdk:
+    def test_nested_cdk_adds_cdk_tag(self):
+        """Nested CDK paths should produce a 'cdk' tag."""
+        _, tags = _detect_tags("Python", ("pyproject.toml",), nested_cdk_paths=("cdk/cdk.json",))
+        assert "cdk" in tags
+
+    def test_no_duplicate_cdk_tag_when_root_and_nested(self):
+        """Root + nested CDK should produce exactly one 'cdk' tag."""
+        _, tags = _detect_tags(
+            "TypeScript",
+            ("cdk.json", "package.json"),
+            nested_cdk_paths=("infrastructure/cdk.json",),
+        )
+        assert tags.count("cdk") == 1
+
 
 class TestToIsoUtc:
     def test_none_passthrough(self):

--- a/tests/unit/test_standards_engine.py
+++ b/tests/unit/test_standards_engine.py
@@ -529,6 +529,33 @@ def test_stale_override_id_surfaces_finding():
     assert "retired.check.id" in stale.summary
 
 
+def test_stale_override_key_surfaces_finding():
+    """Override keys referencing retired check IDs should surface as stale."""
+    ctx = _ctx(
+        compliance_overrides_text=(
+            "overrides:\n"
+            "  retired.override.id:\n"
+            "    url: https://example.com/health\n"
+            '    reason: "Custom endpoint"\n'
+            "    created_at: 2026-04-23\n"
+            '    approved_by: "dev@example.com"\n'
+        ),
+    )
+    doc = {
+        "checks": [
+            {
+                "id": "active.check",
+                "severity": "HIGH",
+                "check": {"type": "handler", "name": "_test_always_pass"},
+            }
+        ]
+    }
+    results = _run_with_doc(doc, ctx)
+    stale = next(r for r in results if r.check_name == "standards_engine.stale_overrides")
+    assert stale.severity == Severity.LOW
+    assert "retired.override.id" in stale.summary
+
+
 def test_malformed_compliance_yaml_does_not_break_engine():
     ctx = _ctx(compliance_overrides_text="not: [valid: yaml::")
     doc = {


### PR DESCRIPTION
## Summary

- Probe `cdk.json` at `cdk/`, `infrastructure/`, and `infra/` subdirectories via GraphQL blob lookups so repos with nested CDK infrastructure are correctly classified as services
- Fix Python-library exclusion that incorrectly blocked service detection for Python backends with CDK infra (root or nested)
- Include `.ai-compliance.yaml` override keys in stale opt-out detection alongside disabled_checks

## Test plan

- [x] Unit tests for nested CDK service marker detection (5 new tests)
- [x] Unit tests for nested CDK tag detection (2 new tests)  
- [x] Unit test for stale override key surfacing (1 new test)
- [x] All 1046 existing tests pass
- [x] Pre-commit hooks pass

Closes #104