### PR TITLE
fix(dashboard): card rendering bypasses broken_ci severity for stale main

### DIFF
--- a/src/augint_tools/dashboard/widgets/repo_card.py
+++ b/src/augint_tools/dashboard/widgets/repo_card.py
@@ -234,11 +234,12 @@ class RepoCard(Widget):
         if health is None:
             return False
         status = health.status
-        # Critical: flash while any failing branch is within the window.
-        if status.main_status == "failure" or status.dev_status == "failure":
-            return _within_window(status.main_failing_since, window_seconds) or _within_window(
-                status.dev_failing_since, window_seconds
-            )
+        # Critical: flash while the actively-failing branch is within the window.
+        # A stale main failure on a dev-default repo is not an active degradation.
+        if status.dev_status == "failure":
+            return _within_window(status.dev_failing_since, window_seconds)
+        if status.main_status == "failure" and status.default_branch != "dev":
+            return _within_window(status.main_failing_since, window_seconds)
         # Warning: flash while the repo has only recently crossed into yellow.
         if "card--warning" in self.classes:
             return _within_window(health.warning_since, window_seconds)
@@ -252,7 +253,13 @@ class RepoCard(Widget):
         if health is None:
             return
         status = health.status
-        if status.main_status == "failure" or status.dev_status == "failure":
+        # Only force critical for an actively-failing default branch. A stale
+        # main failure on a dev-default repo is handled by broken_ci (which
+        # returns LOW), so let worst_severity drive the card color instead.
+        if status.dev_status == "failure":
+            self.add_class("card--critical")
+            return
+        if status.main_status == "failure" and status.default_branch != "dev":
             self.add_class("card--critical")
             return
         worst = health.worst_severity


### PR DESCRIPTION
The broken_ci health check correctly returns LOW for stale main failures on dev-default repos (v5.42.2). But repo_card.py has two hardcoded checks on `status.main_status == "failure"` that force `card--critical` (red) and trigger the flash animation, bypassing the health check severity entirely.

Fix: only force critical for dev failures (always critical) or main failures when main IS the default branch. For dev-default repos with stale main, let worst_severity from the health check drive the card color.