### PR TITLE
fix(health): downgrade stale main CI when dev is default and passing

### DIFF
--- a/src/augint_tools/dashboard/health/checks/broken_ci.py
+++ b/src/augint_tools/dashboard/health/checks/broken_ci.py
@@ -30,6 +30,17 @@ class BrokenCICheck:
 
         if status.main_status == "failure":
             detail = f": {status.main_error}" if status.main_error else ""
+            # When dev is the default branch, a failing main is a promotion
+            # target that hasn't received the latest pipeline yet -- not an
+            # active development failure. Downgrade to LOW so it surfaces for
+            # awareness without painting the card red.
+            if status.default_branch == "dev" and status.dev_status not in ("failure", None):
+                return HealthCheckResult(
+                    check_name=self.name,
+                    severity=Severity.LOW,
+                    summary=f"main pipeline stale (dev is default and passing){detail}",
+                    link=actions_url,
+                )
             return HealthCheckResult(
                 check_name=self.name,
                 severity=Severity.CRITICAL,


### PR DESCRIPTION
When dev is the default branch and passing, a failing main pipeline is a stale promotion target, not an active failure. Downgrade from CRITICAL to LOW.

This is the common state for pre-prod service repos (woxom-infra, woxom-sales-dashboard, woxom-health-web): dev is active, main exists but hasn't received the new pipeline via promotion. The old pipeline fails, painting the card red when the repo is actually healthy.

woxom-commissions doesn't have this problem because it has no main branch at all (engine marks it ABSENT).